### PR TITLE
move.test fix to support CRLF on Windows

### DIFF
--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -60,8 +60,9 @@ describe('move', function () {
     fse.move(src, dest, function (err) {
       assert.ifError(err)
       fs.readFile(dest, 'utf8', function (err, contents) {
+        var expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'sonic the hedgehog\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
         done()
       })
     })
@@ -103,8 +104,9 @@ describe('move', function () {
     fse.move(src, dest, function (err) {
       assert.ifError(err)
       fs.readFile(dest, 'utf8', function (err, contents) {
+        var expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'sonic the hedgehog\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
         done()
       })
     })
@@ -121,8 +123,9 @@ describe('move', function () {
       assert.strictEqual(fs.link.callCount, 1)
 
       fs.readFile(dest, 'utf8', function (err, contents) {
+        var expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'sonic the hedgehog\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
 
         tearDownMockFs()
         done()
@@ -140,8 +143,9 @@ describe('move', function () {
     fse.move(src, dest, function (err) {
       assert.ifError(err)
       fs.readFile(dest + '/another-file', 'utf8', function (err, contents) {
+        var expected = /^tails\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'tails\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
         done()
       })
     })
@@ -158,8 +162,9 @@ describe('move', function () {
       assert.strictEqual(fs.link.callCount, 1)
 
       fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
+        var expected = /^knuckles\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'knuckles\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
 
         tearDownMockFs('EISDIR')
 
@@ -181,8 +186,9 @@ describe('move', function () {
       assert.strictEqual(fs.rename.callCount, 1)
 
       fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
+        var expected = /^knuckles\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'knuckles\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
 
         tearDownMockFs('EXDEV')
 
@@ -202,8 +208,9 @@ describe('move', function () {
       assert.strictEqual(fs.link.callCount, 1)
 
       fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
+        var expected = /^knuckles\r?\n$/
         assert.ifError(err)
-        assert.strictEqual(contents, 'knuckles\n')
+        assert.ok(contents.match(expected), contents + ' match ' + expected)
 
         tearDownMockFs()
 


### PR DESCRIPTION
move.test modified to support testing files with both LF (NIX) and CRLF (Windows) line endings. This commit fixes #188.