### PR TITLE
Document the return value of ensureDir

### DIFF
--- a/docs/ensureDir.md
+++ b/docs/ensureDir.md
@@ -18,3 +18,18 @@ fs.ensureDir(dir, function (err) {
   // dir has now been created, including the directory it is to be placed in
 })
 ```
+
+---
+
+The callback receives a second argument, containing the path to the first directory that was created in the process. If no directories were made, this will be `null`.
+```js
+var fs = require('fs-extra')
+
+// Let's assume that /var/www exists
+
+var dir = '/var/www/this/path/does/not/exist'
+fs.ensureDir(dir, function (err, created) {
+  console.log(created) // => /var/www/this
+  // second argument contains the first directory in the path that did not exist before
+})
+```


### PR DESCRIPTION
This feature is implemented in mkdirp and verified in the mkdirp tests. Just adding it to documentation.
Fixes #349 