### PR TITLE
copySync to overwrite destination file if readonly and clobber true

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -183,6 +183,20 @@ describe('+ copySync()', function () {
             assert.strictEqual(destData, destDataNew)
           })
         })
+
+        describe('> when clobber is true and dest is readonly', function () {
+          it('should copy the file and not throw an error', function () {
+            try {
+              fs.chmodSync(dest, parseInt('444', 8))
+              fs.copySync(src, dest, {clobber: true})
+              destData = fs.readFileSync(dest, 'utf8')
+              assert.strictEqual(srcData, destData)
+            } finally {
+              // destination file is readonly so just remove it so we don't affect other tests
+              fs.unlinkSync(dest)
+            }
+          })
+        })
       })
     })
   })

--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -7,8 +7,12 @@ function copyFileSync (srcFile, destFile, options) {
   var clobber = options.clobber
   var preserveTimestamps = options.preserveTimestamps
 
-  if (fs.existsSync(destFile) && !clobber) {
-    throw Error('EEXIST')
+  if (fs.existsSync(destFile)) {
+    if (clobber) {
+      fs.unlinkSync(destFile)
+    } else {
+      throw Error('EEXIST')
+    }
   }
 
   var fdr = fs.openSync(srcFile, 'r')

--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -9,6 +9,7 @@ function copyFileSync (srcFile, destFile, options) {
 
   if (fs.existsSync(destFile)) {
     if (clobber) {
+      fs.chmodSync(destFile, parseInt('777', 8))
       fs.unlinkSync(destFile)
     } else {
       throw Error('EEXIST')


### PR DESCRIPTION
copySync updated to overwrite destination file if readonly and clobber set to true. Added test case. This commit fixes #183.