### PR TITLE
Adds symlink dereference option to `fse.copySync` (#191)

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ Copy a file or directory. The directory can have contents. Like `cp -r`.
 
 Options:
 - clobber (boolean): overwrite existing file or directory
+- dereference (boolean): dereference symlinks
 - preserveTimestamps (boolean): will set last modification and access times to the ones of the original source files, default is `false`.
 - filter: Function or RegExp to filter copied files. If function, return true to include, false to exclude. If RegExp, same as function, where `filter` is `filter.test`.
 

--- a/lib/copy-sync/__tests__/broken-symlink.test.js
+++ b/lib/copy-sync/__tests__/broken-symlink.test.js
@@ -1,0 +1,59 @@
+var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
+var os = require('os')
+var fse = require(process.cwd())
+var copySync = require('../copy-sync')
+
+/* global afterEach, beforeEach, describe, it */
+
+describe('copy-sync / broken symlink', function () {
+  var TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy-sync-broken-symlinks')
+  var src = path.join(TEST_DIR, 'src')
+  var out = path.join(TEST_DIR, 'out')
+
+  beforeEach(function (done) {
+    fse.emptyDir(TEST_DIR, function (err) {
+      assert.ifError(err)
+      createFixtures(src, done)
+    })
+  })
+
+  afterEach(function (done) {
+    fse.remove(TEST_DIR, done)
+  })
+
+  it('should copy broken symlinks by default', function () {
+    assert.doesNotThrow(function () {
+      copySync(src, out)
+    })
+
+    assert.equal(fs.readlinkSync(path.join(out, 'broken-symlink')), path.join(src, 'does-not-exist'))
+  })
+
+  it('should throw an error when dereference=true', function () {
+    assert.throws(function () {
+      copySync(src, out, {dereference: true})
+    }, function (err) {
+      return err.code === 'ENOENT'
+    })
+  })
+})
+
+function createFixtures (srcDir, callback) {
+  fs.mkdir(srcDir, function (err) {
+    if (err) return callback(err)
+
+    try {
+      var brokenFile = path.join(srcDir, 'does-not-exist')
+      var brokenFileLink = path.join(srcDir, 'broken-symlink')
+      fs.writeFileSync(brokenFile, 'does not matter')
+      fs.symlinkSync(brokenFile, brokenFileLink, 'file')
+    } catch (err) {
+      callback(err)
+    }
+
+    // break the symlink now
+    fse.remove(brokenFile, callback)
+  })
+}

--- a/lib/copy-sync/__tests__/symlink.test.js
+++ b/lib/copy-sync/__tests__/symlink.test.js
@@ -1,0 +1,76 @@
+var assert = require('assert')
+var fs = require('fs')
+var path = require('path')
+var os = require('os')
+var fse = require(process.cwd())
+var copySync = require('../copy-sync')
+
+/* global afterEach, beforeEach, describe, it */
+
+describe('copy-sync / symlink', function () {
+  var TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy-sync-symlinks')
+  var src = path.join(TEST_DIR, 'src')
+  var out = path.join(TEST_DIR, 'out')
+
+  beforeEach(function (done) {
+    fse.emptyDir(TEST_DIR, function (err) {
+      assert.ifError(err)
+      createFixtures(src, done)
+    })
+  })
+
+  afterEach(function (done) {
+    fse.remove(TEST_DIR, done)
+  })
+
+  it('copies symlinks by default', function () {
+    assert.doesNotThrow(function () {
+      copySync(src, out)
+    })
+
+    assert.equal(fs.readlinkSync(path.join(out, 'file-symlink')), path.join(src, 'foo'))
+    assert.equal(fs.readlinkSync(path.join(out, 'dir-symlink')), path.join(src, 'dir'))
+  })
+
+  it('copies file contents when dereference=true', function () {
+    try {
+      copySync(src, out, {dereference: true})
+    } catch (err) {
+      assert.ifError(err)
+    }
+
+    var fileSymlinkPath = path.join(out, 'file-symlink')
+    assert.ok(fs.lstatSync(fileSymlinkPath).isFile())
+    assert.equal(fs.readFileSync(fileSymlinkPath), 'foo contents')
+
+    var dirSymlinkPath = path.join(out, 'dir-symlink')
+    assert.ok(fs.lstatSync(dirSymlinkPath).isDirectory())
+    assert.deepEqual(fs.readdirSync(dirSymlinkPath), ['bar'])
+  })
+})
+
+function createFixtures (srcDir, callback) {
+  fs.mkdir(srcDir, function (err) {
+    if (err) return callback(err)
+
+    // note: third parameter in symlinkSync is type e.g. 'file' or 'dir'
+    // https://nodejs.org/api/fs.html#fs_fs_symlink_srcpath_dstpath_type_callback
+    try {
+      var fooFile = path.join(srcDir, 'foo')
+      var fooFileLink = path.join(srcDir, 'file-symlink')
+      fs.writeFileSync(fooFile, 'foo contents')
+      fs.symlinkSync(fooFile, fooFileLink, 'file')
+
+      var dir = path.join(srcDir, 'dir')
+      var dirFile = path.join(dir, 'bar')
+      var dirLink = path.join(srcDir, 'dir-symlink')
+      fs.mkdirSync(dir)
+      fs.writeFileSync(dirFile, 'bar contents')
+      fs.symlinkSync(dir, dirLink, 'dir')
+    } catch (err) {
+      callback(err)
+    }
+
+    callback()
+  })
+}

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -13,11 +13,12 @@ function copySync (src, dest, options) {
 
   // default to true for now
   options.clobber = 'clobber' in options ? !!options.clobber : true
+  options.dereference = 'dereference' in options ? !!options.dereference : false
   options.preserveTimestamps = 'preserveTimestamps' in options ? !!options.preserveTimestamps : false
 
   options.filter = options.filter || function () { return true }
 
-  var stats = options.recursive ? fs.lstatSync(src) : fs.statSync(src)
+  var stats = (options.recursive && !options.dereference) ? fs.lstatSync(src) : fs.statSync(src)
   var destFolder = path.dirname(dest)
   var destFolderExists = fs.existsSync(destFolder)
   var performCopy = false


### PR DESCRIPTION
Carries forward the behavior and specs governing the existing (async-only) implementation and updates the documentation.

Thanks for considering this change!