### PR TITLE
Disable rimraf globbing

### DIFF
--- a/lib/remove/index.js
+++ b/lib/remove/index.js
@@ -1,11 +1,12 @@
 var rimraf = require('rimraf')
 
 function removeSync (dir) {
-  return rimraf.sync(dir)
+  return rimraf.sync(dir, {disableGlob: true})
 }
 
 function remove (dir, callback) {
-  return callback ? rimraf(dir, callback) : rimraf(dir, function () {})
+  var options = {disableGlob: true}
+  return callback ? rimraf(dir, options, callback) : rimraf(dir, options, function () {})
 }
 
 module.exports = {


### PR DESCRIPTION
Its important to pass the options through as ensuring symmetry between the `fs.extra#remove` and `rimraf` APIs means I don't need to include `rimraf` AND `fs-extra`, just for the sake of using `rimraf` with specific options.

One option that is particularly useful and quite commonly used is `disableGlob`.