### PR TITLE
adding an `.npmignore` file

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+test/
+.travis.yml


### PR DESCRIPTION
should slightly help speed up `npm i` time, and is generally a good practice
