### PR TITLE
Preserve file mode in copySync

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -13,9 +13,10 @@ var BUF_LENGTH = 64 * 1024
 var _buff = new Buffer(BUF_LENGTH)
 
 var copyFileSync = function(srcFile, destFile) {
-  var bytesRead, fdr, fdw, pos;
+  var bytesRead, fdr, fdw, pos, stat;
   fdr = fs.openSync(srcFile, 'r');
-  fdw = fs.openSync(destFile, 'w');
+  stat = fs.fstatSync(fdr);
+  fdw = fs.openSync(destFile, 'w', stat.mode);
   bytesRead = 1;
   pos = 0;
   while (bytesRead > 0) {
@@ -59,18 +60,19 @@ function copy(src, dest, filter, callback) {
 function copySync(src, dest, filter) {
   filter = filter || function () { return true; };
   var stats = fs.lstatSync(src),
-      destExists = fs.exists(dest),
+      destFolder = path.dirname(dest),
+      destFolderExists = fs.exists(destFolder),
       performCopy = false;
   if (stats.isFile()) {
     if (filter instanceof RegExp) performCopy = filter.test(src);
     else if (typeof filter === "function") performCopy = filter(src);
     if(performCopy) {
-      if (!destExists) create.createFileSync(dest);
+      if (!destFolderExists) mkdir.mkdirsSync(destFolder);
       copyFileSync(src, dest);
     }
   }
   else if (stats.isDirectory()) {
-    if (!destExists) mkdir.mkdirsSync(dest);
+    if (!destFolderExists) mkdir.mkdirsSync(dest);
     var contents = fs.readdirSync(src);
     contents.forEach(function (content) {
       copySync(src + "/" + content, dest + "/" + content, filter);

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -254,6 +254,20 @@ describe('fs-extra', function() {
         done();
       });
 
+      it("should maintain file mode", function (done) {
+        var fileSrc = path.join(DIR, "TEST_fs-extra_src")
+            , fileDest = path.join(DIR, "TEST_fs-extra_copy")
+            , fileSrc = testutil.createFileWithData(fileSrc, SIZE);
+        fs.chmodSync(fileSrc, 0750);
+        fs.copySync(fileSrc, fileDest);
+
+        var statSrc = fs.statSync(fileSrc)
+            , statDest = fs.statSync(fileDest);
+        EQ (statSrc.mode, statDest.mode);
+
+        done();
+      });
+
       it("should only copy files allowed by filter regex", function(done) {
         var srcFile1 = testutil.createFileWithData(path.join(DIR, "1.html"), SIZE),
             srcFile2 = testutil.createFileWithData(path.join(DIR, "2.css"), SIZE),


### PR DESCRIPTION
This fix the file mode not being preserved when using copySync.
