### PR TITLE
Re-add Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,5 @@ matrix:
 env:
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE
+after_success:
+  - npm run coveralls


### PR DESCRIPTION
@jprichardson Not sure if this is the best way, as it runs the tests twice. Other ways:

- Only run `coveralls` on the `LINT` build.
- Run the coverage script as the main script, and modify the coveralls script to only use the existing coverage report.
- Write a custom travis script in JS that runs tests for every platform and runs `standard` and `coveralls` on only one version.

Thoughts?