### PR TITLE
Fixing problem when copying file with no write permission

### DIFF
--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -34,7 +34,7 @@ function copyFileSync (srcFile, destFile, options) {
 
   fs.closeSync(fdr)
   fs.closeSync(fdw)
-  
+
   fs.chmodSync(destFile, stat.mode)
 }
 

--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -18,7 +18,7 @@ function copyFileSync (srcFile, destFile, options) {
 
   var fdr = fs.openSync(srcFile, 'r')
   var stat = fs.fstatSync(fdr)
-  var fdw = fs.openSync(destFile, 'w', stat.mode)
+  var fdw = fs.openSync(destFile, 'w')
   var bytesRead = 1
   var pos = 0
 
@@ -34,6 +34,8 @@ function copyFileSync (srcFile, destFile, options) {
 
   fs.closeSync(fdr)
   fs.closeSync(fdw)
+  
+  fs.chmodSync(destFile, stat.mode)
 }
 
 module.exports = copyFileSync


### PR DESCRIPTION
The 3rd parameter passed to openSync is setting the mode for the destination file, and if the source does not have write permissions, then the destination wouldn't have write permissions. It is best to use the default mode (which is 0666) and set the permissions after closing the file for write.
