### PR TITLE
Refactor move / rimraf to ES6

### DIFF
--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -1,23 +1,25 @@
+'use strict'
+
 // most of this code was written by Andrew Kelley
 // licensed under the BSD license: see
 // https://github.com/andrewrk/node-mv/blob/master/package.json
 
 // this needs a cleanup
 
-var fs = require('graceful-fs')
-var ncp = require('../copy/ncp')
-var path = require('path')
-var remove = require('../remove').remove
-var mkdirp = require('../mkdirs').mkdirs
+const fs = require('graceful-fs')
+const ncp = require('../copy/ncp')
+const path = require('path')
+const remove = require('../remove').remove
+const mkdirp = require('../mkdirs').mkdirs
 
-function mv (source, dest, options, callback) {
+function move (source, dest, options, callback) {
   if (typeof options === 'function') {
     callback = options
     options = {}
   }
 
-  var shouldMkdirp = ('mkdirp' in options) ? options.mkdirp : true
-  var overwrite = options.overwrite || options.clobber || false
+  const shouldMkdirp = ('mkdirp' in options) ? options.mkdirp : true
+  const overwrite = options.overwrite || options.clobber || false
 
   if (shouldMkdirp) {
     mkdirs()
@@ -26,7 +28,7 @@ function mv (source, dest, options, callback) {
   }
 
   function mkdirs () {
-    mkdirp(path.dirname(dest), function (err) {
+    mkdirp(path.dirname(dest), err => {
       if (err) return callback(err)
       doRename()
     })
@@ -34,25 +36,25 @@ function mv (source, dest, options, callback) {
 
   function doRename () {
     if (overwrite) {
-      fs.rename(source, dest, function (err) {
+      fs.rename(source, dest, err => {
         if (!err) return callback()
 
         if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST') {
-          remove(dest, function (err) {
+          remove(dest, err => {
             if (err) return callback(err)
             options.overwrite = false // just overwriteed it, no need to do it again
-            mv(source, dest, options, callback)
+            move(source, dest, options, callback)
           })
           return
         }
 
         // weird Windows shit
         if (err.code === 'EPERM') {
-          setTimeout(function () {
-            remove(dest, function (err) {
+          setTimeout(() => {
+            remove(dest, err => {
               if (err) return callback(err)
               options.overwrite = false
-              mv(source, dest, options, callback)
+              move(source, dest, options, callback)
             })
           }, 200)
           return
@@ -62,7 +64,7 @@ function mv (source, dest, options, callback) {
         moveAcrossDevice(source, dest, overwrite, callback)
       })
     } else {
-      fs.link(source, dest, function (err) {
+      fs.link(source, dest, err => {
         if (err) {
           if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'EPERM') {
             moveAcrossDevice(source, dest, overwrite, callback)
@@ -78,7 +80,7 @@ function mv (source, dest, options, callback) {
 }
 
 function moveAcrossDevice (source, dest, overwrite, callback) {
-  fs.stat(source, function (err, stat) {
+  fs.stat(source, (err, stat) => {
     if (err) {
       callback(err)
       return
@@ -93,11 +95,11 @@ function moveAcrossDevice (source, dest, overwrite, callback) {
 }
 
 function moveFileAcrossDevice (source, dest, overwrite, callback) {
-  var outFlags = overwrite ? 'w' : 'wx'
-  var ins = fs.createReadStream(source)
-  var outs = fs.createWriteStream(dest, {flags: outFlags})
+  const flags = overwrite ? 'w' : 'wx'
+  const ins = fs.createReadStream(source)
+  const outs = fs.createWriteStream(dest, { flags })
 
-  ins.on('error', function (err) {
+  ins.on('error', err => {
     ins.destroy()
     outs.destroy()
     outs.removeListener('close', onClose)
@@ -105,7 +107,7 @@ function moveFileAcrossDevice (source, dest, overwrite, callback) {
     // may want to create a directory but `out` line above
     // creates an empty file for us: See #108
     // don't care about error here
-    fs.unlink(dest, function () {
+    fs.unlink(dest, () => {
       // note: `err` here is from the input stream errror
       if (err.code === 'EISDIR' || err.code === 'EPERM') {
         moveDirAcrossDevice(source, dest, overwrite, callback)
@@ -115,7 +117,7 @@ function moveFileAcrossDevice (source, dest, overwrite, callback) {
     })
   })
 
-  outs.on('error', function (err) {
+  outs.on('error', err => {
     ins.destroy()
     outs.destroy()
     outs.removeListener('close', onClose)
@@ -131,27 +133,27 @@ function moveFileAcrossDevice (source, dest, overwrite, callback) {
 }
 
 function moveDirAcrossDevice (source, dest, overwrite, callback) {
-  var options = {
+  const options = {
     overwrite: false
   }
 
-  function startNcp () {
-    ncp(source, dest, options, function (err) {
-      if (err) return callback(err)
-      remove(source, callback)
-    })
-  }
-
   if (overwrite) {
-    remove(dest, function (err) {
+    remove(dest, err => {
       if (err) return callback(err)
       startNcp()
     })
   } else {
     startNcp()
   }
+
+  function startNcp () {
+    ncp(source, dest, options, err => {
+      if (err) return callback(err)
+      remove(source, callback)
+    })
+  }
 }
 
 module.exports = {
-  move: mv
+  move
 }

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -1,14 +1,13 @@
-module.exports = rimraf
-rimraf.sync = rimrafSync
+'use strict'
 
-var assert = require('assert')
-var path = require('path')
-var fs = require('graceful-fs')
+const fs = require('graceful-fs')
+const path = require('path')
+const assert = require('assert')
 
-var isWindows = (process.platform === 'win32')
+const isWindows = (process.platform === 'win32')
 
 function defaults (options) {
-  var methods = [
+  const methods = [
     'unlink',
     'chmod',
     'stat',
@@ -16,7 +15,7 @@ function defaults (options) {
     'rmdir',
     'readdir'
   ]
-  methods.forEach(function (m) {
+  methods.forEach(m => {
     options[m] = options[m] || fs[m]
     m = m + 'Sync'
     options[m] = options[m] || fs[m]
@@ -26,6 +25,8 @@ function defaults (options) {
 }
 
 function rimraf (p, options, cb) {
+  let busyTries = 0
+
   if (typeof options === 'function') {
     cb = options
     options = {}
@@ -39,18 +40,14 @@ function rimraf (p, options, cb) {
 
   defaults(options)
 
-  var busyTries = 0
-
   rimraf_(p, options, function CB (er) {
     if (er) {
       if (isWindows && (er.code === 'EBUSY' || er.code === 'ENOTEMPTY' || er.code === 'EPERM') &&
           busyTries < options.maxBusyTries) {
         busyTries++
-        var time = busyTries * 100
+        let time = busyTries * 100
         // try again, with the same exact callback as this one.
-        return setTimeout(function () {
-          rimraf_(p, options, CB)
-        }, time)
+        return setTimeout(() => rimraf_(p, options, CB), time)
       }
 
       // already gone
@@ -79,7 +76,7 @@ function rimraf_ (p, options, cb) {
 
   // sunos lets the root user unlink directories, which is... weird.
   // so we have to lstat here and make sure it's not a dir.
-  options.lstat(p, function (er, st) {
+  options.lstat(p, (er, st) => {
     if (er && er.code === 'ENOENT') {
       return cb(null)
     }
@@ -93,7 +90,7 @@ function rimraf_ (p, options, cb) {
       return rmdir(p, options, er, cb)
     }
 
-    options.unlink(p, function (er) {
+    options.unlink(p, er => {
       if (er) {
         if (er.code === 'ENOENT') {
           return cb(null)
@@ -120,11 +117,11 @@ function fixWinEPERM (p, options, er, cb) {
     assert(er instanceof Error)
   }
 
-  options.chmod(p, 666, function (er2) {
+  options.chmod(p, 666, er2 => {
     if (er2) {
       cb(er2.code === 'ENOENT' ? null : er)
     } else {
-      options.stat(p, function (er3, stats) {
+      options.stat(p, (er3, stats) => {
         if (er3) {
           cb(er3.code === 'ENOENT' ? null : er)
         } else if (stats.isDirectory()) {
@@ -138,6 +135,8 @@ function fixWinEPERM (p, options, er, cb) {
 }
 
 function fixWinEPERMSync (p, options, er) {
+  let stats
+
   assert(p)
   assert(options)
   if (er) {
@@ -155,7 +154,7 @@ function fixWinEPERMSync (p, options, er) {
   }
 
   try {
-    var stats = options.statSync(p)
+    stats = options.statSync(p)
   } catch (er3) {
     if (er3.code === 'ENOENT') {
       return
@@ -182,7 +181,7 @@ function rmdir (p, options, originalEr, cb) {
   // try to rmdir first, and only readdir on ENOTEMPTY or EEXIST (SunOS)
   // if we guessed wrong, and it's not a directory, then
   // raise the original error.
-  options.rmdir(p, function (er) {
+  options.rmdir(p, er => {
     if (er && (er.code === 'ENOTEMPTY' || er.code === 'EEXIST' || er.code === 'EPERM')) {
       rmkids(p, options, cb)
     } else if (er && er.code === 'ENOTDIR') {
@@ -198,23 +197,20 @@ function rmkids (p, options, cb) {
   assert(options)
   assert(typeof cb === 'function')
 
-  options.readdir(p, function (er, files) {
-    if (er) {
-      return cb(er)
-    }
-    var n = files.length
-    if (n === 0) {
-      return options.rmdir(p, cb)
-    }
-    var errState
-    files.forEach(function (f) {
-      rimraf(path.join(p, f), options, function (er) {
+  options.readdir(p, (er, files) => {
+    if (er) return cb(er)
+
+    let n = files.length
+    let errState
+
+    if (n === 0) return options.rmdir(p, cb)
+
+    files.forEach(f => {
+      rimraf(path.join(p, f), options, er => {
         if (errState) {
           return
         }
-        if (er) {
-          return cb(errState = er)
-        }
+        if (er) return cb(errState = er)
         if (--n === 0) {
           options.rmdir(p, cb)
         }
@@ -227,6 +223,8 @@ function rmkids (p, options, cb) {
 // tie up the JavaScript thread and fail on excessively
 // deep directory trees.
 function rimrafSync (p, options) {
+  let st
+
   options = options || {}
   defaults(options)
 
@@ -236,7 +234,7 @@ function rimrafSync (p, options) {
   assert.equal(typeof options, 'object', 'rimraf: options should be object')
 
   try {
-    var st = options.lstatSync(p)
+    st = options.lstatSync(p)
   } catch (er) {
     if (er.code === 'ENOENT') {
       return
@@ -258,11 +256,9 @@ function rimrafSync (p, options) {
   } catch (er) {
     if (er.code === 'ENOENT') {
       return
-    }
-    if (er.code === 'EPERM') {
+    } else if (er.code === 'EPERM') {
       return isWindows ? fixWinEPERMSync(p, options, er) : rmdirSync(p, options, er)
-    }
-    if (er.code !== 'EISDIR') {
+    } else if (er.code !== 'EISDIR') {
       throw er
     }
     rmdirSync(p, options, er)
@@ -281,11 +277,9 @@ function rmdirSync (p, options, originalEr) {
   } catch (er) {
     if (er.code === 'ENOENT') {
       return
-    }
-    if (er.code === 'ENOTDIR') {
+    } else if (er.code === 'ENOTDIR') {
       throw originalEr
-    }
-    if (er.code === 'ENOTEMPTY' || er.code === 'EEXIST' || er.code === 'EPERM') {
+    } else if (er.code === 'ENOTEMPTY' || er.code === 'EEXIST' || er.code === 'EPERM') {
       rmkidsSync(p, options)
     }
   }
@@ -294,8 +288,9 @@ function rmdirSync (p, options, originalEr) {
 function rmkidsSync (p, options) {
   assert(p)
   assert(options)
-  options.readdirSync(p).forEach(function (f) {
-    rimrafSync(path.join(p, f), options)
-  })
+  options.readdirSync(p).forEach(f => rimrafSync(path.join(p, f), options))
   options.rmdirSync(p, options)
 }
+
+module.exports = rimraf
+rimraf.sync = rimrafSync


### PR DESCRIPTION
(#355)
`move`:

I renamed the function from `mv` to `move`, it shouldn't be a breaking change

`rimraf`:

Here I put `module.exports` to the end of the file, as it is the same in all other files. Also I refactored one line `if`-statements, also with the same reason that it is the same in all other files.

---
I skipped `copy/ncp` as discussed in https://github.com/jprichardson/node-fs-extra/pull/360#issuecomment-280857354. Now I will start with the tests, unless I missed anything. I will make a pull request for each folder (`copy`, `copy-sync`, ...) if that is ok for you.