### PR TITLE
Fix coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ env:
   - TEST_SUITE=unit
 script: npm run-script $TEST_SUITE
 after_success:
-  - npm run coveralls
+  - if [ $TEST_SUITE = lint ]; then npm run coveralls; fi

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "main": "./lib/index",
   "scripts": {
-    "coverage": "istanbul cover test.js",
+    "coverage": "istanbul cover -i 'lib/**' -x '**/__tests__/**' test.js",
     "coveralls": "npm run coverage && coveralls < coverage/lcov.info",
     "lint": "standard",
     "test-find": "find ./lib/**/__tests__ -name *.test.js | xargs mocha",


### PR DESCRIPTION
- istanbul shouldn't include test files in the coverage report
- Run coveralls only on the lint build in Travis CI

Coverage is pretty low, mainly due to window-specific code. How would coveralls handle it if we ran it on appveyor as well? Coverage would be higher there.