### PR TITLE
ensure test.js works

### DIFF
--- a/test.js
+++ b/test.js
@@ -9,10 +9,9 @@ var mocha = new Mocha({
   timeout: 30000
 })
 
-walk('./')
+walk('./lib')
   .on('data', function (item, stat) {
     if (!stat.isFile()) return
-    if (item.indexOf('node_modules') >= 0) return
     if (item.lastIndexOf('.test.js') !== (item.length - '.test.js'.length)) return
     mocha.addFile(item)
   })


### PR DESCRIPTION
fix `test.js` implementation mentioned in #144

This PR ensures that tests are:

    - only found in `fs-extra/lib`
    - found even if `fs-extra` is in a `node_modules` folder