### PR TITLE
fix #187 #70 options.filter bug

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -23,7 +23,10 @@ function copySync (src, dest, options) {
   var performCopy = false
 
   if (stats.isFile()) {
-    if (options.filter instanceof RegExp) performCopy = options.filter.test(src)
+    if (options.filter instanceof RegExp){
+      options.filter.lastIndex=0;
+      performCopy = options.filter.test(src);
+    } 
     else if (typeof options.filter === 'function') performCopy = options.filter(src)
 
     if (performCopy) {


### PR DESCRIPTION
#187 #70
Files only filter each file while ever returns true, if the first file on the folder or the folder name dont pass the filter, the copy stops.