### PR TITLE
port fix for mkdirp issue #111

### DIFF
--- a/lib/mkdirs/mkdirs.js
+++ b/lib/mkdirs/mkdirs.js
@@ -40,7 +40,7 @@ function mkdirs (p, opts, callback, made) {
         mkdirs(path.dirname(p), opts, function (er, made) {
           if (er) callback(er, made)
           else mkdirs(p, opts, callback, made)
-        })
+        }, made)
         break
 
       // In the case of any other error, just see if there's a dir


### PR DESCRIPTION
The original mkdirp mis-handles the fourth parameter when a directory
component is missing.  The same issue is present in the fs-extra
variant.

See: https://github.com/substack/node-mkdirp/issues/111
