### PR TITLE
Inline Rimraf

### DIFF
--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -7,7 +7,7 @@
 var fs = require('graceful-fs')
 var ncp = require('../copy/ncp')
 var path = require('path')
-var rimraf = require('rimraf')
+var remove = require('../remove').remove
 var mkdirp = require('../mkdirs').mkdirs
 
 function mv (source, dest, options, callback) {
@@ -40,7 +40,7 @@ function mv (source, dest, options, callback) {
         if (!err) return callback()
 
         if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST') {
-          rimraf(dest, function (err) {
+          remove(dest, function (err) {
             if (err) return callback(err)
             options.clobber = false // just clobbered it, no need to do it again
             mv(source, dest, options, callback)
@@ -51,7 +51,7 @@ function mv (source, dest, options, callback) {
         // weird Windows shit
         if (err.code === 'EPERM') {
           setTimeout(function () {
-            rimraf(dest, function (err) {
+            remove(dest, function (err) {
               if (err) return callback(err)
               options.clobber = false
               mv(source, dest, options, callback)
@@ -142,12 +142,12 @@ function moveDirAcrossDevice (source, dest, clobber, limit, callback) {
   function startNcp () {
     ncp(source, dest, options, function (errList) {
       if (errList) return callback(errList[0])
-      rimraf(source, callback)
+      remove(source, callback)
     })
   }
 
   if (clobber) {
-    rimraf(dest, function (err) {
+    remove(dest, function (err) {
       if (err) return callback(err)
       startNcp()
     })

--- a/lib/remove/index.js
+++ b/lib/remove/index.js
@@ -1,4 +1,4 @@
-var rimraf = require('rimraf')
+var rimraf = require('./rimraf')
 
 function removeSync (dir) {
   return rimraf.sync(dir, {disableGlob: true})

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -1,0 +1,301 @@
+module.exports = rimraf
+rimraf.sync = rimrafSync
+
+var assert = require('assert')
+var path = require('path')
+var fs = require('graceful-fs')
+
+var isWindows = (process.platform === 'win32')
+
+function defaults (options) {
+  var methods = [
+    'unlink',
+    'chmod',
+    'stat',
+    'lstat',
+    'rmdir',
+    'readdir'
+  ]
+  methods.forEach(function (m) {
+    options[m] = options[m] || fs[m]
+    m = m + 'Sync'
+    options[m] = options[m] || fs[m]
+  })
+
+  options.maxBusyTries = options.maxBusyTries || 3
+}
+
+function rimraf (p, options, cb) {
+  if (typeof options === 'function') {
+    cb = options
+    options = {}
+  }
+
+  assert(p, 'rimraf: missing path')
+  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
+  assert.equal(typeof cb, 'function', 'rimraf: callback function required')
+  assert(options, 'rimraf: invalid options argument provided')
+  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+
+  defaults(options)
+
+  var busyTries = 0
+
+  rimraf_(p, options, function CB (er) {
+    if (er) {
+      if (isWindows && (er.code === 'EBUSY' || er.code === 'ENOTEMPTY' || er.code === 'EPERM') &&
+          busyTries < options.maxBusyTries) {
+        busyTries++
+        var time = busyTries * 100
+        // try again, with the same exact callback as this one.
+        return setTimeout(function () {
+          rimraf_(p, options, CB)
+        }, time)
+      }
+
+      // already gone
+      if (er.code === 'ENOENT') er = null
+    }
+
+    cb(er)
+  })
+}
+
+// Two possible strategies.
+// 1. Assume it's a file.  unlink it, then do the dir stuff on EPERM or EISDIR
+// 2. Assume it's a directory.  readdir, then do the file stuff on ENOTDIR
+//
+// Both result in an extra syscall when you guess wrong.  However, there
+// are likely far more normal files in the world than directories.  This
+// is based on the assumption that a the average number of files per
+// directory is >= 1.
+//
+// If anyone ever complains about this, then I guess the strategy could
+// be made configurable somehow.  But until then, YAGNI.
+function rimraf_ (p, options, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+
+  // sunos lets the root user unlink directories, which is... weird.
+  // so we have to lstat here and make sure it's not a dir.
+  options.lstat(p, function (er, st) {
+    if (er && er.code === 'ENOENT') {
+      return cb(null)
+    }
+
+    // Windows can EPERM on stat.  Life is suffering.
+    if (er && er.code === 'EPERM' && isWindows) {
+      fixWinEPERM(p, options, er, cb)
+    }
+
+    if (st && st.isDirectory()) {
+      return rmdir(p, options, er, cb)
+    }
+
+    options.unlink(p, function (er) {
+      if (er) {
+        if (er.code === 'ENOENT') {
+          return cb(null)
+        }
+        if (er.code === 'EPERM') {
+          return (isWindows)
+            ? fixWinEPERM(p, options, er, cb)
+            : rmdir(p, options, er, cb)
+        }
+        if (er.code === 'EISDIR') {
+          return rmdir(p, options, er, cb)
+        }
+      }
+      return cb(er)
+    })
+  })
+}
+
+function fixWinEPERM (p, options, er, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+  if (er) {
+    assert(er instanceof Error)
+  }
+
+  options.chmod(p, 666, function (er2) {
+    if (er2) {
+      cb(er2.code === 'ENOENT' ? null : er)
+    } else {
+      options.stat(p, function (er3, stats) {
+        if (er3) {
+          cb(er3.code === 'ENOENT' ? null : er)
+        } else if (stats.isDirectory()) {
+          rmdir(p, options, er, cb)
+        } else {
+          options.unlink(p, cb)
+        }
+      })
+    }
+  })
+}
+
+function fixWinEPERMSync (p, options, er) {
+  assert(p)
+  assert(options)
+  if (er) {
+    assert(er instanceof Error)
+  }
+
+  try {
+    options.chmodSync(p, 666)
+  } catch (er2) {
+    if (er2.code === 'ENOENT') {
+      return
+    } else {
+      throw er
+    }
+  }
+
+  try {
+    var stats = options.statSync(p)
+  } catch (er3) {
+    if (er3.code === 'ENOENT') {
+      return
+    } else {
+      throw er
+    }
+  }
+
+  if (stats.isDirectory()) {
+    rmdirSync(p, options, er)
+  } else {
+    options.unlinkSync(p)
+  }
+}
+
+function rmdir (p, options, originalEr, cb) {
+  assert(p)
+  assert(options)
+  if (originalEr) {
+    assert(originalEr instanceof Error)
+  }
+  assert(typeof cb === 'function')
+
+  // try to rmdir first, and only readdir on ENOTEMPTY or EEXIST (SunOS)
+  // if we guessed wrong, and it's not a directory, then
+  // raise the original error.
+  options.rmdir(p, function (er) {
+    if (er && (er.code === 'ENOTEMPTY' || er.code === 'EEXIST' || er.code === 'EPERM')) {
+      rmkids(p, options, cb)
+    } else if (er && er.code === 'ENOTDIR') {
+      cb(originalEr)
+    } else {
+      cb(er)
+    }
+  })
+}
+
+function rmkids (p, options, cb) {
+  assert(p)
+  assert(options)
+  assert(typeof cb === 'function')
+
+  options.readdir(p, function (er, files) {
+    if (er) {
+      return cb(er)
+    }
+    var n = files.length
+    if (n === 0) {
+      return options.rmdir(p, cb)
+    }
+    var errState
+    files.forEach(function (f) {
+      rimraf(path.join(p, f), options, function (er) {
+        if (errState) {
+          return
+        }
+        if (er) {
+          return cb(errState = er)
+        }
+        if (--n === 0) {
+          options.rmdir(p, cb)
+        }
+      })
+    })
+  })
+}
+
+// this looks simpler, and is strictly *faster*, but will
+// tie up the JavaScript thread and fail on excessively
+// deep directory trees.
+function rimrafSync (p, options) {
+  options = options || {}
+  defaults(options)
+
+  assert(p, 'rimraf: missing path')
+  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
+  assert(options, 'rimraf: missing options')
+  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+
+  try {
+    var st = options.lstatSync(p)
+  } catch (er) {
+    if (er.code === 'ENOENT') {
+      return
+    }
+
+    // Windows can EPERM on stat.  Life is suffering.
+    if (er.code === 'EPERM' && isWindows) {
+      fixWinEPERMSync(p, options, er)
+    }
+  }
+
+  try {
+    // sunos lets the root user unlink directories, which is... weird.
+    if (st && st.isDirectory()) {
+      rmdirSync(p, options, null)
+    } else {
+      options.unlinkSync(p)
+    }
+  } catch (er) {
+    if (er.code === 'ENOENT') {
+      return
+    }
+    if (er.code === 'EPERM') {
+      return isWindows ? fixWinEPERMSync(p, options, er) : rmdirSync(p, options, er)
+    }
+    if (er.code !== 'EISDIR') {
+      throw er
+    }
+    rmdirSync(p, options, er)
+  }
+}
+
+function rmdirSync (p, options, originalEr) {
+  assert(p)
+  assert(options)
+  if (originalEr) {
+    assert(originalEr instanceof Error)
+  }
+
+  try {
+    options.rmdirSync(p)
+  } catch (er) {
+    if (er.code === 'ENOENT') {
+      return
+    }
+    if (er.code === 'ENOTDIR') {
+      throw originalEr
+    }
+    if (er.code === 'ENOTEMPTY' || er.code === 'EEXIST' || er.code === 'EPERM') {
+      rmkidsSync(p, options)
+    }
+  }
+}
+
+function rmkidsSync (p, options) {
+  assert(p)
+  assert(options)
+  options.readdirSync(p).forEach(function (f) {
+    rimrafSync(path.join(p, f), options)
+  })
+  options.rmdirSync(p, options)
+}

--- a/package.json
+++ b/package.json
@@ -36,8 +36,7 @@
     "graceful-fs": "^4.1.2",
     "jsonfile": "^2.1.0",
     "klaw": "^1.0.0",
-    "path-is-absolute": "^1.0.0",
-    "rimraf": "^2.2.8"
+    "path-is-absolute": "^1.0.0"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
@@ -46,6 +45,7 @@
     "mocha": "^2.1.0",
     "proxyquire": "^1.7.10",
     "read-dir-files": "^0.1.1",
+    "rimraf": "^2.2.8",
     "secure-random": "^1.1.1",
     "semver": "^4.3.6",
     "standard": "^7.0.0-beta.0"


### PR DESCRIPTION
We aren't using rimraf's glob support, and glob is a rather large dependency.

Changes:

- Remove glob support from rimraf
- Remove move()'s dependency on rimraf; use fs-extra.remove instead
- Make rimraf a devDependency; it is used in the tests

---

**Original comment:**

@jprichardson This is my WIP of inlining rimraf. This needs rebased, **do not merge**.

rimraf has functionality built in to handle alternate `fs` modules. Currently, there is no way for the end-user to leverage that functionality. I could simplify the code by removing that, however, I don't want to have to add it back. Will we be adding custom `fs` module support or glob support to `fs-extra` first?