### PR TITLE
ES6 refactoring

### DIFF
--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -1,26 +1,28 @@
-var fs = require('graceful-fs')
+'use strict'
 
-var BUF_LENGTH = 64 * 1024
-var _buff = new Buffer(BUF_LENGTH)
+const fs = require('graceful-fs')
+
+const BUF_LENGTH = 64 * 1024
+const _buff = new Buffer(BUF_LENGTH)
 
 function copyFileSync (srcFile, destFile, options) {
-  var overwrite = options.overwrite
-  var errorOnExist = options.errorOnExist
-  var preserveTimestamps = options.preserveTimestamps
+  const overwrite = options.overwrite
+  const errorOnExist = options.errorOnExist
+  const preserveTimestamps = options.preserveTimestamps
 
   if (fs.existsSync(destFile)) {
     if (overwrite) {
       fs.unlinkSync(destFile)
     } else if (errorOnExist) {
-      throw new Error(destFile + ' already exists')
+      throw new Error(`${destFile} already exists`)
     } else return
   }
 
-  var fdr = fs.openSync(srcFile, 'r')
-  var stat = fs.fstatSync(fdr)
-  var fdw = fs.openSync(destFile, 'w', stat.mode)
-  var bytesRead = 1
-  var pos = 0
+  const fdr = fs.openSync(srcFile, 'r')
+  const stat = fs.fstatSync(fdr)
+  const fdw = fs.openSync(destFile, 'w', stat.mode)
+  let bytesRead = 1
+  let pos = 0
 
   while (bytesRead > 0) {
     bytesRead = fs.readSync(fdr, _buff, 0, BUF_LENGTH, pos)

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -1,7 +1,9 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var copyFileSync = require('./copy-file-sync')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+const copyFileSync = require('./copy-file-sync')
+const mkdir = require('../mkdirs')
 
 function copySync (src, dest, options) {
   if (typeof options === 'function' || options instanceof RegExp) {
@@ -22,14 +24,14 @@ function copySync (src, dest, options) {
 
   // Warn about using preserveTimestamps on 32-bit node:
   if (options.preserveTimestamps && process.arch === 'ia32') {
-    console.warn('fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n' +
-    'see https://github.com/jprichardson/node-fs-extra/issues/269')
+    console.warn(`fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n
+    see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
-  var stats = (options.recursive && !options.dereference) ? fs.lstatSync(src) : fs.statSync(src)
-  var destFolder = path.dirname(dest)
-  var destFolderExists = fs.existsSync(destFolder)
-  var performCopy = false
+  const stats = (options.recursive && !options.dereference) ? fs.lstatSync(src) : fs.statSync(src)
+  const destFolder = path.dirname(dest)
+  const destFolderExists = fs.existsSync(destFolder)
+  let performCopy = false
 
   if (options.filter instanceof RegExp) {
     console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
@@ -45,14 +47,14 @@ function copySync (src, dest, options) {
     })
   } else if (stats.isDirectory() && performCopy) {
     if (!fs.existsSync(dest)) mkdir.mkdirsSync(dest)
-    var contents = fs.readdirSync(src)
-    contents.forEach(function (content) {
-      var opts = options
+    const contents = fs.readdirSync(src)
+    contents.forEach(content => {
+      const opts = options
       opts.recursive = true
       copySync(path.join(src, content), path.join(dest, content), opts)
     })
   } else if (options.recursive && stats.isSymbolicLink() && performCopy) {
-    var srcPath = fs.readlinkSync(src)
+    const srcPath = fs.readlinkSync(src)
     fs.symlinkSync(srcPath, dest)
   }
 }

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -1,7 +1,9 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var ncp = require('./ncp')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+const ncp = require('./ncp')
+const mkdir = require('../mkdirs')
 
 function copy (src, dest, options, callback) {
   if (typeof options === 'function' && !callback) {
@@ -15,31 +17,31 @@ function copy (src, dest, options, callback) {
 
   // Warn about using preserveTimestamps on 32-bit node:
   if (options.preserveTimestamps && process.arch === 'ia32') {
-    console.warn('fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n' +
-    'see https://github.com/jprichardson/node-fs-extra/issues/269')
+    console.warn(`fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n
+    see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
   // don't allow src and dest to be the same
-  var basePath = process.cwd()
-  var currentPath = path.resolve(basePath, src)
-  var targetPath = path.resolve(basePath, dest)
+  const basePath = process.cwd()
+  const currentPath = path.resolve(basePath, src)
+  const targetPath = path.resolve(basePath, dest)
   if (currentPath === targetPath) return callback(new Error('Source and destination must not be the same.'))
 
-  fs.lstat(src, function (err, stats) {
+  fs.lstat(src, (err, stats) => {
     if (err) return callback(err)
 
-    var dir = null
+    let dir = null
     if (stats.isDirectory()) {
-      var parts = dest.split(path.sep)
+      const parts = dest.split(path.sep)
       parts.pop()
       dir = parts.join(path.sep)
     } else {
       dir = path.dirname(dest)
     }
 
-    fs.exists(dir, function (dirExists) {
+    fs.exists(dir, dirExists => {
       if (dirExists) return ncp(src, dest, options, callback)
-      mkdir.mkdirs(dir, function (err) {
+      mkdir.mkdirs(dir, err => {
         if (err) return callback(err)
         ncp(src, dest, options, callback)
       })

--- a/lib/empty/index.js
+++ b/lib/empty/index.js
@@ -1,23 +1,23 @@
-var fs = require('fs')
-var path = require('path')
-var mkdir = require('../mkdirs')
-var remove = require('../remove')
+'use strict'
+
+const fs = require('fs')
+const path = require('path')
+const mkdir = require('../mkdirs')
+const remove = require('../remove')
 
 function emptyDir (dir, callback) {
   callback = callback || function () {}
-  fs.readdir(dir, function (err, items) {
+  fs.readdir(dir, (err, items) => {
     if (err) return mkdir.mkdirs(dir, callback)
 
-    items = items.map(function (item) {
-      return path.join(dir, item)
-    })
+    items = items.map(item => path.join(dir, item))
 
     deleteItem()
 
     function deleteItem () {
-      var item = items.pop()
+      const item = items.pop()
       if (!item) return callback()
-      remove.remove(item, function (err) {
+      remove.remove(item, err => {
         if (err) return callback(err)
         deleteItem()
       })
@@ -26,22 +26,22 @@ function emptyDir (dir, callback) {
 }
 
 function emptyDirSync (dir) {
-  var items
+  let items
   try {
     items = fs.readdirSync(dir)
   } catch (err) {
     return mkdir.mkdirsSync(dir)
   }
 
-  items.forEach(function (item) {
+  items.forEach(item => {
     item = path.join(dir, item)
     remove.removeSync(item)
   })
 }
 
 module.exports = {
-  emptyDirSync: emptyDirSync,
+  emptyDirSync,
   emptydirSync: emptyDirSync,
-  emptyDir: emptyDir,
+  emptyDir,
   emptydir: emptyDir
 }

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -1,21 +1,23 @@
-var path = require('path')
-var fs = require('graceful-fs')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const path = require('path')
+const fs = require('graceful-fs')
+const mkdir = require('../mkdirs')
 
 function createFile (file, callback) {
   function makeFile () {
-    fs.writeFile(file, '', function (err) {
+    fs.writeFile(file, '', err => {
       if (err) return callback(err)
       callback()
     })
   }
 
-  fs.exists(file, function (fileExists) {
+  fs.exists(file, fileExists => {
     if (fileExists) return callback()
-    var dir = path.dirname(file)
-    fs.exists(dir, function (dirExists) {
+    const dir = path.dirname(file)
+    fs.exists(dir, dirExists => {
       if (dirExists) return makeFile()
-      mkdir.mkdirs(dir, function (err) {
+      mkdir.mkdirs(dir, err => {
         if (err) return callback(err)
         makeFile()
       })
@@ -26,7 +28,7 @@ function createFile (file, callback) {
 function createFileSync (file) {
   if (fs.existsSync(file)) return
 
-  var dir = path.dirname(file)
+  const dir = path.dirname(file)
   if (!fs.existsSync(dir)) {
     mkdir.mkdirsSync(dir)
   }
@@ -35,8 +37,8 @@ function createFileSync (file) {
 }
 
 module.exports = {
-  createFile: createFile,
-  createFileSync: createFileSync,
+  createFile,
+  createFileSync,
   // alias
   ensureFile: createFile,
   ensureFileSync: createFileSync

--- a/lib/ensure/index.js
+++ b/lib/ensure/index.js
@@ -1,6 +1,8 @@
-var file = require('./file')
-var link = require('./link')
-var symlink = require('./symlink')
+'use strict'
+
+const file = require('./file')
+const link = require('./link')
+const symlink = require('./symlink')
 
 module.exports = {
   // file

--- a/lib/ensure/link.js
+++ b/lib/ensure/link.js
@@ -1,27 +1,29 @@
-var path = require('path')
-var fs = require('graceful-fs')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const path = require('path')
+const fs = require('graceful-fs')
+const mkdir = require('../mkdirs')
 
 function createLink (srcpath, dstpath, callback) {
   function makeLink (srcpath, dstpath) {
-    fs.link(srcpath, dstpath, function (err) {
+    fs.link(srcpath, dstpath, err => {
       if (err) return callback(err)
       callback(null)
     })
   }
 
-  fs.exists(dstpath, function (destinationExists) {
+  fs.exists(dstpath, destinationExists => {
     if (destinationExists) return callback(null)
-    fs.lstat(srcpath, function (err, stat) {
+    fs.lstat(srcpath, (err, stat) => {
       if (err) {
         err.message = err.message.replace('lstat', 'ensureLink')
         return callback(err)
       }
 
-      var dir = path.dirname(dstpath)
-      fs.exists(dir, function (dirExists) {
+      const dir = path.dirname(dstpath)
+      fs.exists(dir, dirExists => {
         if (dirExists) return makeLink(srcpath, dstpath)
-        mkdir.mkdirs(dir, function (err) {
+        mkdir.mkdirs(dir, err => {
           if (err) return callback(err)
           makeLink(srcpath, dstpath)
         })
@@ -31,7 +33,7 @@ function createLink (srcpath, dstpath, callback) {
 }
 
 function createLinkSync (srcpath, dstpath, callback) {
-  var destinationExists = fs.existsSync(dstpath)
+  const destinationExists = fs.existsSync(dstpath)
   if (destinationExists) return undefined
 
   try {
@@ -41,8 +43,8 @@ function createLinkSync (srcpath, dstpath, callback) {
     throw err
   }
 
-  var dir = path.dirname(dstpath)
-  var dirExists = fs.existsSync(dir)
+  const dir = path.dirname(dstpath)
+  const dirExists = fs.existsSync(dir)
   if (dirExists) return fs.linkSync(srcpath, dstpath)
   mkdir.mkdirsSync(dir)
 
@@ -50,8 +52,8 @@ function createLinkSync (srcpath, dstpath, callback) {
 }
 
 module.exports = {
-  createLink: createLink,
-  createLinkSync: createLinkSync,
+  createLink,
+  createLinkSync,
   // alias
   ensureLink: createLink,
   ensureLinkSync: createLinkSync


### PR DESCRIPTION
I refactored some files to ES6 according to #355 . Much things are not available in Node v4.

`'use strict'` is a must in Node v4 if `let` is used. For consistency I also put it although no `let` is used.