### PR TITLE
Escape '$' in replacement string for async file copying

### DIFF
--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -89,6 +89,18 @@ describe('fs-extra', function () {
         })
       })
 
+      it('should copy to a destination file with two \'$\' characters in name (eg: TEST_fs-extra_$$_copy)', function (done) {
+        var fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_src')
+        var fileDest = path.join(TEST_DIR, 'TEST_fs-extra_$$_copy')
+        fs.writeFileSync(fileSrc, '')
+
+        fse.copy(fileSrc, fileDest, function (err) {
+          assert(!err)
+          fs.statSync(fileDest)
+          done()
+        })
+      })
+
       describe('> when the destination dir does not exist', function () {
         it('should create the destination directory and copy the file', function (done) {
           var src = path.join(TEST_DIR, 'file.txt')

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -79,7 +79,7 @@ function ncp (source, dest, options, callback) {
   }
 
   function onFile (file) {
-    var target = file.name.replace(currentPath, targetPath)
+    var target = file.name.replace(currentPath, targetPath.replace('$', '$$$$')) // escapes '$' with '$$'
     isWritable(target, function (writable) {
       if (writable) {
         copyFile(file, target)


### PR DESCRIPTION
Change made in /lib/copy/ncp.js to the string.replace in the onFile function

Fixes #242.