### PR TITLE
Throw error when target is empty so file is not accidentally zeroed out

### DIFF
--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -21,6 +21,16 @@ describe('fs-extra', function () {
   })
 
   describe('+ copy()', function () {
+
+    it('should return an error if src and dest are the same', function (done) {
+      var fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_copy')
+      var fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
+      fse.copy(fileSrc, fileDest, function (err) {
+        assert.equal(err.message, 'Source and destination must not be the same.')
+        done()
+      })
+    })
+
     describe('> when the source is a file', function () {
       it('should copy the file asynchronously', function (done) {
         var fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_src')

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -4,6 +4,7 @@ var ncp = require('./ncp')
 var mkdir = require('../mkdirs')
 
 function copy (src, dest, options, callback) {
+
   if (typeof options === 'function' && !callback) {
     callback = options
     options = {}
@@ -12,6 +13,12 @@ function copy (src, dest, options, callback) {
   }
   callback = callback || function () {}
   options = options || {}
+
+  // do nothing if src and dest are the same
+  var basePath = process.cwd()
+  var currentPath = path.resolve(basePath, src)
+  var targetPath = path.resolve(basePath, dest)
+  if ( currentPath === targetPath ) return callback( new Error('Source and destination must not be the same.'))
 
   fs.lstat(src, function (err, stats) {
     if (err) return callback(err)

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -80,6 +80,7 @@ function ncp (source, dest, options, callback) {
 
   function onFile (file) {
     var target = file.name.replace(currentPath, targetPath)
+    if ( !target ) return onError( new Error( 'Source and target must not be the same' ) );
     isWritable(target, function (writable) {
       if (writable) {
         copyFile(file, target)

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -80,7 +80,6 @@ function ncp (source, dest, options, callback) {
 
   function onFile (file) {
     var target = file.name.replace(currentPath, targetPath)
-    if ( !target ) return onError( new Error( 'Source and target must not be the same' ) );
     isWritable(target, function (writable) {
       if (writable) {
         copyFile(file, target)


### PR DESCRIPTION
This happens if you set source and destination to the same file. Note that `fs.rename` handles this gracefully, and users may expect the same with fs-extra's `copy`. This PR is probably not the best way to handle this, and does not address all cases, but I hope this will open discussion on this issue, since in any event a user copying a file to self would not want or expect the file to remain, but now at length=0.