### PR TITLE
ES6 refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,27 +35,27 @@ Usage
 You don't ever need to include the original `fs` module again:
 
 ```js
-var fs = require('fs') // this is no longer necessary
+const fs = require('fs') // this is no longer necessary
 ```
 
 you can now do this:
 
 ```js
-var fs = require('fs-extra')
+const fs = require('fs-extra')
 ```
 
 or if you prefer to make it clear that you're using `fs-extra` and not `fs`, you may want
 to name your `fs` variable `fse` like so:
 
 ```js
-var fse = require('fs-extra')
+const fse = require('fs-extra')
 ```
 
 you can also keep both, but it's redundant:
 
 ```js
-var fs = require('fs')
-var fse = require('fs-extra')
+const fs = require('fs')
+const fse = require('fs-extra')
 ```
 
 Sync vs Async
@@ -67,9 +67,9 @@ Sync methods on the other hand will throw if an error occurs.
 Example:
 
 ```js
-var fs = require('fs-extra')
+const fs = require('fs-extra')
 
-fs.copy('/tmp/myfile', '/tmp/mynewfile', function (err) {
+fs.copy('/tmp/myfile', '/tmp/mynewfile', err => {
   if (err) return console.error(err)
   console.log("success!")
 });
@@ -128,8 +128,8 @@ Use [Bluebird](https://github.com/petkaantonov/bluebird). See https://github.com
 explicitly listed as supported.
 
 ```js
-var Promise = require('bluebird')
-var fs = Promise.promisifyAll(require('fs-extra'))
+const Promise = require('bluebird')
+const fs = Promise.promisifyAll(require('fs-extra'))
 ```
 
 Or you can use a dedicated package:

--- a/lib/ensure/symlink-paths.js
+++ b/lib/ensure/symlink-paths.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const path = require('path')
-// path.isAbsolute shim for Node.js 0.10 support
 const fs = require('graceful-fs')
 
 /**

--- a/lib/ensure/symlink-paths.js
+++ b/lib/ensure/symlink-paths.js
@@ -1,6 +1,8 @@
-var path = require('path')
+'use strict'
+
+const path = require('path')
 // path.isAbsolute shim for Node.js 0.10 support
-var fs = require('graceful-fs')
+const fs = require('graceful-fs')
 
 /**
  * Function that returns two types of paths, one relative to symlink, and one
@@ -26,7 +28,7 @@ var fs = require('graceful-fs')
 
 function symlinkPaths (srcpath, dstpath, callback) {
   if (path.isAbsolute(srcpath)) {
-    return fs.lstat(srcpath, function (err, stat) {
+    return fs.lstat(srcpath, (err, stat) => {
       if (err) {
         err.message = err.message.replace('lstat', 'ensureSymlink')
         return callback(err)
@@ -37,16 +39,16 @@ function symlinkPaths (srcpath, dstpath, callback) {
       })
     })
   } else {
-    var dstdir = path.dirname(dstpath)
-    var relativeToDst = path.join(dstdir, srcpath)
-    return fs.exists(relativeToDst, function (exists) {
+    const dstdir = path.dirname(dstpath)
+    const relativeToDst = path.join(dstdir, srcpath)
+    return fs.exists(relativeToDst, exists => {
       if (exists) {
         return callback(null, {
           'toCwd': relativeToDst,
           'toDst': srcpath
         })
       } else {
-        return fs.lstat(srcpath, function (err, stat) {
+        return fs.lstat(srcpath, (err, stat) => {
           if (err) {
             err.message = err.message.replace('lstat', 'ensureSymlink')
             return callback(err)
@@ -62,7 +64,7 @@ function symlinkPaths (srcpath, dstpath, callback) {
 }
 
 function symlinkPathsSync (srcpath, dstpath) {
-  var exists
+  let exists
   if (path.isAbsolute(srcpath)) {
     exists = fs.existsSync(srcpath)
     if (!exists) throw new Error('absolute srcpath does not exist')
@@ -71,8 +73,8 @@ function symlinkPathsSync (srcpath, dstpath) {
       'toDst': srcpath
     }
   } else {
-    var dstdir = path.dirname(dstpath)
-    var relativeToDst = path.join(dstdir, srcpath)
+    const dstdir = path.dirname(dstpath)
+    const relativeToDst = path.join(dstdir, srcpath)
     exists = fs.existsSync(relativeToDst)
     if (exists) {
       return {
@@ -91,6 +93,6 @@ function symlinkPathsSync (srcpath, dstpath) {
 }
 
 module.exports = {
-  'symlinkPaths': symlinkPaths,
-  'symlinkPathsSync': symlinkPathsSync
+  symlinkPaths,
+  symlinkPathsSync
 }

--- a/lib/ensure/symlink-type.js
+++ b/lib/ensure/symlink-type.js
@@ -1,10 +1,12 @@
-var fs = require('graceful-fs')
+'use strict'
+
+const fs = require('graceful-fs')
 
 function symlinkType (srcpath, type, callback) {
   callback = (typeof type === 'function') ? type : callback
   type = (typeof type === 'function') ? false : type
   if (type) return callback(null, type)
-  fs.lstat(srcpath, function (err, stats) {
+  fs.lstat(srcpath, (err, stats) => {
     if (err) return callback(null, 'file')
     type = (stats && stats.isDirectory()) ? 'dir' : 'file'
     callback(null, type)
@@ -12,9 +14,11 @@ function symlinkType (srcpath, type, callback) {
 }
 
 function symlinkTypeSync (srcpath, type) {
+  let stats
+
   if (type) return type
   try {
-    var stats = fs.lstatSync(srcpath)
+    stats = fs.lstatSync(srcpath)
   } catch (e) {
     return 'file'
   }
@@ -22,6 +26,6 @@ function symlinkTypeSync (srcpath, type) {
 }
 
 module.exports = {
-  symlinkType: symlinkType,
-  symlinkTypeSync: symlinkTypeSync
+  symlinkType,
+  symlinkTypeSync
 }

--- a/lib/ensure/symlink.js
+++ b/lib/ensure/symlink.js
@@ -1,32 +1,34 @@
-var path = require('path')
-var fs = require('graceful-fs')
-var _mkdirs = require('../mkdirs')
-var mkdirs = _mkdirs.mkdirs
-var mkdirsSync = _mkdirs.mkdirsSync
+'use strict'
 
-var _symlinkPaths = require('./symlink-paths')
-var symlinkPaths = _symlinkPaths.symlinkPaths
-var symlinkPathsSync = _symlinkPaths.symlinkPathsSync
+const path = require('path')
+const fs = require('graceful-fs')
+const _mkdirs = require('../mkdirs')
+const mkdirs = _mkdirs.mkdirs
+const mkdirsSync = _mkdirs.mkdirsSync
 
-var _symlinkType = require('./symlink-type')
-var symlinkType = _symlinkType.symlinkType
-var symlinkTypeSync = _symlinkType.symlinkTypeSync
+const _symlinkPaths = require('./symlink-paths')
+const symlinkPaths = _symlinkPaths.symlinkPaths
+const symlinkPathsSync = _symlinkPaths.symlinkPathsSync
+
+const _symlinkType = require('./symlink-type')
+const symlinkType = _symlinkType.symlinkType
+const symlinkTypeSync = _symlinkType.symlinkTypeSync
 
 function createSymlink (srcpath, dstpath, type, callback) {
   callback = (typeof type === 'function') ? type : callback
   type = (typeof type === 'function') ? false : type
 
-  fs.exists(dstpath, function (destinationExists) {
+  fs.exists(dstpath, destinationExists => {
     if (destinationExists) return callback(null)
-    symlinkPaths(srcpath, dstpath, function (err, relative) {
+    symlinkPaths(srcpath, dstpath, (err, relative) => {
       if (err) return callback(err)
       srcpath = relative.toDst
-      symlinkType(relative.toCwd, type, function (err, type) {
+      symlinkType(relative.toCwd, type, (err, type) => {
         if (err) return callback(err)
-        var dir = path.dirname(dstpath)
-        fs.exists(dir, function (dirExists) {
+        const dir = path.dirname(dstpath)
+        fs.exists(dir, dirExists => {
           if (dirExists) return fs.symlink(srcpath, dstpath, type, callback)
-          mkdirs(dir, function (err) {
+          mkdirs(dir, err => {
             if (err) return callback(err)
             fs.symlink(srcpath, dstpath, type, callback)
           })
@@ -40,22 +42,22 @@ function createSymlinkSync (srcpath, dstpath, type, callback) {
   callback = (typeof type === 'function') ? type : callback
   type = (typeof type === 'function') ? false : type
 
-  var destinationExists = fs.existsSync(dstpath)
+  const destinationExists = fs.existsSync(dstpath)
   if (destinationExists) return undefined
 
-  var relative = symlinkPathsSync(srcpath, dstpath)
+  const relative = symlinkPathsSync(srcpath, dstpath)
   srcpath = relative.toDst
   type = symlinkTypeSync(relative.toCwd, type)
-  var dir = path.dirname(dstpath)
-  var exists = fs.existsSync(dir)
+  const dir = path.dirname(dstpath)
+  const exists = fs.existsSync(dir)
   if (exists) return fs.symlinkSync(srcpath, dstpath, type)
   mkdirsSync(dir)
   return fs.symlinkSync(srcpath, dstpath, type)
 }
 
 module.exports = {
-  createSymlink: createSymlink,
-  createSymlinkSync: createSymlinkSync,
+  createSymlink,
+  createSymlinkSync,
   // alias
   ensureSymlink: createSymlink,
   ensureSymlinkSync: createSymlinkSync

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,14 +1,16 @@
-var assign = require('./util/assign')
+'use strict'
 
-var fse = {}
-var gfs = require('graceful-fs')
+const assign = require('./util/assign')
+
+const fse = {}
+const gfs = require('graceful-fs')
 
 // attach fs methods to fse
-Object.keys(gfs).forEach(function (key) {
+Object.keys(gfs).forEach(key => {
   fse[key] = gfs[key]
 })
 
-var fs = fse
+const fs = fse
 
 assign(fs, require('./copy'))
 assign(fs, require('./copy-sync'))
@@ -23,12 +25,10 @@ assign(fs, require('./output'))
 module.exports = fs
 
 // maintain backwards compatibility for awhile
-var jsonfile = {}
+const jsonfile = {}
 Object.defineProperty(jsonfile, 'spaces', {
-  get: function () {
-    return fs.spaces // found in ./json
-  },
-  set: function (val) {
+  get: () => fs.spaces, // found in ./json
+  set: val => {
     fs.spaces = val
   }
 })

--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -1,4 +1,6 @@
-var jsonFile = require('./jsonfile')
+'use strict'
+
+const jsonFile = require('./jsonfile')
 
 jsonFile.outputJsonSync = require('./output-json-sync')
 jsonFile.outputJson = require('./output-json')

--- a/lib/json/jsonfile.js
+++ b/lib/json/jsonfile.js
@@ -1,4 +1,6 @@
-var jsonFile = require('jsonfile')
+'use strict'
+
+const jsonFile = require('jsonfile')
 
 module.exports = {
   // jsonfile exports

--- a/lib/json/output-json-sync.js
+++ b/lib/json/output-json-sync.js
@@ -1,10 +1,12 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var jsonFile = require('./jsonfile')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+const mkdir = require('../mkdirs')
+const jsonFile = require('./jsonfile')
 
 function outputJsonSync (file, data, options) {
-  var dir = path.dirname(file)
+  const dir = path.dirname(file)
 
   if (!fs.existsSync(dir)) {
     mkdir.mkdirsSync(dir)

--- a/lib/json/output-json.js
+++ b/lib/json/output-json.js
@@ -1,7 +1,9 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var jsonFile = require('./jsonfile')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+const mkdir = require('../mkdirs')
+const jsonFile = require('./jsonfile')
 
 function outputJson (file, data, options, callback) {
   if (typeof options === 'function') {
@@ -9,12 +11,12 @@ function outputJson (file, data, options, callback) {
     options = {}
   }
 
-  var dir = path.dirname(file)
+  const dir = path.dirname(file)
 
-  fs.exists(dir, function (itDoes) {
+  fs.exists(dir, itDoes => {
     if (itDoes) return jsonFile.writeJson(file, data, options, callback)
 
-    mkdir.mkdirs(dir, function (err) {
+    mkdir.mkdirs(dir, err => {
       if (err) return callback(err)
       jsonFile.writeJson(file, data, options, callback)
     })

--- a/lib/mkdirs/mkdirs-sync.js
+++ b/lib/mkdirs/mkdirs-sync.js
@@ -1,19 +1,21 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var invalidWin32Path = require('./win32').invalidWin32Path
+'use strict'
 
-var o777 = parseInt('0777', 8)
+const fs = require('graceful-fs')
+const path = require('path')
+const invalidWin32Path = require('./win32').invalidWin32Path
+
+const o777 = parseInt('0777', 8)
 
 function mkdirsSync (p, opts, made) {
   if (!opts || typeof opts !== 'object') {
     opts = { mode: opts }
   }
 
-  var mode = opts.mode
-  var xfs = opts.fs || fs
+  let mode = opts.mode
+  const xfs = opts.fs || fs
 
   if (process.platform === 'win32' && invalidWin32Path(p)) {
-    var errInval = new Error(p + ' contains invalid WIN32 path characters.')
+    const errInval = new Error(p + ' contains invalid WIN32 path characters.')
     errInval.code = 'EINVAL'
     throw errInval
   }
@@ -40,7 +42,7 @@ function mkdirsSync (p, opts, made) {
       // there already.  If so, then hooray!  If not, then something
       // is borked.
       default:
-        var stat
+        let stat
         try {
           stat = xfs.statSync(p)
         } catch (err1) {

--- a/lib/mkdirs/mkdirs.js
+++ b/lib/mkdirs/mkdirs.js
@@ -1,8 +1,10 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var invalidWin32Path = require('./win32').invalidWin32Path
+'use strict'
 
-var o777 = parseInt('0777', 8)
+const fs = require('graceful-fs')
+const path = require('path')
+const invalidWin32Path = require('./win32').invalidWin32Path
+
+const o777 = parseInt('0777', 8)
 
 function mkdirs (p, opts, callback, made) {
   if (typeof opts === 'function') {
@@ -13,13 +15,13 @@ function mkdirs (p, opts, callback, made) {
   }
 
   if (process.platform === 'win32' && invalidWin32Path(p)) {
-    var errInval = new Error(p + ' contains invalid WIN32 path characters.')
+    const errInval = new Error(p + ' contains invalid WIN32 path characters.')
     errInval.code = 'EINVAL'
     return callback(errInval)
   }
 
-  var mode = opts.mode
-  var xfs = opts.fs || fs
+  let mode = opts.mode
+  const xfs = opts.fs || fs
 
   if (mode === undefined) {
     mode = o777 & (~process.umask())
@@ -29,7 +31,7 @@ function mkdirs (p, opts, callback, made) {
   callback = callback || function () {}
   p = path.resolve(p)
 
-  xfs.mkdir(p, mode, function (er) {
+  xfs.mkdir(p, mode, er => {
     if (!er) {
       made = made || p
       return callback(null, made)
@@ -37,7 +39,7 @@ function mkdirs (p, opts, callback, made) {
     switch (er.code) {
       case 'ENOENT':
         if (path.dirname(p) === p) return callback(er)
-        mkdirs(path.dirname(p), opts, function (er, made) {
+        mkdirs(path.dirname(p), opts, (er, made) => {
           if (er) callback(er, made)
           else mkdirs(p, opts, callback, made)
         })
@@ -47,7 +49,7 @@ function mkdirs (p, opts, callback, made) {
       // there already.  If so, then hooray!  If not, then something
       // is borked.
       default:
-        xfs.stat(p, function (er2, stat) {
+        xfs.stat(p, (er2, stat) => {
           // if the stat fails, then that's super weird.
           // let the original error be the failure reason.
           if (er2 || !stat.isDirectory()) callback(er, made)

--- a/lib/mkdirs/win32.js
+++ b/lib/mkdirs/win32.js
@@ -1,24 +1,25 @@
 'use strict'
-var path = require('path')
+
+const path = require('path')
 
 // get drive on windows
 function getRootPath (p) {
   p = path.normalize(path.resolve(p)).split(path.sep)
   if (p.length > 0) return p[0]
-  else return null
+  return null
 }
 
 // http://stackoverflow.com/a/62888/10333 contains more accurate
 // TODO: expand to include the rest
-var INVALID_PATH_CHARS = /[<>:"|?*]/
+const INVALID_PATH_CHARS = /[<>:"|?*]/
 
 function invalidWin32Path (p) {
-  var rp = getRootPath(p)
+  const rp = getRootPath(p)
   p = p.replace(rp, '')
   return INVALID_PATH_CHARS.test(p)
 }
 
 module.exports = {
-  getRootPath: getRootPath,
-  invalidWin32Path: invalidWin32Path
+  getRootPath,
+  invalidWin32Path
 }

--- a/lib/output/index.js
+++ b/lib/output/index.js
@@ -1,6 +1,8 @@
-var path = require('path')
-var fs = require('graceful-fs')
-var mkdir = require('../mkdirs')
+'use strict'
+
+const fs = require('graceful-fs')
+const path = require('path')
+const mkdir = require('../mkdirs')
 
 function outputFile (file, data, encoding, callback) {
   if (typeof encoding === 'function') {
@@ -8,11 +10,11 @@ function outputFile (file, data, encoding, callback) {
     encoding = 'utf8'
   }
 
-  var dir = path.dirname(file)
-  fs.exists(dir, function (itDoes) {
+  const dir = path.dirname(file)
+  fs.exists(dir, itDoes => {
     if (itDoes) return fs.writeFile(file, data, encoding, callback)
 
-    mkdir.mkdirs(dir, function (err) {
+    mkdir.mkdirs(dir, err => {
       if (err) return callback(err)
 
       fs.writeFile(file, data, encoding, callback)
@@ -21,7 +23,7 @@ function outputFile (file, data, encoding, callback) {
 }
 
 function outputFileSync (file, data, encoding) {
-  var dir = path.dirname(file)
+  const dir = path.dirname(file)
   if (fs.existsSync(dir)) {
     return fs.writeFileSync.apply(fs, arguments)
   }
@@ -30,6 +32,6 @@ function outputFileSync (file, data, encoding) {
 }
 
 module.exports = {
-  outputFile: outputFile,
-  outputFileSync: outputFileSync
+  outputFile,
+  outputFileSync
 }

--- a/lib/remove/index.js
+++ b/lib/remove/index.js
@@ -1,15 +1,17 @@
-var rimraf = require('./rimraf')
+'use strict'
+
+const rimraf = require('./rimraf')
 
 function removeSync (dir) {
   return rimraf.sync(dir, {disableGlob: true})
 }
 
 function remove (dir, callback) {
-  var options = {disableGlob: true}
+  const options = {disableGlob: true}
   return callback ? rimraf(dir, options, callback) : rimraf(dir, options, function () {})
 }
 
 module.exports = {
-  remove: remove,
-  removeSync: removeSync
+  remove,
+  removeSync
 }

--- a/lib/util/assign.js
+++ b/lib/util/assign.js
@@ -1,9 +1,11 @@
+'use strict'
+
 // simple mutable assign
 function assign () {
-  var args = [].slice.call(arguments).filter(function (i) { return i })
-  var dest = args.shift()
-  args.forEach(function (src) {
-    Object.keys(src).forEach(function (key) {
+  const args = [].slice.call(arguments).filter(i => i)
+  const dest = args.shift()
+  args.forEach(src => {
+    Object.keys(src).forEach(key => {
       dest[key] = src[key]
     })
   })

--- a/lib/util/utimes.js
+++ b/lib/util/utimes.js
@@ -1,36 +1,38 @@
-var fs = require('graceful-fs')
-var path = require('path')
-var os = require('os')
+'use strict'
+
+const fs = require('graceful-fs')
+const os = require('os')
+const path = require('path')
 
 // HFS, ext{2,3}, FAT do not, Node.js v0.10 does not
 function hasMillisResSync () {
-  var tmpfile = path.join('millis-test-sync' + Date.now().toString() + Math.random().toString().slice(2))
+  let tmpfile = path.join('millis-test-sync' + Date.now().toString() + Math.random().toString().slice(2))
   tmpfile = path.join(os.tmpdir(), tmpfile)
 
   // 550 millis past UNIX epoch
-  var d = new Date(1435410243862)
+  const d = new Date(1435410243862)
   fs.writeFileSync(tmpfile, 'https://github.com/jprichardson/node-fs-extra/pull/141')
-  var fd = fs.openSync(tmpfile, 'r+')
+  const fd = fs.openSync(tmpfile, 'r+')
   fs.futimesSync(fd, d, d)
   fs.closeSync(fd)
   return fs.statSync(tmpfile).mtime > 1435410243000
 }
 
 function hasMillisRes (callback) {
-  var tmpfile = path.join('millis-test' + Date.now().toString() + Math.random().toString().slice(2))
+  let tmpfile = path.join('millis-test' + Date.now().toString() + Math.random().toString().slice(2))
   tmpfile = path.join(os.tmpdir(), tmpfile)
 
   // 550 millis past UNIX epoch
-  var d = new Date(1435410243862)
-  fs.writeFile(tmpfile, 'https://github.com/jprichardson/node-fs-extra/pull/141', function (err) {
+  const d = new Date(1435410243862)
+  fs.writeFile(tmpfile, 'https://github.com/jprichardson/node-fs-extra/pull/141', err => {
     if (err) return callback(err)
-    fs.open(tmpfile, 'r+', function (err, fd) {
+    fs.open(tmpfile, 'r+', (err, fd) => {
       if (err) return callback(err)
-      fs.futimes(fd, d, d, function (err) {
+      fs.futimes(fd, d, d, err => {
         if (err) return callback(err)
-        fs.close(fd, function (err) {
+        fs.close(fd, err => {
           if (err) return callback(err)
-          fs.stat(tmpfile, function (err, stats) {
+          fs.stat(tmpfile, (err, stats) => {
             if (err) return callback(err)
             callback(null, stats.mtime > 1435410243000)
           })
@@ -52,10 +54,10 @@ function timeRemoveMillis (timestamp) {
 
 function utimesMillis (path, atime, mtime, callback) {
   // if (!HAS_MILLIS_RES) return fs.utimes(path, atime, mtime, callback)
-  fs.open(path, 'r+', function (err, fd) {
+  fs.open(path, 'r+', (err, fd) => {
     if (err) return callback(err)
-    fs.futimes(fd, atime, mtime, function (futimesErr) {
-      fs.close(fd, function (closeErr) {
+    fs.futimes(fd, atime, mtime, futimesErr => {
+      fs.close(fd, closeErr => {
         if (callback) callback(futimesErr || closeErr)
       })
     })
@@ -63,8 +65,8 @@ function utimesMillis (path, atime, mtime, callback) {
 }
 
 module.exports = {
-  hasMillisRes: hasMillisRes,
-  hasMillisResSync: hasMillisResSync,
-  timeRemoveMillis: timeRemoveMillis,
-  utimesMillis: utimesMillis
+  hasMillisRes,
+  hasMillisResSync,
+  timeRemoveMillis,
+  utimesMillis
 }


### PR DESCRIPTION
(#355 )  I did some more refactoring. Now everything except `move/index`, `copy/ncp` and `remove/rimraf` are as much as possible refactored to ES6. I wasn't sure on the skipped files, as they are from another library or got a comment with something like `needs rewrite` or similar.