### PR TITLE
fse.copy throws error when only src and dest provided

### DIFF
--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -11,6 +11,7 @@ function copy (src, dest, options, callback) {
     options = {filter: options}
   }
   callback = callback || function () {}
+  options = options || {}
 
   fs.lstat(src, function (err, stats) {
     if (err) return callback(err)


### PR DESCRIPTION
I have a lot of legacy code which uses old version(0.12.0) of fs-extra.
Old code does not work with new fs-extra due to it uses fse.copy with only 2 arguments `src` and `dest`.
Let's improve backward compatibility, guys