### PR TITLE
Test that remove() ignores glob characters.

### DIFF
--- a/lib/remove/__tests__/remove.test.js
+++ b/lib/remove/__tests__/remove.test.js
@@ -83,7 +83,14 @@ describe('remove', function () {
 
     it('shouldn’t delete glob matches', function (done) {
       var file = path.join(TEST_DIR, 'file?')
-      fs.writeFileSync(file, 'hello')
+      try {
+        fs.writeFileSync(file, 'hello')
+      } catch (ex) {
+        if (ex.code === 'ENOENT') {
+          return this.skip('Windows does not support filenames with ‘?’ or ‘*’ in them.')
+        }
+        throw ex
+      }
 
       var wrongFile = path.join(TEST_DIR, 'file1')
       fs.writeFileSync(wrongFile, 'yo')
@@ -93,6 +100,22 @@ describe('remove', function () {
       fse.remove(file, function (err) {
         assert.ifError(err)
         assert(!fs.existsSync(file))
+        assert(fs.existsSync(wrongFile))
+        done()
+      })
+    })
+
+    it('shouldn’t delete glob matches when file doesn’t exist', function (done) {
+      var nonexistentFile = path.join(TEST_DIR, 'file?')
+
+      var wrongFile = path.join(TEST_DIR, 'file1')
+      fs.writeFileSync(wrongFile, 'yo')
+
+      assert(!fs.existsSync(nonexistentFile))
+      assert(fs.existsSync(wrongFile))
+      fse.remove(nonexistentFile, function (err) {
+        assert.ifError(err)
+        assert(!fs.existsSync(nonexistentFile))
         assert(fs.existsSync(wrongFile))
         done()
       })

--- a/lib/remove/__tests__/remove.test.js
+++ b/lib/remove/__tests__/remove.test.js
@@ -80,5 +80,22 @@ describe('remove', function () {
       }, 25)
       fse.remove(file)
     })
+
+    it('shouldn’t delete glob matches', function (done) {
+      var file = path.join(TEST_DIR, 'file?')
+      fs.writeFileSync(file, 'hello')
+
+      var wrongFile = path.join(TEST_DIR, 'file1')
+      fs.writeFileSync(wrongFile, 'yo')
+
+      assert(fs.existsSync(file))
+      assert(fs.existsSync(wrongFile))
+      fse.remove(file, function (err) {
+        assert.ifError(err)
+        assert(!fs.existsSync(file))
+        assert(fs.existsSync(wrongFile))
+        done()
+      })
+    })
   })
 })


### PR DESCRIPTION
After looking at rimraf, I began to fear that node-fs-extra, which
is based on rimraf, might also automatically glob things. I find
this confusing when the API is being used as an overlay of the
node built-in fs module which never expands globs. This test
explicitly verifies that the remove() function does not follow
glob characters.