### PR TITLE
Enhance walkSync() to return items with path and stats

### DIFF
--- a/lib/walk-sync/__tests__/walkSync.test.js
+++ b/lib/walk-sync/__tests__/walkSync.test.js
@@ -27,14 +27,28 @@ describe('walk-sync', function () {
     }
   })
 
-  it('should return all files successfully for a dir', function (done) {
-    var files = fse.walkSync(fixturesDir)
-    var expectedFiles = ['dir1/file1_2', 'dir2/dir2_1/file2_1_1', 'file1']
-    expectedFiles = expectedFiles.map(function (item) {
+  it('should return all items of a dir containing path and stats data successfully', function (done) {
+    var items = fse.walkSync(fixturesDir)
+    var files = ['dir1/file1_2', 'dir2/dir2_1/file2_1_1', 'file1']
+    files = files.map(function (item) {
       return path.join(fixturesDir, item)
     })
-    files.forEach(function (elem, i) {
-      assert.equal(elem, expectedFiles[i])
+    var dirs = ['dir1', 'dir2', 'dir2/dir2_1']
+    dirs = dirs.map(function (item) {
+      return path.join(fixturesDir, item)
+    })
+    var expectedItems = [
+      {path: dirs[0], stats: fse.lstatSync(dirs[0])},
+      {path: files[0], stats: fse.lstatSync(files[0])},
+      {path: dirs[1], stats: fse.lstatSync(dirs[1])},
+      {path: dirs[2], stats: fse.lstatSync(dirs[2])},
+      {path: files[1], stats: fse.lstatSync(files[1])},
+      {path: files[2], stats: fse.lstatSync(files[2])}
+    ]
+    items.forEach(function (elem, i) {
+      assert.deepEqual(elem, expectedItems[i])
+      assert.strictEqual(elem.path, expectedItems[i].path)
+      assert.deepEqual(elem.stats, expectedItems[i].stats)
     })
     done()
   })

--- a/lib/walk-sync/index.js
+++ b/lib/walk-sync/index.js
@@ -1,18 +1,20 @@
 var fs = require('graceful-fs')
 var path = require('path')
 
-var walkSync = function (dir, filelist) {
-  var files = fs.readdirSync(dir)
-  filelist = filelist || []
+var walkSync = function (dir, list) {
+  var files = fs.readdirSync(path.resolve(dir))
+  list = list || []
   files.forEach(function (file) {
     var nestedPath = path.join(dir, file)
-    if (fs.lstatSync(nestedPath).isDirectory()) {
-      filelist = walkSync(nestedPath, filelist)
+    var stat = fs.lstatSync(nestedPath)
+    if (stat.isDirectory()) {
+      list.push({path: nestedPath, stats: stat})
+      list = walkSync(nestedPath, list)
     } else {
-      filelist.push(nestedPath)
+      list.push({path: nestedPath, stats: stat})
     }
   })
-  return filelist
+  return list
 }
 
 module.exports = {


### PR DESCRIPTION
Hi,

This PR is regarding #310. I modified `walkSync` and its test to return an array of items `{path:,stats:}` to be consistent with `walk`. Please let me know what you think. I appreciate it in advance. Thanks a lot. 