### PR TITLE
Return err in copy() fstat cb, because stat could be undefined or null

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -35,7 +35,7 @@ function copy(src, dest, filter, callback) {
   callback = callback || function(){}
 
   fs.lstat(src, function(err, stats) {
-    if (err) callback(err)
+    if (err) return callback(err)
 
     var dir = null
     if (stats.isDirectory()) {


### PR DESCRIPTION
I had a problem with FlyLaTeX, where some weird arguments (notexistent files etc) were passed to copy() --> err is ENOENT, but the copy() code failed to properly terminate the lstat callback when err is not false-ish, resulting in the whole application terminating with this stacktrace:

```
/var/lib/nodejs/node-apps/flylatex/node_modules/fs-extra/lib/copy.js:41
    if (stats.isDirectory()) {
```

This PR fixes this by not only calling _callback(err)_ but instead returning it. I didn't check other functions or files for similar problems. Please feel free to comment if you think this should be fixed otherwise or see possible side-effects with this fix.
