### PR TITLE
Update devDeps, fix lint error

### DIFF
--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -37,7 +37,7 @@ describe('utimes', function () {
       // does anyone use FAT anymore?
       /* if (process.platform === 'win32') {
         assert.equal(res, true)
-      }*/
+      } */
       // fails on appveyor... could appveyor be using FAT?
 
       // this would fail if ext2/ext3

--- a/package.json
+++ b/package.json
@@ -39,15 +39,15 @@
   },
   "devDependencies": {
     "coveralls": "^2.11.2",
-    "istanbul": "^0.3.5",
+    "istanbul": "^0.4.5",
     "minimist": "^1.1.1",
-    "mocha": "^2.1.0",
+    "mocha": "^3.1.2",
     "proxyquire": "^1.7.10",
     "read-dir-files": "^0.1.1",
     "rimraf": "^2.2.8",
     "secure-random": "^1.1.1",
-    "semver": "^4.3.6",
-    "standard": "^7.0.0-beta.0"
+    "semver": "^5.3.0",
+    "standard": "^8.5.0"
   },
   "main": "./lib/index",
   "scripts": {


### PR DESCRIPTION
@jprichardson Ever think of using @greenkeeperio-bot so I don't have to do this? I use it on all of my projects and really like it. Not only does it update dependencies outside your version range, it also checks to make sure none of your dependencies break semver.

My only gripe is the commit messages: `chore(package): update eslint to version 3.8.0`. I always use the squash-merge function so I can reword the commit message to `Update eslint to version 3.8.0`.

https://greenkeeper.io/