### PR TITLE
Fix move clobber tests to work around graceful-fs bug.

### DIFF
--- a/lib/move/__tests__/move-clobber.test.js
+++ b/lib/move/__tests__/move-clobber.test.js
@@ -29,6 +29,12 @@ describe('move / clobber', function () {
   describe('> when clobber = true', function () {
     describe('> when dest is a directory', function () {
       it('should clobber the destination', function (done) {
+        // Tests fail on appveyor/Windows due to
+        // https://github.com/isaacs/node-graceful-fs/issues/98.
+        // Workaround by increasing the timeout by a minute (because
+        // graceful times out after a minute).
+        this.timeout(90000)
+
         // use fixtures dir as dest since it has stuff
         var dest = FIXTURES_DIR
         var paths = fs.readdirSync(dest)


### PR DESCRIPTION
When trying to rename a directory over another directory, graceful-fs-4.1.10
(maybe other versions?) takes 1 minute to fail the call with an error.
This causes the test to timeout. The workaround is to increase the timeout
of that one test to 1m30s.

See https://github.com/isaacs/node-graceful-fs/issues/98