### PR TITLE
isDirectory method

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Methods
 - [ensureFileSync](#ensurefilefile-callback)
 - [ensureDir](#ensuredirdir-callback)
 - [ensureDirSync](#ensuredirdir-callback)
+- [isDirectory](#isdirectoryfile-callback)
+- [isDirectorySync](#isdirectoryfile-callback)
 - [mkdirs](#mkdirsdir-callback)
 - [mkdirsSync](#mkdirsdir-callback)
 - [move](#movesrc-dest-options-callback)
@@ -192,6 +194,28 @@ var dir = '/tmp/this/path/does/not/exist'
 fs.ensureDir(dir, function (err) {
   console.log(err) // => null
   // dir has now been created, including the directory it is to be placed in
+})
+```
+
+
+
+### isDirectory(file, callback)
+
+Check if a file is a directory. Shortcut for `fs.stat()` followed by running `isDirectory()` on the result.
+
+Alias: `isDir()`
+
+Sync: `isDirectorySync()` (alias `isDirSync()`)
+
+
+Example:
+
+```js
+var fs = require('fs-extra')
+
+var file = '/tmp/path/to/a/file'
+fs.isDirectory(file, function (err, isDir) {
+  console.log(isDir) // => true if is directory, false if not
 })
 ```
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -87,6 +87,12 @@ Object.keys(empty).forEach(function (method) {
   fs[method] = empty[method]
 })
 
+var isDir = require('./is-dir')
+fs.isDirectory = isDir.isDirectory
+fs.isDirectorySync = isDir.isDirectorySync
+fs.isDir = isDir.isDirectory
+fs.isDirSync = isDir.isDirectorySync
+
 module.exports = fs
 
 jsonFile.spaces = 2 // set to 2

--- a/lib/is-dir.js
+++ b/lib/is-dir.js
@@ -1,0 +1,18 @@
+var fs = require('fs')
+
+function isDirectory (path, callback) {
+  fs.stat(path, function (err, stats) {
+    if (err) return callback(err)
+
+    callback(null, stats.isDirectory())
+  })
+}
+
+function isDirectorySync (path) {
+  return fs.statSync(path).isDirectory()
+}
+
+module.exports = {
+  isDirectory: isDirectory,
+  isDirectorySync: isDirectorySync
+}


### PR DESCRIPTION
This PR adds convenience methods `isDirectory()` and `isDirectorySync()`.

They are shortcuts for `fs.stat()` followed by calling `.isDirectory()` on the result. These methods are in my [fs-extra-promise](https://github.com/overlookmotel/fs-extra-promise) module, but you said previously that you thought this could be useful to add to fs-extra, and it seems more natural to me to have them here. So here they are!

I've called them `isDirectory` to match the native node method name, but also aliased them as `isDir` to fit with the naming of other methods in fs-extra.

I didn't write any tests as (a) I'm not sure how to exactly within your testing framework and (b) the tests would basically be comprised of the same code as the methods themselves!

Please let me know if you'd like any amends to this PR.