### PR TITLE
copy: options object or filter to pass to ncp

### DIFF
--- a/lib/copy.js
+++ b/lib/copy.js
@@ -24,10 +24,12 @@ var copyFileSync = function(srcFile, destFile) {
   fs.closeSync(fdw)
 }
 
-function copy(src, dest, filter, callback) {
-  if( typeof filter == "function" && !callback) {
-    callback = filter
-    filter = null
+function copy(src, dest, options, callback) {
+  if( typeof options == "function" && !callback) {
+    callback = options
+    options = {}
+  } else if (typeof options == "function" || options instanceof RegExp) {
+    options = {filter: options}
   }
   callback = callback || function(){}
 
@@ -44,10 +46,10 @@ function copy(src, dest, filter, callback) {
     }
 
     fs.exists(dir, function(dirExists) {
-      if (dirExists) return ncp(src, dest, {filter: filter}, callback)
+      if (dirExists) return ncp(src, dest, options, callback)
       mkdir.mkdirs(dir, function(err) {
         if (err) return callback(err)
-        ncp(src, dest, {filter: filter}, callback)
+        ncp(src, dest, options, callback)
       })
     })
   })

--- a/test/copy.test.js
+++ b/test/copy.test.js
@@ -68,6 +68,16 @@ describe('fs-extra', function() {
         })
       })
 
+      it("accepts options object in place of filter", function(done) {
+        var srcFile1 = testlib.createFileWithData(path.join(DIR, "1.jade"), SIZE)
+        var destFile1 = path.join(DIR, "dest1.jade")
+        var options = {filter: /.html$|.css$/i}
+        fs.copy(srcFile1, destFile1, options, function() {
+          assert(!fs.existsSync(destFile1))
+          done()
+        })
+      })
+
       describe('> when the destination dir does not exist', function() {
         it('should create the destination directory and copy the file', function(done) {
           var src = path.join(DIR, 'file.txt')


### PR DESCRIPTION
Hi.

This PR allows `copy()` to be called with the following signature:

```js
fs.copy(src, dest, [options], callback)
```

The options object is passed to ncp. The original signature `fs.copy(src, dest, [filters], callback)` still works as it checks for a function or RexExp and if so treats it as a filter option. All tests pass.

My use case is wanting to pass in a transform function to ncp. Yes, OK, I could just use ncp module direct, but I've got used to using fs-extra and I like it!

I understand if you think this adds extra complexity and don't want it, but please let me know either way, so I can publish a fork instead for my own use if needs be.