### PR TITLE
Update klaw-sync link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Methods
 
 ### What happened to `walk()` and `walkSync()`?
 
-They were removed from `fs-extra` in v2.0.0. If you need the functionality, `walk` and `walkSync` are available as separate packages, [`klaw`](https://github.com/jprichardson/node-klaw) and [`klaw-sync`](https://github.com/mawni/node-klaw-sync).
+They were removed from `fs-extra` in v2.0.0. If you need the functionality, `walk` and `walkSync` are available as separate packages, [`klaw`](https://github.com/jprichardson/node-klaw) and [`klaw-sync`](https://github.com/manidlou/node-klaw-sync).
 
 
 Third Party


### PR DESCRIPTION
This PR updates `klaw-sync` link in README. I changed my username from `mawni` to `manidlou`, so I updated the `klaw-sync` link to the new one https://github.com/manidlou/node-klaw-sync. Sorry for inconvenience. Thanks a lot.