### PR TITLE
lib/copy/ncp.js: use finish event instead of close in writestream when copying file

### DIFF
--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -109,7 +109,7 @@ function ncp (source, dest, options, callback) {
       })
     }
 
-    writeStream.once('close', function () {
+    writeStream.once('finish', function () {
       fs.chmod(target, file.mode, function (err) {
         if (err) return onError(err)
         if (preserveTimestamps) {


### PR DESCRIPTION
This should resolve #357. I provided the argument there. Based on the node docs, I believe  for writestreams the `finish` event is the correct one to use not the `close` event.