### PR TITLE
copySync was not applying filters to directories

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -61,19 +61,19 @@ function copySync(src, dest, filter) {
   var stats = fs.lstatSync(src),
       destExists = fs.exists(dest),
       performCopy = false;
+  if (filter instanceof RegExp) performCopy = filter.test(src);
+  else if (typeof filter === "function") performCopy = filter(src);
   if (stats.isFile()) {
-    if (filter instanceof RegExp) performCopy = filter.test(src);
-    else if (typeof filter === "function") performCopy = filter(src);
     if(performCopy) {
       if (!destExists) create.createFileSync(dest);
       copyFileSync(src, dest);
     }
   }
   else if (stats.isDirectory()) {
-    if (!destExists) mkdir.mkdirsSync(dest);
+    if (!destExists && performCopy) mkdir.mkdirsSync(dest);
     var contents = fs.readdirSync(src);
     contents.forEach(function (content) {
-      copySync(src + "/" + content, dest + "/" + content, filter);
+      if (performCopy) copySync(src + "/" + content, dest + "/" + content, filter);
     });
   }
 }


### PR DESCRIPTION
this only fixes `copySync` method, `copy` may still have same issue
