### PR TITLE
Copy symlinks in copySync

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -57,9 +57,10 @@ function copy(src, dest, filter, callback) {
   })
 }
 
-function copySync(src, dest, filter) {
+function copySync(src, dest, filter, recursive) {
   filter = filter || function () { return true; };
-  var stats = fs.lstatSync(src),
+  recursive = recursive || false;
+  var stats = recursive ? fs.lstatSync(src) : fs.statSync(src),
       destFolder = path.dirname(dest),
       destFolderExists = fs.exists(destFolder),
       performCopy = false;
@@ -75,7 +76,10 @@ function copySync(src, dest, filter) {
     if (!destFolderExists) mkdir.mkdirsSync(dest);
     var contents = fs.readdirSync(src);
     contents.forEach(function (content) {
-      copySync(src + "/" + content, dest + "/" + content, filter);
+      copySync(src + "/" + content, dest + "/" + content, filter, true);
     });
+  } else if (recursive && stats.isSymbolicLink()) {
+    var srcPath = fs.readlinkSync(src);
+    fs.symlinkSync(srcPath, dest);
   }
 }

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -254,6 +254,21 @@ describe('fs-extra', function() {
         done();
       });
 
+      it("should follow symlinks", function (done) {
+        var fileSrc = path.join(DIR, "TEST_fs-extra_src")
+            , fileDest = path.join(DIR, "TEST_fs-extra_copy")
+            , linkSrc = path.join(DIR, "TEST_fs-extra_copy_link")
+            , fileSrc = testutil.createFileWithData(fileSrc, SIZE)
+            , srcMd5 = crypto.createHash('md5').update(fs.readFileSync(fileSrc)).digest("hex")
+            , destMd5 = '';
+
+        fs.symlinkSync(fileSrc, linkSrc);
+        fs.copySync(linkSrc, fileDest);
+        destMd5 = crypto.createHash('md5').update(fs.readFileSync(fileDest)).digest("hex");
+        T(srcMd5 === destMd5);
+        done();
+      });
+
       it("should maintain file mode", function (done) {
         var fileSrc = path.join(DIR, "TEST_fs-extra_src")
             , fileDest = path.join(DIR, "TEST_fs-extra_copy")
@@ -337,6 +352,22 @@ describe('fs-extra', function() {
 
         var destSub = path.join(dest, 'subdir');
         for (j = 0; j < FILES; ++j) T (fs.existsSync(path.join(destSub, j.toString())));
+
+        done()
+      });
+
+      it("should preserve symbolic links", function(done) {
+        var FILES = 2,
+            src = path.join(DIR, 'src'),
+            dest = path.join(DIR, 'dest'),
+            i, j;
+        mkdir.sync(src);
+        fs.symlinkSync('destination', path.join(src, 'symlink'));
+
+        fs.copySync(src, dest);
+
+        var link = fs.readlinkSync(path.join(dest, 'symlink'));
+        EQ (link, 'destination');
 
         done()
       });


### PR DESCRIPTION
This fixes the symlinks being ignored by copySync.

I chose to follow the behavior of `cp -R` which is the most logical to me:
- If the source is a file: we follow the link and copy the file content
- If the source is a directory: we copy the links
