### PR TITLE
Add dest as an additional parameter to filter option in copy and copySync

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -26,3 +26,23 @@ fs.copy('/tmp/mydir', '/tmp/mynewdir', function (err) {
   console.log('success!')
 }) // copies directory, even if it has subdirectories or files
 ```
+
+**Using filter function**
+
+```js
+var fs = require('fs-extra')
+
+var mtimeCondition = new Date(2016, 11, 17).getTime()
+
+var filterFunc = function (src, dest) {
+  fs.lstat(dest, function (err, destStat) {
+    if (err) return false
+    return src.indexOf('node_modules') < 0 && destStat.mtime.getTime() > mtimeCondition
+  })
+}
+
+fs.copy('/tmp/mydir', '/tmp/mynewdir', { filter: filterFunc }, function (err) {
+  if (err) return console.error(err)
+  console.log('success!')
+})
+```

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -32,13 +32,9 @@ fs.copy('/tmp/mydir', '/tmp/mynewdir', function (err) {
 ```js
 var fs = require('fs-extra')
 
-var mtimeCondition = new Date(2016, 11, 17).getTime()
-
 var filterFunc = function (src, dest) {
-  fs.lstat(dest, function (err, destStat) {
-    if (err) return false
-    return src.indexOf('node_modules') < 0 && destStat.mtime.getTime() > mtimeCondition
-  })
+  // your logic here
+  // if return true, it will be copied otherwise it won't
 }
 
 fs.copy('/tmp/mydir', '/tmp/mynewdir', { filter: filterFunc }, function (err) {

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -64,63 +64,117 @@ describe('+ copySync()', () => {
       assert.strictEqual(link, 'destination')
     })
 
-    it('should should apply filter recursively', () => {
-      const FILES = 2
-      // Don't match anything that ends with a digit higher than 0:
-      const filter = s => /(0|\D)$/i.test(s)
+    describe('> when filter is used', () => {
+      it('should should apply filter recursively', done => {
+        const FILES = 2
+        // Don't match anything that ends with a digit higher than 0:
+        const filter = s => /(0|\D)$/i.test(s)
 
-      fs.mkdirsSync(src)
+        fs.mkdirsSync(src)
 
-      for (let i = 0; i < FILES; ++i) {
-        fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
-      }
-
-      const subdir = path.join(src, 'subdir')
-      fs.mkdirsSync(subdir)
-
-      for (let i = 0; i < FILES; ++i) {
-        fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
-      }
-
-      fs.copySync(src, dest, filter)
-
-      assert(fs.existsSync(dest))
-      assert(FILES > 1)
-
-      for (let i = 0; i < FILES; ++i) {
-        if (i === 0) {
-          assert(fs.existsSync(path.join(dest, i.toString())))
-        } else {
-          assert(!fs.existsSync(path.join(dest, i.toString())))
+        for (let i = 0; i < FILES; ++i) {
+          fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
         }
-      }
 
-      const destSub = path.join(dest, 'subdir')
+        const subdir = path.join(src, 'subdir')
+        fs.mkdirsSync(subdir)
 
-      for (let j = 0; j < FILES; ++j) {
-        if (j === 0) {
-          assert(fs.existsSync(path.join(destSub, j.toString())))
-        } else {
-          assert(!fs.existsSync(path.join(destSub, j.toString())))
+        for (let i = 0; i < FILES; ++i) {
+          fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
         }
-      }
-    })
 
-    it('should apply the filter to directory names', () => {
-      const IGNORE = 'ignore'
-      const filter = p => !~p.indexOf(IGNORE)
+        fs.copySync(src, dest, filter)
 
-      fs.mkdirsSync(src)
+        assert(fs.existsSync(dest))
+        assert(FILES > 1)
 
-      const ignoreDir = path.join(src, IGNORE)
-      fs.mkdirsSync(ignoreDir)
+        for (let i = 0; i < FILES; ++i) {
+          if (i === 0) {
+            assert(fs.existsSync(path.join(dest, i.toString())))
+          } else {
+            assert(!fs.existsSync(path.join(dest, i.toString())))
+          }
+        }
 
-      fs.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
+        const destSub = path.join(dest, 'subdir')
 
-      fs.copySync(src, dest, filter)
+        for (let j = 0; j < FILES; ++j) {
+          if (j === 0) {
+            assert(fs.existsSync(path.join(destSub, j.toString())))
+          } else {
+            assert(!fs.existsSync(path.join(destSub, j.toString())))
+          }
+        }
+        done()
+      })
 
-      assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
-      assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+      it('should apply the filter to directory names', done => {
+        const IGNORE = 'ignore'
+        const filter = p => !~p.indexOf(IGNORE)
+
+        fs.mkdirsSync(src)
+
+        const ignoreDir = path.join(src, IGNORE)
+        fs.mkdirsSync(ignoreDir)
+
+        fs.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
+
+        fs.copySync(src, dest, filter)
+
+        assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
+        assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+        done()
+      })
+
+      it('should apply filter when it is applied only to dest', done => {
+        // 16893 refers to 0o777 mode
+        const filter = (s, d) => fs.lstatSync(d).mode === 16893
+
+        const subdir = path.join(src, 'subdir')
+        fs.mkdirsSync(subdir)
+
+        // make another dest to make sure not affecting other tests
+        const dest1 = path.join(TEST_DIR, 'dest1')
+        fs.mkdirsSync(dest1, 0o774) // mode 16892
+
+        try {
+          fs.copySync(src, dest1, filter)
+        } catch (err) {
+          assert.ifError(err)
+        }
+        assert(!fs.existsSync(path.join(dest1, 'subdir')))
+        done()
+      })
+
+      it('should apply filter when it is applied to both src and dest', done => {
+        // 16892 refers to 0o774 mode
+        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mode === 16892
+
+        const dest1 = path.join(TEST_DIR, 'dest1')
+        fs.mkdirsSync(dest1, 0o774) // mode 16892
+
+        // console.log(fs.readdirSync(dest1))
+        const srcFile1 = path.join(TEST_DIR, '1.html')
+        const srcFile2 = path.join(TEST_DIR, '2.css')
+        const srcFile3 = path.join(TEST_DIR, '3.jade')
+
+        fs.writeFileSync(srcFile1, '')
+        fs.writeFileSync(srcFile2, '')
+        fs.writeFileSync(srcFile3, '')
+
+        const destFile1 = path.join(dest1, 'dest1.html')
+        const destFile2 = path.join(dest1, 'dest2.css')
+        const destFile3 = path.join(dest1, 'dest3.jade')
+
+        fs.copySync(srcFile1, destFile1, filter)
+        fs.copySync(srcFile2, destFile2, filter)
+        fs.copySync(srcFile3, destFile3, filter)
+
+        assert(fs.existsSync(destFile1))
+        assert(!fs.existsSync(destFile2))
+        assert(fs.existsSync(destFile3))
+        done()
+      })
     })
 
     describe('> when the destination dir does not exist', () => {

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -153,7 +153,7 @@ describe('+ copySync()', () => {
     it('should apply filter when it is applied only to dest', done => {
       const timeCond = new Date().getTime()
 
-      const filter = (s, d) => fs.statSync(path.dirname(d)).birthtime.getTime() < timeCond
+      const filter = (s, d) => fs.statSync(d).birthtime.getTime() < timeCond
 
       const subdir = path.join(src, 'subdir')
       fs.mkdirsSync(subdir)

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -151,30 +151,32 @@ describe('+ copySync()', () => {
     })
 
     it('should apply filter when it is applied only to dest', done => {
-      const mtimeCond = new Date().getTime()
+      const timeCond = new Date().getTime()
 
-      const filter = (s, d) => fs.lstatSync(path.dirname(d)).mtime.getTime() > mtimeCond
+      const filter = (s, d) => fs.statSync(path.dirname(d)).birthtime.getTime() < timeCond
 
       const subdir = path.join(src, 'subdir')
       fs.mkdirsSync(subdir)
 
       const dest = path.join(TEST_DIR, 'dest')
 
-      try {
-        fs.copySync(src, dest, filter)
-      } catch (err) {
-        assert.ifError(err)
-      }
-      assert(!fs.existsSync(path.join(dest, 'subdir')))
-      done()
+      setTimeout(() => {
+        fs.mkdirsSync(dest)
+        try {
+          fs.copySync(src, dest, filter)
+        } catch (err) {
+          assert.ifError(err)
+        }
+        assert(!fs.existsSync(path.join(dest, 'subdir')))
+        done()
+      }, 1000)
     })
 
     it('should apply filter when it is applied to both src and dest', done => {
-      const mtimeCond = new Date().getTime()
-      const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mtime.getTime() < mtimeCond
+      const timeCond = new Date().getTime()
+      const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).birthtime.getTime() > timeCond
 
       const dest = path.join(TEST_DIR, 'dest')
-      fs.mkdirsSync(dest)
 
       const srcFile1 = path.join(TEST_DIR, '1.html')
       const srcFile2 = path.join(TEST_DIR, '2.css')
@@ -188,14 +190,18 @@ describe('+ copySync()', () => {
       const destFile2 = path.join(dest, 'dest2.css')
       const destFile3 = path.join(dest, 'dest3.jade')
 
-      fs.copySync(srcFile1, destFile1, filter)
-      fs.copySync(srcFile2, destFile2, filter)
-      fs.copySync(srcFile3, destFile3, filter)
+      setTimeout(() => {
+        fs.mkdirsSync(dest)
 
-      assert(fs.existsSync(destFile1))
-      assert(!fs.existsSync(destFile2))
-      assert(fs.existsSync(destFile3))
-      done()
+        fs.copySync(srcFile1, destFile1, filter)
+        fs.copySync(srcFile2, destFile2, filter)
+        fs.copySync(srcFile3, destFile3, filter)
+
+        assert(fs.existsSync(destFile1))
+        assert(!fs.existsSync(destFile2))
+        assert(fs.existsSync(destFile3))
+        done()
+      }, 1000)
     })
   })
 })

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -64,119 +64,6 @@ describe('+ copySync()', () => {
       assert.strictEqual(link, 'destination')
     })
 
-    describe('> when filter is used', () => {
-      it('should should apply filter recursively', done => {
-        const FILES = 2
-        // Don't match anything that ends with a digit higher than 0:
-        const filter = s => /(0|\D)$/i.test(s)
-
-        fs.mkdirsSync(src)
-
-        for (let i = 0; i < FILES; ++i) {
-          fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
-        }
-
-        const subdir = path.join(src, 'subdir')
-        fs.mkdirsSync(subdir)
-
-        for (let i = 0; i < FILES; ++i) {
-          fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
-        }
-
-        fs.copySync(src, dest, filter)
-
-        assert(fs.existsSync(dest))
-        assert(FILES > 1)
-
-        for (let i = 0; i < FILES; ++i) {
-          if (i === 0) {
-            assert(fs.existsSync(path.join(dest, i.toString())))
-          } else {
-            assert(!fs.existsSync(path.join(dest, i.toString())))
-          }
-        }
-
-        const destSub = path.join(dest, 'subdir')
-
-        for (let j = 0; j < FILES; ++j) {
-          if (j === 0) {
-            assert(fs.existsSync(path.join(destSub, j.toString())))
-          } else {
-            assert(!fs.existsSync(path.join(destSub, j.toString())))
-          }
-        }
-        done()
-      })
-
-      it('should apply the filter to directory names', done => {
-        const IGNORE = 'ignore'
-        const filter = p => !~p.indexOf(IGNORE)
-
-        fs.mkdirsSync(src)
-
-        const ignoreDir = path.join(src, IGNORE)
-        fs.mkdirsSync(ignoreDir)
-
-        fs.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
-
-        fs.copySync(src, dest, filter)
-
-        assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
-        assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
-        done()
-      })
-
-      it('should apply filter when it is applied only to dest', done => {
-        // 16893 refers to 0o777 mode
-        const filter = (s, d) => fs.lstatSync(d).mode === 16893
-
-        const subdir = path.join(src, 'subdir')
-        fs.mkdirsSync(subdir)
-
-        // make another dest to make sure not affecting other tests
-        const dest1 = path.join(TEST_DIR, 'dest1')
-        fs.mkdirsSync(dest1, 0o774) // mode 16892
-
-        try {
-          fs.copySync(src, dest1, filter)
-        } catch (err) {
-          assert.ifError(err)
-        }
-        assert(!fs.existsSync(path.join(dest1, 'subdir')))
-        done()
-      })
-
-      it('should apply filter when it is applied to both src and dest', done => {
-        // 16892 refers to 0o774 mode
-        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mode === 16892
-
-        const dest1 = path.join(TEST_DIR, 'dest1')
-        fs.mkdirsSync(dest1, 0o774) // mode 16892
-
-        // console.log(fs.readdirSync(dest1))
-        const srcFile1 = path.join(TEST_DIR, '1.html')
-        const srcFile2 = path.join(TEST_DIR, '2.css')
-        const srcFile3 = path.join(TEST_DIR, '3.jade')
-
-        fs.writeFileSync(srcFile1, '')
-        fs.writeFileSync(srcFile2, '')
-        fs.writeFileSync(srcFile3, '')
-
-        const destFile1 = path.join(dest1, 'dest1.html')
-        const destFile2 = path.join(dest1, 'dest2.css')
-        const destFile3 = path.join(dest1, 'dest3.jade')
-
-        fs.copySync(srcFile1, destFile1, filter)
-        fs.copySync(srcFile2, destFile2, filter)
-        fs.copySync(srcFile3, destFile3, filter)
-
-        assert(fs.existsSync(destFile1))
-        assert(!fs.existsSync(destFile2))
-        assert(fs.existsSync(destFile3))
-        done()
-      })
-    })
-
     describe('> when the destination dir does not exist', () => {
       it('should create the destination directory and copy the file', () => {
         const src = path.join(TEST_DIR, 'data/')
@@ -198,6 +85,117 @@ describe('+ copySync()', () => {
         assert.strictEqual(d1, o1)
         assert.strictEqual(d2, o2)
       })
+    })
+  })
+
+  describe('> when filter is used', () => {
+    it('should should apply filter recursively', done => {
+      const FILES = 2
+      // Don't match anything that ends with a digit higher than 0:
+      const filter = s => /(0|\D)$/i.test(s)
+
+      fs.mkdirsSync(src)
+
+      for (let i = 0; i < FILES; ++i) {
+        fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
+      }
+
+      const subdir = path.join(src, 'subdir')
+      fs.mkdirsSync(subdir)
+
+      for (let i = 0; i < FILES; ++i) {
+        fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
+      }
+
+      fs.copySync(src, dest, filter)
+
+      assert(fs.existsSync(dest))
+      assert(FILES > 1)
+
+      for (let i = 0; i < FILES; ++i) {
+        if (i === 0) {
+          assert(fs.existsSync(path.join(dest, i.toString())))
+        } else {
+          assert(!fs.existsSync(path.join(dest, i.toString())))
+        }
+      }
+
+      const destSub = path.join(dest, 'subdir')
+
+      for (let j = 0; j < FILES; ++j) {
+        if (j === 0) {
+          assert(fs.existsSync(path.join(destSub, j.toString())))
+        } else {
+          assert(!fs.existsSync(path.join(destSub, j.toString())))
+        }
+      }
+      done()
+    })
+
+    it('should apply the filter to directory names', done => {
+      const IGNORE = 'ignore'
+      const filter = p => !~p.indexOf(IGNORE)
+
+      fs.mkdirsSync(src)
+
+      const ignoreDir = path.join(src, IGNORE)
+      fs.mkdirsSync(ignoreDir)
+
+      fs.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
+
+      fs.copySync(src, dest, filter)
+
+      assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
+      assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+      done()
+    })
+
+    it('should apply filter when it is applied only to dest', done => {
+      const mtimeCond = new Date().getTime()
+
+      const filter = (s, d) => fs.lstatSync(path.dirname(d)).mtime.getTime() > mtimeCond
+
+      const subdir = path.join(src, 'subdir')
+      fs.mkdirsSync(subdir)
+
+      const dest = path.join(TEST_DIR, 'dest')
+
+      try {
+        fs.copySync(src, dest, filter)
+      } catch (err) {
+        assert.ifError(err)
+      }
+      assert(!fs.existsSync(path.join(dest, 'subdir')))
+      done()
+    })
+
+    it('should apply filter when it is applied to both src and dest', done => {
+      const mtimeCond = new Date().getTime()
+      const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mtime.getTime() < mtimeCond
+
+      const dest = path.join(TEST_DIR, 'dest')
+      fs.mkdirsSync(dest)
+
+      const srcFile1 = path.join(TEST_DIR, '1.html')
+      const srcFile2 = path.join(TEST_DIR, '2.css')
+      const srcFile3 = path.join(TEST_DIR, '3.jade')
+
+      fs.writeFileSync(srcFile1, '')
+      fs.writeFileSync(srcFile2, '')
+      fs.writeFileSync(srcFile3, '')
+
+      const destFile1 = path.join(dest, 'dest1.html')
+      const destFile2 = path.join(dest, 'dest2.css')
+      const destFile3 = path.join(dest, 'dest3.jade')
+
+      fs.copySync(srcFile1, destFile1, filter)
+      fs.copySync(srcFile2, destFile2, filter)
+      fs.copySync(srcFile3, destFile3, filter)
+
+      assert(fs.existsSync(destFile1))
+      assert(!fs.existsSync(destFile2))
+      assert(fs.existsSync(destFile3))
+      done()
     })
   })
 })

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -35,8 +35,8 @@ function copySync (src, dest, options) {
 
   if (options.filter instanceof RegExp) {
     console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-    performCopy = options.filter.test(src)
-  } else if (typeof options.filter === 'function') performCopy = options.filter(src)
+    performCopy = options.filter.test(src, dest)
+  } else if (typeof options.filter === 'function') performCopy = options.filter(src, dest)
 
   if (stats.isFile() && performCopy) {
     if (!destFolderExists) mkdir.mkdirsSync(destFolder)

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -71,160 +71,6 @@ describe('fs-extra', () => {
         })
       })
 
-      describe('> when filter is used', () => {
-        it('should only copy files allowed by filter fn', done => {
-          const srcFile1 = path.join(TEST_DIR, '1.css')
-          fs.writeFileSync(srcFile1, '')
-          const destFile1 = path.join(TEST_DIR, 'dest1.css')
-          const filter = s => s.split('.').pop() !== 'css'
-
-          fse.copy(srcFile1, destFile1, filter, err => {
-            assert(!err)
-            assert(!fs.existsSync(destFile1))
-            done()
-          })
-        })
-
-        it('accepts options object in place of filter', done => {
-          const srcFile1 = path.join(TEST_DIR, '1.jade')
-          fs.writeFileSync(srcFile1, '')
-          const destFile1 = path.join(TEST_DIR, 'dest1.jade')
-          const options = { filter: s => /.html$|.css$/i.test(s) }
-
-          fse.copy(srcFile1, destFile1, options, (err) => {
-            assert(!err)
-            assert(!fs.existsSync(destFile1))
-            done()
-          })
-        })
-
-        it('should should apply filter recursively', done => {
-          const FILES = 2
-          // Don't match anything that ends with a digit higher than 0:
-          const filter = s => /(0|\D)$/i.test(s)
-
-          const src = path.join(TEST_DIR, 'src')
-          fse.mkdirsSync(src)
-
-          for (let i = 0; i < FILES; ++i) {
-            fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
-          }
-
-          const subdir = path.join(src, 'subdir')
-          fse.mkdirsSync(subdir)
-
-          for (let i = 0; i < FILES; ++i) {
-            fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
-          }
-          const dest = path.join(TEST_DIR, 'dest')
-          fse.copy(src, dest, filter, err => {
-            assert(!err)
-
-            assert(fs.existsSync(dest))
-            assert(FILES > 1)
-
-            for (let i = 0; i < FILES; ++i) {
-              if (i === 0) {
-                assert(fs.existsSync(path.join(dest, i.toString())))
-              } else {
-                assert(!fs.existsSync(path.join(dest, i.toString())))
-              }
-            }
-
-            const destSub = path.join(dest, 'subdir')
-
-            for (let j = 0; j < FILES; ++j) {
-              if (j === 0) {
-                assert(fs.existsSync(path.join(destSub, j.toString())))
-              } else {
-                assert(!fs.existsSync(path.join(destSub, j.toString())))
-              }
-            }
-            done()
-          })
-        })
-
-        it('should apply the filter to directory names', done => {
-          const IGNORE = 'ignore'
-          const filter = p => !~p.indexOf(IGNORE)
-
-          const src = path.join(TEST_DIR, 'src')
-          fse.mkdirsSync(src)
-
-          const ignoreDir = path.join(src, IGNORE)
-          fse.mkdirsSync(ignoreDir)
-
-          fse.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
-
-          const dest = path.join(TEST_DIR, 'dest')
-
-          fse.copySync(src, dest, filter)
-
-          assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
-          assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
-          done()
-        })
-
-        it('should apply filter when it is applied only to dest', done => {
-          // 16893 refers to 0o777 mode
-          const filter = (s, d) => fs.lstatSync(d).mode === 16893
-
-          const src = path.join(TEST_DIR, 'src')
-          fse.mkdirsSync(src)
-          const subdir = path.join(src, 'subdir')
-          fse.mkdirsSync(subdir)
-
-          // make another dest to make sure not affecting other tests
-          const dest1 = path.join(TEST_DIR, 'dest1')
-          fse.mkdirsSync(dest1, 0o774) // mode 16892
-
-          assert.strictEqual(fs.lstatSync(dest1).mode, 16892)
-
-          fse.copy(src, dest1, filter, err => {
-            assert(!err)
-            assert(!fs.existsSync(path.join(dest1, 'subdir')))
-            done()
-          })
-        })
-
-        it('should apply filter when it is applied to both src and dest', done => {
-          // 16892 refers to 0o774 mode
-          const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mode === 16892
-
-          const dest2 = path.join(TEST_DIR, 'dest2')
-          fse.mkdirsSync(dest2, 0o774) // mode 16892
-          assert.strictEqual(fs.lstatSync(dest2).mode, 16892)
-
-          const srcFile1 = path.join(TEST_DIR, '1.html')
-          const srcFile2 = path.join(TEST_DIR, '2.css')
-          const srcFile3 = path.join(TEST_DIR, '3.jade')
-
-          fse.writeFileSync(srcFile1, '')
-          fse.writeFileSync(srcFile2, '')
-          fse.writeFileSync(srcFile3, '')
-
-          const destFile1 = path.join(dest2, 'dest1.html')
-          const destFile2 = path.join(dest2, 'dest2.css')
-          const destFile3 = path.join(dest2, 'dest3.jade')
-
-          fse.copy(srcFile1, destFile1, filter, err => {
-            assert(!err)
-            assert(fs.existsSync(destFile1))
-
-            fse.copy(srcFile2, destFile2, filter, err => {
-              assert(!err)
-              assert(!fs.existsSync(destFile2))
-
-              fse.copy(srcFile3, destFile3, filter, err => {
-                assert(!err)
-                assert(fs.existsSync(destFile3))
-                done()
-              })
-            })
-          })
-        })
-      })
-
       describe('> when the destination dir does not exist', () => {
         it('should create the destination directory and copy the file', done => {
           const src = path.join(TEST_DIR, 'file.txt')
@@ -320,6 +166,158 @@ describe('fs-extra', () => {
           fse.copy('/does/not/exist', '/something/else', err => {
             assert(err instanceof Error)
             done()
+          })
+        })
+      })
+    })
+
+    describe('> when filter is used', () => {
+      it('should only copy files allowed by filter fn', done => {
+        const srcFile1 = path.join(TEST_DIR, '1.css')
+        fs.writeFileSync(srcFile1, '')
+        const destFile1 = path.join(TEST_DIR, 'dest1.css')
+        const filter = s => s.split('.').pop() !== 'css'
+
+        fse.copy(srcFile1, destFile1, filter, err => {
+          assert(!err)
+          assert(!fs.existsSync(destFile1))
+          done()
+        })
+      })
+
+      it('accepts options object in place of filter', done => {
+        const srcFile1 = path.join(TEST_DIR, '1.jade')
+        fs.writeFileSync(srcFile1, '')
+        const destFile1 = path.join(TEST_DIR, 'dest1.jade')
+        const options = { filter: s => /.html$|.css$/i.test(s) }
+
+        fse.copy(srcFile1, destFile1, options, (err) => {
+          assert(!err)
+          assert(!fs.existsSync(destFile1))
+          done()
+        })
+      })
+
+      it('should should apply filter recursively', done => {
+        const FILES = 2
+        // Don't match anything that ends with a digit higher than 0:
+        const filter = s => /(0|\D)$/i.test(s)
+
+        const src = path.join(TEST_DIR, 'src')
+        fse.mkdirsSync(src)
+
+        for (let i = 0; i < FILES; ++i) {
+          fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
+        }
+
+        const subdir = path.join(src, 'subdir')
+        fse.mkdirsSync(subdir)
+
+        for (let i = 0; i < FILES; ++i) {
+          fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
+        }
+        const dest = path.join(TEST_DIR, 'dest')
+        fse.copy(src, dest, filter, err => {
+          assert(!err)
+
+          assert(fs.existsSync(dest))
+          assert(FILES > 1)
+
+          for (let i = 0; i < FILES; ++i) {
+            if (i === 0) {
+              assert(fs.existsSync(path.join(dest, i.toString())))
+            } else {
+              assert(!fs.existsSync(path.join(dest, i.toString())))
+            }
+          }
+
+          const destSub = path.join(dest, 'subdir')
+
+          for (let j = 0; j < FILES; ++j) {
+            if (j === 0) {
+              assert(fs.existsSync(path.join(destSub, j.toString())))
+            } else {
+              assert(!fs.existsSync(path.join(destSub, j.toString())))
+            }
+          }
+          done()
+        })
+      })
+
+      it('should apply the filter to directory names', done => {
+        const IGNORE = 'ignore'
+        const filter = p => !~p.indexOf(IGNORE)
+
+        const src = path.join(TEST_DIR, 'src')
+        fse.mkdirsSync(src)
+
+        const ignoreDir = path.join(src, IGNORE)
+        fse.mkdirsSync(ignoreDir)
+
+        fse.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
+
+        const dest = path.join(TEST_DIR, 'dest')
+
+        fse.copySync(src, dest, filter)
+
+        assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
+        assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+        done()
+      })
+
+      it('should apply filter when it is applied only to dest', done => {
+        const mtimeCond = new Date().getTime()
+
+        const filter = (s, d) => fs.lstatSync(path.dirname(d)).mtime.getTime() > mtimeCond
+
+        const src = path.join(TEST_DIR, 'src')
+        fse.mkdirsSync(src)
+        const subdir = path.join(src, 'subdir')
+        fse.mkdirsSync(subdir)
+
+        const dest = path.join(TEST_DIR, 'dest')
+
+        fse.copy(src, dest, filter, err => {
+          assert(!err)
+          assert(!fs.existsSync(path.join(dest, 'subdir')))
+          done()
+        })
+      })
+
+      it('should apply filter when it is applied to both src and dest', done => {
+        const mtimeCond = new Date().getTime()
+        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mtime.getTime() < mtimeCond
+
+        const dest = path.join(TEST_DIR, 'dest')
+        setTimeout(function () {
+          fse.mkdirsSync(dest)
+        }, 1000)
+
+        const srcFile1 = path.join(TEST_DIR, '1.html')
+        const srcFile2 = path.join(TEST_DIR, '2.css')
+        const srcFile3 = path.join(TEST_DIR, '3.jade')
+
+        fse.writeFileSync(srcFile1, '')
+        fse.writeFileSync(srcFile2, '')
+        fse.writeFileSync(srcFile3, '')
+
+        const destFile1 = path.join(dest, 'dest1.html')
+        const destFile2 = path.join(dest, 'dest2.css')
+        const destFile3 = path.join(dest, 'dest3.jade')
+
+        fse.copy(srcFile1, destFile1, filter, err => {
+          assert(!err)
+          assert(fs.existsSync(destFile1))
+
+          fse.copy(srcFile2, destFile2, filter, err => {
+            assert(!err)
+            assert(!fs.existsSync(destFile2))
+
+            fse.copy(srcFile3, destFile3, filter, err => {
+              assert(!err)
+              assert(fs.existsSync(destFile3))
+              done()
+            })
           })
         })
       })

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -58,28 +58,6 @@ describe('fs-extra', () => {
         })
       })
 
-      it('should only copy files allowed by filter fn', done => {
-        const srcFile1 = path.join(TEST_DIR, '1.css')
-        fs.writeFileSync(srcFile1, '')
-        const destFile1 = path.join(TEST_DIR, 'dest1.css')
-        const filter = s => s.split('.').pop() !== 'css'
-        fse.copy(srcFile1, destFile1, filter, () => {
-          assert(!fs.existsSync(destFile1))
-          done()
-        })
-      })
-
-      it('accepts options object in place of filter', done => {
-        const srcFile1 = path.join(TEST_DIR, '1.jade')
-        fs.writeFileSync(srcFile1, '')
-        const destFile1 = path.join(TEST_DIR, 'dest1.jade')
-        const options = { filter: s => /.html$|.css$/i.test(s) }
-        fse.copy(srcFile1, destFile1, options, () => {
-          assert(!fs.existsSync(destFile1))
-          done()
-        })
-      })
-
       it('should copy to a destination file with two \'$\' characters in name (eg: TEST_fs-extra_$$_copy)', done => {
         const fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_src')
         const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_$$_copy')
@@ -90,6 +68,160 @@ describe('fs-extra', () => {
           assert(!err)
           fs.statSync(fileDest)
           done()
+        })
+      })
+
+      describe('> when filter is used', () => {
+        it('should only copy files allowed by filter fn', done => {
+          const srcFile1 = path.join(TEST_DIR, '1.css')
+          fs.writeFileSync(srcFile1, '')
+          const destFile1 = path.join(TEST_DIR, 'dest1.css')
+          const filter = s => s.split('.').pop() !== 'css'
+
+          fse.copy(srcFile1, destFile1, filter, err => {
+            assert(!err)
+            assert(!fs.existsSync(destFile1))
+            done()
+          })
+        })
+
+        it('accepts options object in place of filter', done => {
+          const srcFile1 = path.join(TEST_DIR, '1.jade')
+          fs.writeFileSync(srcFile1, '')
+          const destFile1 = path.join(TEST_DIR, 'dest1.jade')
+          const options = { filter: s => /.html$|.css$/i.test(s) }
+
+          fse.copy(srcFile1, destFile1, options, (err) => {
+            assert(!err)
+            assert(!fs.existsSync(destFile1))
+            done()
+          })
+        })
+
+        it('should should apply filter recursively', done => {
+          const FILES = 2
+          // Don't match anything that ends with a digit higher than 0:
+          const filter = s => /(0|\D)$/i.test(s)
+
+          const src = path.join(TEST_DIR, 'src')
+          fse.mkdirsSync(src)
+
+          for (let i = 0; i < FILES; ++i) {
+            fs.writeFileSync(path.join(src, i.toString()), crypto.randomBytes(SIZE))
+          }
+
+          const subdir = path.join(src, 'subdir')
+          fse.mkdirsSync(subdir)
+
+          for (let i = 0; i < FILES; ++i) {
+            fs.writeFileSync(path.join(subdir, i.toString()), crypto.randomBytes(SIZE))
+          }
+          const dest = path.join(TEST_DIR, 'dest')
+          fse.copy(src, dest, filter, err => {
+            assert(!err)
+
+            assert(fs.existsSync(dest))
+            assert(FILES > 1)
+
+            for (let i = 0; i < FILES; ++i) {
+              if (i === 0) {
+                assert(fs.existsSync(path.join(dest, i.toString())))
+              } else {
+                assert(!fs.existsSync(path.join(dest, i.toString())))
+              }
+            }
+
+            const destSub = path.join(dest, 'subdir')
+
+            for (let j = 0; j < FILES; ++j) {
+              if (j === 0) {
+                assert(fs.existsSync(path.join(destSub, j.toString())))
+              } else {
+                assert(!fs.existsSync(path.join(destSub, j.toString())))
+              }
+            }
+            done()
+          })
+        })
+
+        it('should apply the filter to directory names', done => {
+          const IGNORE = 'ignore'
+          const filter = p => !~p.indexOf(IGNORE)
+
+          const src = path.join(TEST_DIR, 'src')
+          fse.mkdirsSync(src)
+
+          const ignoreDir = path.join(src, IGNORE)
+          fse.mkdirsSync(ignoreDir)
+
+          fse.writeFileSync(path.join(ignoreDir, 'file'), crypto.randomBytes(SIZE))
+
+          const dest = path.join(TEST_DIR, 'dest')
+
+          fse.copySync(src, dest, filter)
+
+          assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
+          assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+          done()
+        })
+
+        it('should apply filter when it is applied only to dest', done => {
+          // 16893 refers to 0o777 mode
+          const filter = (s, d) => fs.lstatSync(d).mode === 16893
+
+          const src = path.join(TEST_DIR, 'src')
+          fse.mkdirsSync(src)
+          const subdir = path.join(src, 'subdir')
+          fse.mkdirsSync(subdir)
+
+          // make another dest to make sure not affecting other tests
+          const dest1 = path.join(TEST_DIR, 'dest1')
+          fse.mkdirsSync(dest1, 0o774) // mode 16892
+
+          assert.strictEqual(fs.lstatSync(dest1).mode, 16892)
+
+          fse.copy(src, dest1, filter, err => {
+            assert(!err)
+            assert(!fs.existsSync(path.join(dest1, 'subdir')))
+            done()
+          })
+        })
+
+        it('should apply filter when it is applied to both src and dest', done => {
+          // 16892 refers to 0o774 mode
+          const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mode === 16892
+
+          const dest2 = path.join(TEST_DIR, 'dest2')
+          fse.mkdirsSync(dest2, 0o774) // mode 16892
+          assert.strictEqual(fs.lstatSync(dest2).mode, 16892)
+
+          const srcFile1 = path.join(TEST_DIR, '1.html')
+          const srcFile2 = path.join(TEST_DIR, '2.css')
+          const srcFile3 = path.join(TEST_DIR, '3.jade')
+
+          fse.writeFileSync(srcFile1, '')
+          fse.writeFileSync(srcFile2, '')
+          fse.writeFileSync(srcFile3, '')
+
+          const destFile1 = path.join(dest2, 'dest1.html')
+          const destFile2 = path.join(dest2, 'dest2.css')
+          const destFile3 = path.join(dest2, 'dest3.jade')
+
+          fse.copy(srcFile1, destFile1, filter, err => {
+            assert(!err)
+            assert(fs.existsSync(destFile1))
+
+            fse.copy(srcFile2, destFile2, filter, err => {
+              assert(!err)
+              assert(!fs.existsSync(destFile2))
+
+              fse.copy(srcFile3, destFile3, filter, err => {
+                assert(!err)
+                assert(fs.existsSync(destFile3))
+                done()
+              })
+            })
+          })
         })
       })
 

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -266,9 +266,9 @@ describe('fs-extra', () => {
       })
 
       it('should apply filter when it is applied only to dest', done => {
-        const mtimeCond = new Date().getTime()
+        const timeCond = new Date().getTime()
 
-        const filter = (s, d) => fs.lstatSync(path.dirname(d)).mtime.getTime() > mtimeCond
+        const filter = (s, d) => fs.statSync(path.dirname(d)).birthtime.getTime() < timeCond
 
         const src = path.join(TEST_DIR, 'src')
         fse.mkdirsSync(src)
@@ -277,49 +277,53 @@ describe('fs-extra', () => {
 
         const dest = path.join(TEST_DIR, 'dest')
 
-        fse.copy(src, dest, filter, err => {
-          assert(!err)
-          assert(!fs.existsSync(path.join(dest, 'subdir')))
-          done()
-        })
+        setTimeout(function () {
+          fse.mkdirsSync(dest)
+
+          fse.copy(src, dest, filter, err => {
+            assert(!err)
+            assert(!fs.existsSync(path.join(dest, 'subdir')))
+            done()
+          })
+        }, 1000)
       })
 
       it('should apply filter when it is applied to both src and dest', done => {
-        const mtimeCond = new Date().getTime()
-        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.lstatSync(path.dirname(d)).mtime.getTime() < mtimeCond
+        const timeCond = new Date().getTime()
+        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).birthtime.getTime() > timeCond
 
         const dest = path.join(TEST_DIR, 'dest')
         setTimeout(function () {
           fse.mkdirsSync(dest)
-        }, 1000)
 
-        const srcFile1 = path.join(TEST_DIR, '1.html')
-        const srcFile2 = path.join(TEST_DIR, '2.css')
-        const srcFile3 = path.join(TEST_DIR, '3.jade')
+          const srcFile1 = path.join(TEST_DIR, '1.html')
+          const srcFile2 = path.join(TEST_DIR, '2.css')
+          const srcFile3 = path.join(TEST_DIR, '3.jade')
 
-        fse.writeFileSync(srcFile1, '')
-        fse.writeFileSync(srcFile2, '')
-        fse.writeFileSync(srcFile3, '')
+          fse.writeFileSync(srcFile1, '')
+          fse.writeFileSync(srcFile2, '')
+          fse.writeFileSync(srcFile3, '')
 
-        const destFile1 = path.join(dest, 'dest1.html')
-        const destFile2 = path.join(dest, 'dest2.css')
-        const destFile3 = path.join(dest, 'dest3.jade')
+          const destFile1 = path.join(dest, 'dest1.html')
+          const destFile2 = path.join(dest, 'dest2.css')
+          const destFile3 = path.join(dest, 'dest3.jade')
 
-        fse.copy(srcFile1, destFile1, filter, err => {
-          assert(!err)
-          assert(fs.existsSync(destFile1))
-
-          fse.copy(srcFile2, destFile2, filter, err => {
+          fse.copy(srcFile1, destFile1, filter, err => {
             assert(!err)
-            assert(!fs.existsSync(destFile2))
+            assert(fs.existsSync(destFile1))
 
-            fse.copy(srcFile3, destFile3, filter, err => {
+            fse.copy(srcFile2, destFile2, filter, err => {
               assert(!err)
-              assert(fs.existsSync(destFile3))
-              done()
+              assert(!fs.existsSync(destFile2))
+
+              fse.copy(srcFile3, destFile3, filter, err => {
+                assert(!err)
+                assert(fs.existsSync(destFile3))
+                done()
+              })
             })
           })
-        })
+        }, 1000)
       })
     })
   })

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -268,7 +268,7 @@ describe('fs-extra', () => {
       it('should apply filter when it is applied only to dest', done => {
         const timeCond = new Date().getTime()
 
-        const filter = (s, d) => fs.statSync(path.dirname(d)).birthtime.getTime() < timeCond
+        const filter = (s, d) => fs.statSync(d).birthtime.getTime() < timeCond
 
         const src = path.join(TEST_DIR, 'src')
         fse.mkdirsSync(src)

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -277,7 +277,7 @@ describe('fs-extra', () => {
 
         const dest = path.join(TEST_DIR, 'dest')
 
-        setTimeout(function () {
+        setTimeout(() => {
           fse.mkdirsSync(dest)
 
           fse.copy(src, dest, filter, err => {
@@ -293,7 +293,7 @@ describe('fs-extra', () => {
         const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).birthtime.getTime() > timeCond
 
         const dest = path.join(TEST_DIR, 'dest')
-        setTimeout(function () {
+        setTimeout(() => {
           fse.mkdirsSync(dest)
 
           const srcFile1 = path.join(TEST_DIR, '1.html')

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -37,11 +37,11 @@ function ncp (source, dest, options, callback) {
     if (filter) {
       if (filter instanceof RegExp) {
         console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-        if (!filter.test(source)) {
+        if (!filter.test(source, dest)) {
           return doneOne(true)
         }
       } else if (typeof filter === 'function') {
-        if (!filter(source)) {
+        if (!filter(source, dest)) {
           return doneOne(true)
         }
       }


### PR DESCRIPTION
This resolves #351.

However, I have to update new unit tests that I added for this feature as some of them are not passing in earlier node versions in travis. Basically I shouldn't have used fs mode. So, I am changing the new tests to use `fs.stat.mtime.getTime()` instead of `fs.stat.mode` for filtering dest. I will update the PR right away then.

**Edit**

I fixed the tests by using `fs.stat` `birthtime` instead of `mtime`. Now all tests passed!