### PR TITLE
(Closes #271) lib/util/utimes: properly close file descriptors in the event of an error

### DIFF
--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -4,7 +4,9 @@ var os = require('os')
 var fs = require('fs')
 var fse = require(process.cwd())
 var semver = require('semver')
-var utimes = require('../utimes')
+var proxyquire = require('proxyquire')
+var gracefulFsStub
+var utimes
 
 /* global beforeEach, describe, it */
 
@@ -17,6 +19,9 @@ describe('utimes', function () {
   beforeEach(function (done) {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'utimes')
     fse.emptyDir(TEST_DIR, done)
+    // reset stubs
+    gracefulFsStub = {}
+    utimes = proxyquire('../utimes', {'graceful-fs': gracefulFsStub})
   })
 
   describe('hasMillisResSync()', function () {
@@ -76,6 +81,40 @@ describe('utimes', function () {
           assert.deepEqual(stats.mtime, awhileAgoNoMillis)
           assert.deepEqual(stats.atime, awhileAgoNoMillis)
         }
+        done()
+      })
+    })
+
+    it('should close open file desciptors after encountering an error', function (done) {
+      var fakeFd = Math.random()
+
+      gracefulFsStub.open = function (pathIgnored, flagsIgnored, modeIgnored, callback) {
+        if (typeof modeIgnored === 'function') {
+          callback = modeIgnored
+        }
+        process.nextTick(function () {
+          callback(null, fakeFd)
+        })
+      }
+
+      var closeCalled = false
+      gracefulFsStub.close = function (fd, callback) {
+        assert.equal(fd, fakeFd)
+        closeCalled = true
+        if (callback) process.nextTick(callback)
+      }
+
+      var testError
+      gracefulFsStub.futimes = function (fd, atimeIgnored, mtimeIgnored, callback) {
+        process.nextTick(function () {
+          testError = new Error('A test error')
+          callback(testError)
+        })
+      }
+
+      utimes.utimesMillis('ignored', 'ignored', 'ignored', function (err) {
+        assert.equal(err, testError)
+        assert(closeCalled)
         done()
       })
     })

--- a/lib/util/utimes.js
+++ b/lib/util/utimes.js
@@ -54,9 +54,10 @@ function utimesMillis (path, atime, mtime, callback) {
   // if (!HAS_MILLIS_RES) return fs.utimes(path, atime, mtime, callback)
   fs.open(path, 'r+', function (err, fd) {
     if (err) return callback(err)
-    fs.futimes(fd, atime, mtime, function (err) {
-      if (err) return callback(err)
-      fs.close(fd, callback)
+    fs.futimes(fd, atime, mtime, function (futimesErr) {
+      fs.close(fd, function (closeErr) {
+        if (callback) callback(futimesErr || closeErr)
+      })
     })
   })
 }

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "istanbul": "^0.3.5",
     "minimist": "^1.1.1",
     "mocha": "^2.1.0",
+    "proxyquire": "^1.7.10",
     "read-dir-files": "^0.1.1",
     "secure-random": "^1.1.1",
     "semver": "^4.3.6",


### PR DESCRIPTION
I made one other change in utimes.js to ensure that the callback for `utimesMillis` is only called after the file has been closed.