### PR TITLE
Using graceful-ncp instead of ncp

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
 var path = require('path')
-var ncp = require('ncp').ncp
+var ncp = require('graceful-ncp').ncp
 var mkdir = require('./mkdir')
 var create = require('./create')
 

--- a/lib/move.js
+++ b/lib/move.js
@@ -2,7 +2,7 @@
 //licensed under the BSD license: see https://github.com/andrewrk/node-mv/blob/master/package.json
 
 var fs = require('fs')
-var ncp = require('ncp').ncp
+var ncp = require('graceful-ncp').ncp
 var path = require('path')
 var rimraf = require('rimraf')
 var mkdirp = require('mkdirp')

--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     }
   ],
   "dependencies": {
-    "ncp": "^1.0.1",
     "mkdirp": "^0.5.0",
     "jsonfile": "^2.0.0",
-    "rimraf": "^2.2.8"
+    "rimraf": "^2.2.8",
+    "graceful-ncp": "0.0.1"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test/copy-sync.test.js
+++ b/test/copy-sync.test.js
@@ -4,7 +4,7 @@ var path = require('path')
 var mkdirp = require('mkdirp')
 var fs = require('../lib')
 var testutil = require('testutil')
-var ncp = require('ncp')
+var ncp = require('graceful-ncp')
 
 var testlib = require('./lib/util')
 

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -5,7 +5,7 @@ var path = require('path')
 var testutil = require('testutil')
 var mkdirp = require('mkdirp')
 //var userid = require('userid')
-var ncp = require('ncp')
+var ncp = require('graceful-ncp')
 
 var testlib = require('./lib/util')
 


### PR DESCRIPTION
This helps with EMFILE errors. See [adam-lynch/graceful-ncp](https://github.com/adam-lynch/graceful-ncp).

This is related to https://github.com/mllrsohn/node-webkit-builder/pull/123