### PR TITLE
Proposal: Stream support

### DIFF
--- a/lib/output.js
+++ b/lib/output.js
@@ -3,6 +3,7 @@
 var mkdir = require('./mkdir')
   , path = require('path')
   , fs = require('fs')
+  , Stream = require('stream').Stream
   , exists = fs.exists || path.exists
   , existsSync = fs.existsSync || path.existsSync
 
@@ -14,7 +15,12 @@ function outputFile (file, data, encoding, callback) {
 
   var dir = path.dirname(file)
   exists(dir, function(itDoes) {
-    if (itDoes) return fs.writeFile(file, data, encoding, callback)
+    if (itDoes) {
+      if (data instanceof Stream) {
+        return data.pipe( fs.createWriteStream(file, { encoding: encoding }) );
+      }
+      return fs.writeFile(file, data, encoding, callback)
+    }
 
     mkdir.mkdirs(dir, function(err) {
       if (err) return callback(err)


### PR DESCRIPTION
## Proposed change

Add support for passing in writable streams to `.outputFile` and similar methods, e.g. usage:

```javascript
require('fs-extra').outputFile('./foo.md', fs.createReadStream('./README.md'))
```

The PR implements a rough pass at this to `outputFile()`, just to capture the idea (no new tests, etc)


## How it works currently
Currently, if you were to do:

```javascript
require('fs-extra').outputFile('./foo.md', fs.createReadStream('./README.md'))
```

you get a file:
```md
[object Object]
```

What does everyone think?  @jprichardson would you be ok w/ something like this? I'm happy to send PRs, add tests, etc.


## To try it

```bash
$ npm install fs-extra@git://github.com/mikermcneil/node-fs-extra.git#patch-1
```

## Stuff that probably needs to be added

+ Obviously tests
+ Check that the stream is an `instanceof Writable` not just `Stream`
+ Might even want to check that the writable stream hasn't been opened yet (not sure how to do this off-hand but I don't think it would be hard to do)
