### PR TITLE
allow ensureFile(Sync) to provide data to be written to created file

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ fs.emptyDir('/tmp/some/dir', function (err) {
 ```
 
 
-### ensureFile(file, callback)
+### ensureFile(file, [data], callback)
 
-Ensures that the file exists. If the file that is requested to be created is in directories that do not exist, these directories are created. If the file already exists, it is **NOT MODIFIED**.
+Ensures that the file exists. If `data` is provided, it will be written to the created file, otherwise an empty file will be written. If the file that is requested to be created is in directories that do not exist, these directories are created. If the file already exists, it is **NOT MODIFIED**.
 
 Alias: `createFile()`
 

--- a/lib/ensure/__tests__/ensure.test.js
+++ b/lib/ensure/__tests__/ensure.test.js
@@ -45,6 +45,20 @@ describe('fs-extra', function () {
         })
       })
     })
+
+    describe('> when file does not exist and data is provided', function () {
+      it('should create the file with data', function (done) {
+        var file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
+
+        assert(!fs.existsSync(file))
+        fse.ensureFile(file, 'test', function (err) {
+          assert.ifError(err)
+          assert(fs.existsSync(file))
+          assert.equal(fs.readFileSync(file, 'utf8'), 'test')
+          done()
+        })
+      })
+    })
   })
 
   describe('+ ensureFileSync()', function () {
@@ -66,6 +80,17 @@ describe('fs-extra', function () {
         assert(!fs.existsSync(file))
         fse.ensureFileSync(file)
         assert(fs.existsSync(file))
+      })
+    })
+
+    describe('> when file does not exist and data is provided', function () {
+      it('should create the file with data', function () {
+        var file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
+
+        assert(!fs.existsSync(file))
+        fse.ensureFileSync(file, 'test')
+        assert(fs.existsSync(file))
+        assert.equal(fs.readFileSync(file, 'utf8'), 'test')
       })
     })
   })

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -2,9 +2,14 @@ var path = require('path')
 var fs = require('graceful-fs')
 var mkdir = require('../mkdirs')
 
-function createFile (file, callback) {
+function createFile (file, data, callback) {
+  callback = arguments[arguments.length - 1]
+  if (!data || typeof data === 'function') {
+    data = ''
+  }
+
   function makeFile () {
-    fs.writeFile(file, '', function (err) {
+    fs.writeFile(file, data, function (err) {
       if (err) return callback(err)
       callback()
     })
@@ -23,7 +28,7 @@ function createFile (file, callback) {
   })
 }
 
-function createFileSync (file) {
+function createFileSync (file, data) {
   if (fs.existsSync(file)) return
 
   var dir = path.dirname(file)
@@ -31,7 +36,7 @@ function createFileSync (file) {
     mkdir.mkdirsSync(dir)
   }
 
-  fs.writeFileSync(file, '')
+  fs.writeFileSync(file, data || '')
 }
 
 module.exports = {


### PR DESCRIPTION
> This PR includes tests and docs for a backwards compatible change to the API.

Essentially I've changed the signature of `ensureFile(file, callback)` to `ensureFile(file, [data], callback)`, adding an optional `data` parameter that can be used to populate a created file. I use fs-extra frequently and find myself needing this functionality fairly often. For example, if I want to make sure an JSON configuration file exists, and if not put bare minimum valid JSON in it, I might use this new version of the API like this:

```js
fse.ensureFile('file.json', '{}', function(err) {
    // do stuff...
});
```

The change is modeled along the same lines as node.js's `fs.writeFile()` API. At this time it does not _complete_ that API, meaning this PR does not attempt to additionally add the optional `options` parameter that is available in `fs.writeFile()`. Having said that, if adding that aspect would make this PR more acceptable, I'd be happy to implement that as well, making `ensureFile()` and near mirror of the `fs.writeFile()` API.