### PR TITLE
Mention defaults for clobber and dereference options

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,8 +126,8 @@ Methods
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 
 Options:
-- clobber (boolean): overwrite existing file or directory
-- dereference (boolean): dereference symlinks
+- clobber (boolean): overwrite existing file or directory, default is `true`.
+- dereference (boolean): dereference symlinks, default is `false`.
 - preserveTimestamps (boolean): will set last modification and access times to the ones of the original source files, default is `false`.
 - filter: Function or RegExp to filter copied files. If function, return true to include, false to exclude. If RegExp, same as function, where `filter` is `filter.test`.
 


### PR DESCRIPTION
This wasn’t obvious to me.
Thought it’s worth documenting!