### PR TITLE
Handle EEXIST error when clobbering dir

### DIFF
--- a/lib/move.js
+++ b/lib/move.js
@@ -38,7 +38,7 @@ function mv (source, dest, options, callback) {
       fs.rename(source, dest, function (err) {
         if (!err) return callback()
 
-        if (err.code === 'ENOTEMPTY') {
+        if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST') {
           rimraf(dest, function (err) {
             if (err) return callback(err)
             options.clobber = false // just clobbered it, no need to do it again


### PR DESCRIPTION
Some versions of Linux (including on the Travis container infrastructure) throw an EEXIST error rather than ENOTEMPTY when you try to overwrite a directory while renaming, and that wasn't being handled.

This PR fixes that.