### PR TITLE
This fixes (what I think) is a bug in copySync

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -73,7 +73,7 @@ function copySync(src, dest, filter) {
     if (!destExists) mkdir.mkdirsSync(dest);
     var contents = fs.readdirSync(src);
     contents.forEach(function (content) {
-      copySync(src + "/" + content, dest + "/" + content);
+      copySync(src + "/" + content, dest + "/" + content, filter);
     });
   }
 }

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -248,6 +248,42 @@ describe('fs-extra', function() {
 
         done()
       });
+      it("should should apply filter recursively", function(done) {
+        var FILES = 2,
+            src = path.join(DIR, 'src'),
+            dest = path.join(DIR, 'dest'),
+            filter = /0$/i,
+            i, j;
+        mkdir.sync(src);
+        for (i = 0; i < FILES; ++i)
+          testutil.createFileWithData(path.join(src, i.toString()), SIZE);
+        var subdir = path.join(src, 'subdir');
+        mkdir.sync(subdir);
+        for (i = 0; i < FILES; ++i)
+          testutil.createFileWithData(path.join(subdir, i.toString()), SIZE);
+        fs.copySync(src, dest, filter);
+        T(fs.existsSync(dest));
+	T(FILES>1);
+
+        for (i = 0; i < FILES; ++i) {
+	    if (i==0) {
+		T(fs.existsSync(path.join(dest, i.toString())))
+	    } else {
+		T(!fs.existsSync(path.join(dest, i.toString())))
+	    }
+	};
+
+        var destSub = path.join(dest, 'subdir');
+        for (j = 0; j < FILES; ++j) {
+	    if (j==0) {
+		T(fs.existsSync(path.join(destSub, j.toString())));
+	    } else {
+		T(!fs.existsSync(path.join(destSub, j.toString())));
+	    }
+	}
+
+        done()
+      });
       describe("> when the destination dir does not exist", function() {
         it("should create the destination directory and copy the file", function(done) {
           var src = path.join(DIR, 'data/');


### PR DESCRIPTION
The issue is that copySync applies the filter **only** at the root level of a recursive
copy.  This adds a test (that failed with the original code) that checks to make sure that
the filter is applied recursively.  The patch to lib/copy.js then addresses this issue
with a simple fix and the tests pass again with the patch.
