### PR TITLE
use more specific path for method require

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -10,16 +10,16 @@ Object.keys(gfs).forEach(function (key) {
 
 var fs = fse
 
-assign(fs, require('./copy'))
-assign(fs, require('./copy-sync'))
-assign(fs, require('./mkdirs'))
-assign(fs, require('./remove'))
-assign(fs, require('./json'))
-assign(fs, require('./move'))
-assign(fs, require('./empty'))
-assign(fs, require('./ensure'))
-assign(fs, require('./output'))
-assign(fs, require('./walk'))
+assign(fs, require('./copy/index.js'))
+assign(fs, require('./copy-sync/index.js'))
+assign(fs, require('./mkdirs/index.js'))
+assign(fs, require('./remove/index.js'))
+assign(fs, require('./json/index.js'))
+assign(fs, require('./move/index.js'))
+assign(fs, require('./empty/index.js'))
+assign(fs, require('./ensure/index.js'))
+assign(fs, require('./output/index.js'))
+assign(fs, require('./walk/index.js'))
 
 module.exports = fs
 


### PR DESCRIPTION
We encounter a problem when we upgrade fs-extras from 0.18.3 to 0.30.0, all extra method like fs.move is undefined after we upgrade our service.

Our deploy system is a increment deploy system, so every history file was  on the machine.

In 0.18.3 the file path is `lib/move.js` and in 0.30.0 is `lib/move/index.js`, they can both by required by using `require('./move')`, so when we upgrade the fs-extras lib, the new `index.js` will require('lib/move.js') rather than `lib/move/index.js` since old file is still exist.

I think it won't hurt anything if we change require path to a more specific path, and will get a better compatibility.
