### PR TITLE
Refactor tests to ES6

### DIFF
--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -18,9 +18,7 @@ describe('fs-extra', () => {
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(done => {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
   describe('+ copy()', () => {
     it('should return an error if src and dest are the same', done => {

--- a/lib/empty/__tests__/empty-dir-sync.test.js
+++ b/lib/empty/__tests__/empty-dir-sync.test.js
@@ -1,15 +1,17 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('+ emptyDir()', function () {
-  var TEST_DIR
+describe('+ emptyDir()', () => {
+  let TEST_DIR
 
-  beforeEach(function () {
+  beforeEach(() => {
     TEST_DIR = path.join(os.tmpdir(), 'test-fs-extra', 'empty-dir')
     if (fs.existsSync(TEST_DIR)) {
       fse.removeSync(TEST_DIR)
@@ -17,12 +19,10 @@ describe('+ emptyDir()', function () {
     fse.ensureDirSync(TEST_DIR)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('> when directory exists and contains items', function () {
-    it('should delete all of the items', function () {
+  describe('> when directory exists and contains items', () => {
+    it('should delete all of the items', () => {
       // verify nothing
       assert.equal(fs.readdirSync(TEST_DIR).length, 0)
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file'))
@@ -35,16 +35,16 @@ describe('+ emptyDir()', function () {
     })
   })
 
-  describe('> when directory exists and contains no items', function () {
-    it('should do nothing', function () {
+  describe('> when directory exists and contains no items', () => {
+    it('should do nothing', () => {
       assert.equal(fs.readdirSync(TEST_DIR).length, 0)
       fse.emptyDirSync(TEST_DIR)
       assert.equal(fs.readdirSync(TEST_DIR).length, 0)
     })
   })
 
-  describe('> when directory does not exist', function () {
-    it('should create it', function () {
+  describe('> when directory does not exist', () => {
+    it('should create it', () => {
       fse.removeSync(TEST_DIR)
       assert(!fs.existsSync(TEST_DIR))
       fse.emptyDirSync(TEST_DIR)

--- a/lib/empty/__tests__/empty-dir.test.js
+++ b/lib/empty/__tests__/empty-dir.test.js
@@ -1,15 +1,17 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('+ emptyDir()', function () {
-  var TEST_DIR
+describe('+ emptyDir()', () => {
+  let TEST_DIR
 
-  beforeEach(function () {
+  beforeEach(() => {
     TEST_DIR = path.join(os.tmpdir(), 'test-fs-extra', 'empty-dir')
     if (fs.existsSync(TEST_DIR)) {
       fse.removeSync(TEST_DIR)
@@ -17,12 +19,10 @@ describe('+ emptyDir()', function () {
     fse.ensureDirSync(TEST_DIR)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('> when directory exists and contains items', function () {
-    it('should delete all of the items', function (done) {
+  describe('> when directory exists and contains items', () => {
+    it('should delete all of the items', done => {
       // verify nothing
       assert.equal(fs.readdirSync(TEST_DIR).length, 0)
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file'))
@@ -30,7 +30,7 @@ describe('+ emptyDir()', function () {
       fse.ensureDirSync(path.join(TEST_DIR, 'some-dir'))
       assert.equal(fs.readdirSync(TEST_DIR).length, 3)
 
-      fse.emptyDir(TEST_DIR, function (err) {
+      fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
         assert.equal(fs.readdirSync(TEST_DIR).length, 0)
         done()
@@ -38,10 +38,10 @@ describe('+ emptyDir()', function () {
     })
   })
 
-  describe('> when directory exists and contains no items', function () {
-    it('should do nothing', function (done) {
+  describe('> when directory exists and contains no items', () => {
+    it('should do nothing', done => {
       assert.equal(fs.readdirSync(TEST_DIR).length, 0)
-      fse.emptyDir(TEST_DIR, function (err) {
+      fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
         assert.equal(fs.readdirSync(TEST_DIR).length, 0)
         done()
@@ -49,11 +49,11 @@ describe('+ emptyDir()', function () {
     })
   })
 
-  describe('> when directory does not exist', function () {
-    it('should create it', function (done) {
+  describe('> when directory does not exist', () => {
+    it('should create it', done => {
       fse.removeSync(TEST_DIR)
       assert(!fs.existsSync(TEST_DIR))
-      fse.emptyDir(TEST_DIR, function (err) {
+      fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
         assert.equal(fs.readdirSync(TEST_DIR).length, 0)
         done()

--- a/lib/ensure/__tests__/create.test.js
+++ b/lib/ensure/__tests__/create.test.js
@@ -1,29 +1,29 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('fs-extra', function () {
-  var TEST_DIR
+describe('fs-extra', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'create')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ createFile', function () {
-    describe('> when the file and directory does not exist', function () {
-      it('should create the file', function (done) {
-        var file = path.join(TEST_DIR, Math.random() + 't-ne', Math.random() + '.txt')
+  describe('+ createFile', () => {
+    describe('> when the file and directory does not exist', () => {
+      it('should create the file', done => {
+        const file = path.join(TEST_DIR, Math.random() + 't-ne', Math.random() + '.txt')
         assert(!fs.existsSync(file))
-        fse.createFile(file, function (err) {
+        fse.createFile(file, err => {
           assert.ifError(err)
           assert(fs.existsSync(file))
           done()
@@ -31,12 +31,12 @@ describe('fs-extra', function () {
       })
     })
 
-    describe('> when the file does exist', function () {
-      it('should not modify the file', function (done) {
-        var file = path.join(TEST_DIR, Math.random() + 't-e', Math.random() + '.txt')
+    describe('> when the file does exist', () => {
+      it('should not modify the file', done => {
+        const file = path.join(TEST_DIR, Math.random() + 't-e', Math.random() + '.txt')
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
-        fse.createFile(file, function (err) {
+        fse.createFile(file, err => {
           assert.ifError(err)
           assert.equal(fs.readFileSync(file, 'utf8'), 'hello world')
           done()
@@ -45,19 +45,19 @@ describe('fs-extra', function () {
     })
   })
 
-  describe('+ createFileSync', function () {
-    describe('> when the file and directory does not exist', function () {
-      it('should create the file', function () {
-        var file = path.join(TEST_DIR, Math.random() + 'ts-ne', Math.random() + '.txt')
+  describe('+ createFileSync', () => {
+    describe('> when the file and directory does not exist', () => {
+      it('should create the file', () => {
+        const file = path.join(TEST_DIR, Math.random() + 'ts-ne', Math.random() + '.txt')
         assert(!fs.existsSync(file))
         fse.createFileSync(file)
         assert(fs.existsSync(file))
       })
     })
 
-    describe('> when the file does exist', function () {
-      it('should not modify the file', function () {
-        var file = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
+    describe('> when the file does exist', () => {
+      it('should not modify the file', () => {
+        const file = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
         fse.createFileSync(file)

--- a/lib/ensure/__tests__/ensure.test.js
+++ b/lib/ensure/__tests__/ensure.test.js
@@ -1,31 +1,31 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('fs-extra', function () {
-  var TEST_DIR
+describe('fs-extra', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ ensureFile()', function () {
-    describe('> when file exists', function () {
-      it('should not do anything', function (done) {
-        var file = path.join(TEST_DIR, 'file.txt')
+  describe('+ ensureFile()', () => {
+    describe('> when file exists', () => {
+      it('should not do anything', done => {
+        const file = path.join(TEST_DIR, 'file.txt')
         fs.writeFileSync(file, 'blah')
 
         assert(fs.existsSync(file))
-        fse.ensureFile(file, function (err) {
+        fse.ensureFile(file, err => {
           assert.ifError(err)
           assert(fs.existsSync(file))
           done()
@@ -33,12 +33,12 @@ describe('fs-extra', function () {
       })
     })
 
-    describe('> when file does not exist', function () {
-      it('should create the file', function (done) {
-        var file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
+    describe('> when file does not exist', () => {
+      it('should create the file', done => {
+        const file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
 
         assert(!fs.existsSync(file))
-        fse.ensureFile(file, function (err) {
+        fse.ensureFile(file, err => {
           assert.ifError(err)
           assert(fs.existsSync(file))
           done()
@@ -47,10 +47,10 @@ describe('fs-extra', function () {
     })
   })
 
-  describe('+ ensureFileSync()', function () {
-    describe('> when file exists', function () {
-      it('should not do anything', function () {
-        var file = path.join(TEST_DIR, 'file.txt')
+  describe('+ ensureFileSync()', () => {
+    describe('> when file exists', () => {
+      it('should not do anything', () => {
+        const file = path.join(TEST_DIR, 'file.txt')
         fs.writeFileSync(file, 'blah')
 
         assert(fs.existsSync(file))
@@ -59,9 +59,9 @@ describe('fs-extra', function () {
       })
     })
 
-    describe('> when file does not exist', function () {
-      it('should create the file', function () {
-        var file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
+    describe('> when file does not exist', () => {
+      it('should create the file', () => {
+        const file = path.join(TEST_DIR, 'dir/that/does/not/exist', 'file.txt')
 
         assert(!fs.existsSync(file))
         fse.ensureFileSync(file)
@@ -70,14 +70,14 @@ describe('fs-extra', function () {
     })
   })
 
-  describe('+ ensureDir()', function () {
-    describe('> when dir exists', function () {
-      it('should not do anything', function (done) {
-        var dir = path.join(TEST_DIR, 'dir/does/not/exist')
+  describe('+ ensureDir()', () => {
+    describe('> when dir exists', () => {
+      it('should not do anything', done => {
+        const dir = path.join(TEST_DIR, 'dir/does/not/exist')
         fse.mkdirpSync(dir)
 
         assert(fs.existsSync(dir))
-        fse.ensureDir(dir, function (err) {
+        fse.ensureDir(dir, err => {
           assert.ifError(err)
           assert(fs.existsSync(dir))
           done()
@@ -85,12 +85,12 @@ describe('fs-extra', function () {
       })
     })
 
-    describe('> when dir does not exist', function () {
-      it('should create the dir', function (done) {
-        var dir = path.join(TEST_DIR, 'dir/that/does/not/exist')
+    describe('> when dir does not exist', () => {
+      it('should create the dir', done => {
+        const dir = path.join(TEST_DIR, 'dir/that/does/not/exist')
 
         assert(!fs.existsSync(dir))
-        fse.ensureDir(dir, function (err) {
+        fse.ensureDir(dir, err => {
           assert.ifError(err)
           assert(fs.existsSync(dir))
           done()
@@ -99,10 +99,10 @@ describe('fs-extra', function () {
     })
   })
 
-  describe('+ ensureDirSync()', function () {
-    describe('> when dir exists', function () {
-      it('should not do anything', function () {
-        var dir = path.join(TEST_DIR, 'dir/does/not/exist')
+  describe('+ ensureDirSync()', () => {
+    describe('> when dir exists', () => {
+      it('should not do anything', () => {
+        const dir = path.join(TEST_DIR, 'dir/does/not/exist')
         fse.mkdirpSync(dir)
 
         assert(fs.existsSync(dir))
@@ -111,9 +111,9 @@ describe('fs-extra', function () {
       })
     })
 
-    describe('> when dir does not exist', function () {
-      it('should create the dir', function () {
-        var dir = path.join(TEST_DIR, 'dir/that/does/not/exist')
+    describe('> when dir does not exist', () => {
+      it('should create the dir', () => {
+        const dir = path.join(TEST_DIR, 'dir/that/does/not/exist')
 
         assert(!fs.existsSync(dir))
         fse.ensureDirSync(dir)

--- a/lib/ensure/__tests__/link.test.js
+++ b/lib/ensure/__tests__/link.test.js
@@ -1,21 +1,21 @@
-var assert = require('assert')
-var util = require('util')
-var path = require('path')
-var os = require('os')
-var fs = require('graceful-fs')
-var CWD = process.cwd()
-var fse = require(CWD)
-var ensureLink = fse.ensureLink
-var ensureLinkSync = fse.ensureLinkSync
+'use strict'
+
+const CWD = process.cwd()
+
+const fs = require('graceful-fs')
+const os = require('os')
+const fse = require(CWD)
+const path = require('path')
+const assert = require('assert')
+const ensureLink = fse.ensureLink
+const ensureLinkSync = fse.ensureLinkSync
 
 /* global afterEach, beforeEach, describe, it, after, before */
 
-var TEST_DIR
+describe('fse-ensure-link', () => {
+  const TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
 
-describe('fse-ensure-link', function () {
-  TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
-
-  var tests = [
+  const tests = [
     // [[srcpath, dstpath], fs.link expect, ensureLink expect]
     [['./foo.txt', './link.txt'], 'file-success', 'file-success'],
     [['./foo.txt', './dir-foo/link.txt'], 'file-success', 'file-success'],
@@ -42,12 +42,12 @@ describe('fse-ensure-link', function () {
     [[path.resolve(path.join(TEST_DIR, '../dir-foo/foo.txt')), './link.txt'], 'file-error', 'file-error']
   ]
 
-  before(function () {
+  before(() => {
     fse.emptyDirSync(TEST_DIR)
     process.chdir(TEST_DIR)
   })
 
-  beforeEach(function () {
+  beforeEach(() => {
     fs.writeFileSync('./foo.txt', 'foo\n')
     fse.mkdirsSync('empty-dir')
     fse.mkdirsSync('dir-foo')
@@ -57,28 +57,28 @@ describe('fse-ensure-link', function () {
     fse.mkdirsSync('real-alpha/real-beta/real-gamma')
   })
 
-  afterEach(function (done) {
-    fse.emptyDir(TEST_DIR, done)
-  })
+  afterEach(done => fse.emptyDir(TEST_DIR, done))
 
-  after(function () {
+  after(() => {
     process.chdir(CWD)
     fse.removeSync(TEST_DIR)
   })
 
   function fileSuccess (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create link file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should create link file using src ${srcpath} and dst ${dstpath}`, done => {
+      const callback = err => {
         if (err) return done(err)
-        var srcContent = fs.readFileSync(srcpath, 'utf8')
-        var dstDir = path.dirname(dstpath)
-        var dstBasename = path.basename(dstpath)
-        var isSymlink = fs.lstatSync(dstpath).isFile()
-        var dstContent = fs.readFileSync(dstpath, 'utf8')
-        var dstDirContents = fs.readdirSync(dstDir)
+
+        const srcContent = fs.readFileSync(srcpath, 'utf8')
+        const dstDir = path.dirname(dstpath)
+        const dstBasename = path.basename(dstpath)
+        const isSymlink = fs.lstatSync(dstpath).isFile()
+        const dstContent = fs.readFileSync(dstpath, 'utf8')
+        const dstDirContents = fs.readdirSync(dstDir)
+
         assert.equal(isSymlink, true)
         assert.equal(srcContent, dstContent)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -90,15 +90,15 @@ describe('fse-ensure-link', function () {
   }
 
   function fileError (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should return error when creating link file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      function callback (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should return error when creating link file using src ${srcpath} and dst ${dstpath}`, done => {
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      const callback = err => {
         assert.equal(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
-        var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+        const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
         assert.equal(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
@@ -108,14 +108,14 @@ describe('fse-ensure-link', function () {
   }
 
   function fileDestExists (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, done => {
+      const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
+      const callback = err => {
         if (err) return done(err)
-        var destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
+        const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
         assert.equal(destinationContentBefore, destinationContentAfter)
         return done()
       }
@@ -125,17 +125,17 @@ describe('fse-ensure-link', function () {
   }
 
   function fileSuccessSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create link file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should create link file using src ${srcpath} and dst ${dstpath}`, () => {
       fn.apply(null, args)
-      var srcContent = fs.readFileSync(srcpath, 'utf8')
-      var dstDir = path.dirname(dstpath)
-      var dstBasename = path.basename(dstpath)
-      var isSymlink = fs.lstatSync(dstpath).isFile()
-      var dstContent = fs.readFileSync(dstpath, 'utf8')
-      var dstDirContents = fs.readdirSync(dstDir)
+      const srcContent = fs.readFileSync(srcpath, 'utf8')
+      const dstDir = path.dirname(dstpath)
+      const dstBasename = path.basename(dstpath)
+      const isSymlink = fs.lstatSync(dstpath).isFile()
+      const dstContent = fs.readFileSync(dstpath, 'utf8')
+      const dstDirContents = fs.readdirSync(dstDir)
       assert.equal(isSymlink, true)
       assert.equal(srcContent, dstContent)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -143,78 +143,78 @@ describe('fse-ensure-link', function () {
   }
 
   function fileErrorSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should throw error using` src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should throw error using src ${srcpath} and dst ${dstpath}`, () => {
       // will fail if dstdir is created and there's an error
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      var err = null
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      let err = null
       try {
         fn.apply(null, args)
       } catch (e) {
         err = e
       }
       assert.equal(err instanceof Error, true)
-      var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+      const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
       assert.equal(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
   function fileDestExistsSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
-      var destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
+    const srcpath = args[0]
+    const dstpath = args[1]
+
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, () => {
+      const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
       fn.apply(null, args)
-      var destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
+      const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
       assert.equal(destinationContentBefore, destinationContentAfter)
     })
   }
 
-  describe('fs.link()', function () {
-    var fn = fs.link
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var nativeBehavior = test[1]
-      // var newBehavior = test[2]
+  describe('fs.link()', () => {
+    const fn = fs.link
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const nativeBehavior = test[1]
+      // const newBehavior = test[2]
       if (nativeBehavior === 'file-success') fileSuccess(args, fn)
       if (nativeBehavior === 'file-error') fileError(args, fn)
       if (nativeBehavior === 'file-dest-exists') fileDestExists(args, fn)
     })
   })
 
-  describe('ensureLink()', function () {
-    var fn = ensureLink
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      // var nativeBehavior = test[1]
-      var newBehavior = test[2]
+  describe('ensureLink()', () => {
+    const fn = ensureLink
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      // const nativeBehavior = test[1]
+      const newBehavior = test[2]
       if (newBehavior === 'file-success') fileSuccess(args, fn)
       if (newBehavior === 'file-error') fileError(args, fn)
       if (newBehavior === 'file-dest-exists') fileDestExists(args, fn)
     })
   })
 
-  describe('fs.linkSync()', function () {
-    var fn = fs.linkSync
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var nativeBehavior = test[1]
-      // var newBehavior = test[2]
+  describe('fs.linkSync()', () => {
+    const fn = fs.linkSync
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const nativeBehavior = test[1]
+      // const newBehavior = test[2]
       if (nativeBehavior === 'file-success') fileSuccessSync(args, fn)
       if (nativeBehavior === 'file-error') fileErrorSync(args, fn)
       if (nativeBehavior === 'file-dest-exists') fileDestExists(args, fn)
     })
   })
 
-  describe('ensureLinkSync()', function () {
-    var fn = ensureLinkSync
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      // var nativeBehavior = test[1]
-      var newBehavior = test[2]
+  describe('ensureLinkSync()', () => {
+    const fn = ensureLinkSync
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      // const nativeBehavior = test[1]
+      const newBehavior = test[2]
       if (newBehavior === 'file-success') fileSuccessSync(args, fn)
       if (newBehavior === 'file-error') fileErrorSync(args, fn)
       if (newBehavior === 'file-dest-exists') fileDestExistsSync(args, fn)

--- a/lib/ensure/__tests__/symlink-paths.test.js
+++ b/lib/ensure/__tests__/symlink-paths.test.js
@@ -1,24 +1,26 @@
-var assert = require('assert')
-var util = require('util')
-var path = require('path')
-var os = require('os')
-var fs = require('graceful-fs')
-var CWD = process.cwd()
-var fse = require(CWD)
-var _symlinkPaths = require('../symlink-paths')
-var symlinkPaths = _symlinkPaths.symlinkPaths
-var symlinkPathsSync = _symlinkPaths.symlinkPathsSync
-var TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
+'use strict'
+
+const CWD = process.cwd()
+
+const fs = require('graceful-fs')
+const os = require('os')
+const fse = require(CWD)
+const path = require('path')
+const assert = require('assert')
+const _symlinkPaths = require('../symlink-paths')
+const symlinkPaths = _symlinkPaths.symlinkPaths
+const symlinkPathsSync = _symlinkPaths.symlinkPathsSync
+const TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
 
 /* global afterEach, beforeEach, describe, it, after, before */
 
-describe('symlink-type', function () {
-  before(function () {
+describe('symlink-type', () => {
+  before(() => {
     fse.emptyDirSync(TEST_DIR)
     process.chdir(TEST_DIR)
   })
 
-  beforeEach(function () {
+  beforeEach(() => {
     fs.writeFileSync('./foo.txt', 'foo\n')
     fse.mkdirsSync('./empty-dir')
     fse.mkdirsSync('./dir-foo')
@@ -28,16 +30,14 @@ describe('symlink-type', function () {
     fse.mkdirsSync('./real-alpha/real-beta/real-gamma')
   })
 
-  afterEach(function (done) {
-    fse.emptyDir(TEST_DIR, done)
-  })
+  afterEach(done => fse.emptyDir(TEST_DIR, done))
 
-  after(function () {
+  after(() => {
     process.chdir(CWD)
     fse.removeSync(TEST_DIR)
   })
 
-  var tests = [
+  const tests = [
     [['foo.txt', 'symlink.txt'], {toCwd: 'foo.txt', toDst: 'foo.txt'}], // smart && nodestyle
     [['foo.txt', 'empty-dir/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // smart
     [['../foo.txt', 'empty-dir/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // nodestyle
@@ -51,7 +51,7 @@ describe('symlink-type', function () {
   ]
 
   // formats paths to pass on multiple operating systems
-  tests.forEach(function (test) {
+  tests.forEach(test => {
     test[0][0] = path.join(test[0][0])
     test[0][1] = path.join(test[0][1])
     test[1] = {
@@ -60,13 +60,12 @@ describe('symlink-type', function () {
     }
   })
 
-  describe('symlinkPaths()', function () {
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var expectedRelativePaths = test[1]
-      var should = util.format('should return \'%s\' when src \'%s\' and dst is \'%s\'', JSON.stringify(expectedRelativePaths), args[0], args[1])
-      it(should, function (done) {
-        var callback = function (err, relativePaths) {
+  describe('symlinkPaths()', () => {
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const expectedRelativePaths = test[1]
+      it(`should return '${JSON.stringify(expectedRelativePaths)}' when src '${args[0]}' and dst is '${args[1]}'`, done => {
+        const callback = (err, relativePaths) => {
           if (err) done(err)
           assert.deepEqual(relativePaths, expectedRelativePaths)
           done()
@@ -77,13 +76,12 @@ describe('symlink-type', function () {
     })
   })
 
-  describe('symlinkPathsSync()', function () {
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var expectedRelativePaths = test[1]
-      var should = util.format('should return \'%s\' when src \'%s\' and dst is \'%s\'', JSON.stringify(expectedRelativePaths), args[0], args[1])
-      it(should, function () {
-        var relativePaths = symlinkPathsSync.apply(null, args)
+  describe('symlinkPathsSync()', () => {
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const expectedRelativePaths = test[1]
+      it(`should return '${JSON.stringify(expectedRelativePaths)}' when src '${args[0]}' and dst is '${args[1]}'`, () => {
+        const relativePaths = symlinkPathsSync.apply(null, args)
         assert.deepEqual(relativePaths, expectedRelativePaths)
       })
     })

--- a/lib/ensure/__tests__/symlink-type.test.js
+++ b/lib/ensure/__tests__/symlink-type.test.js
@@ -1,24 +1,26 @@
-var assert = require('assert')
-var util = require('util')
-var path = require('path')
-var os = require('os')
-var fs = require('graceful-fs')
-var CWD = process.cwd()
-var fse = require(CWD)
-var _symlinkType = require('../symlink-type')
-var symlinkType = _symlinkType.symlinkType
-var symlinkTypeSync = _symlinkType.symlinkTypeSync
-var TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
+'use strict'
+
+const CWD = process.cwd()
+
+const fs = require('graceful-fs')
+const os = require('os')
+const fse = require(CWD)
+const path = require('path')
+const assert = require('assert')
+const _symlinkType = require('../symlink-type')
+const symlinkType = _symlinkType.symlinkType
+const symlinkTypeSync = _symlinkType.symlinkTypeSync
+const TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
 
 /* global afterEach, beforeEach, describe, it, after, before */
 
-describe('symlink-type', function () {
-  before(function () {
+describe('symlink-type', () => {
+  before(() => {
     fse.emptyDirSync(TEST_DIR)
     process.chdir(TEST_DIR)
   })
 
-  beforeEach(function () {
+  beforeEach(() => {
     fs.writeFileSync('./foo.txt', 'foo\n')
     fse.mkdirsSync('./empty-dir')
     fse.mkdirsSync('./dir-foo')
@@ -28,16 +30,14 @@ describe('symlink-type', function () {
     fse.mkdirsSync('./real-alpha/real-beta/real-gamma')
   })
 
-  afterEach(function (done) {
-    fse.emptyDir(TEST_DIR, done)
-  })
+  afterEach(done => fse.emptyDir(TEST_DIR, done))
 
-  after(function () {
+  after(() => {
     process.chdir(CWD)
     fse.removeSync(TEST_DIR)
   })
 
-  var tests = {
+  const tests = {
     success: [
       // [{arguments} [srcpath, dirpath, [type] , result]
       // smart file type checking
@@ -91,13 +91,12 @@ describe('symlink-type', function () {
     ]
   }
 
-  describe('symlinkType()', function () {
-    tests.success.forEach(function (test) {
-      var args = test[0].slice(0)
-      var expectedType = test[1]
-      var should = util.format('should return \'%s\' when src \'%s\'', expectedType, args[0])
-      it(should, function (done) {
-        var callback = function (err, type) {
+  describe('symlinkType()', () => {
+    tests.success.forEach(test => {
+      const args = test[0].slice(0)
+      const expectedType = test[1]
+      it(`should return '${expectedType}' when src '${args[0]}'`, done => {
+        const callback = (err, type) => {
           if (err) done(err)
           assert.equal(type, expectedType)
           done()
@@ -108,13 +107,12 @@ describe('symlink-type', function () {
     })
   })
 
-  describe('symlinkTypeSync()', function () {
-    tests.success.forEach(function (test) {
-      var args = test[0]
-      var expectedType = test[1]
-      var should = util.format('should return \'%s\' when src \'%s\'', expectedType, args[0])
-      it(should, function () {
-        var type = symlinkTypeSync.apply(null, args)
+  describe('symlinkTypeSync()', () => {
+    tests.success.forEach(test => {
+      const args = test[0]
+      const expectedType = test[1]
+      it(`should return '${expectedType}' when src '${args[0]}'`, () => {
+        const type = symlinkTypeSync.apply(null, args)
         assert.equal(type, expectedType)
       })
     })

--- a/lib/ensure/__tests__/symlink.test.js
+++ b/lib/ensure/__tests__/symlink.test.js
@@ -1,25 +1,25 @@
-var assert = require('assert')
-var util = require('util')
-var path = require('path')
-var os = require('os')
-var fs = require('graceful-fs')
-var CWD = process.cwd()
-var fse = require(CWD)
+'use strict'
 
-var _symlinkPaths = require('../symlink-paths')
-var symlinkPathsSync = _symlinkPaths.symlinkPathsSync
+const CWD = process.cwd()
 
-var ensureSymlink = fse.ensureSymlink
-var ensureSymlinkSync = fse.ensureSymlinkSync
+const fs = require('graceful-fs')
+const os = require('os')
+const fse = require(CWD)
+const path = require('path')
+const assert = require('assert')
+const _symlinkPaths = require('../symlink-paths')
+const symlinkPathsSync = _symlinkPaths.symlinkPathsSync
+const ensureSymlink = fse.ensureSymlink
+const ensureSymlinkSync = fse.ensureSymlinkSync
 
 /* global afterEach, beforeEach, describe, it, after, before */
 
-var TEST_DIR
+let TEST_DIR
 
-describe('fse-ensure-symlink', function () {
+describe('fse-ensure-symlink', () => {
   TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'ensure-symlink')
 
-  var tests = [
+  const tests = [
     // [[srcpath, dstpath], fs.symlink expect, fse.ensureSymlink expect]
     [['./foo.txt', './symlink.txt'], 'file-success', 'file-success'],
     [['../foo.txt', './empty-dir/symlink.txt'], 'file-success', 'file-success'],
@@ -56,12 +56,12 @@ describe('fse-ensure-symlink', function () {
     [[path.resolve(path.join(TEST_DIR, '../dir-foo/foo.txt')), './symlink.txt'], 'file-broken', 'file-error']
   ]
 
-  before(function () {
+  before(() => {
     fse.emptyDirSync(TEST_DIR)
     process.chdir(TEST_DIR)
   })
 
-  beforeEach(function () {
+  beforeEach(() => {
     fs.writeFileSync('./foo.txt', 'foo\n')
     fse.mkdirsSync('empty-dir')
     fse.mkdirsSync('dir-foo')
@@ -71,29 +71,26 @@ describe('fse-ensure-symlink', function () {
     fse.mkdirsSync('real-alpha/real-beta/real-gamma')
   })
 
-  afterEach(function (done) {
-    fse.emptyDir(TEST_DIR, done)
-  })
+  afterEach(done => fse.emptyDir(TEST_DIR, done))
 
-  after(function () {
+  after(() => {
     process.chdir(CWD)
     fse.removeSync(TEST_DIR)
   })
 
   function fileSuccess (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create symlink file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create symlink file using src ${srcpath} and dst ${dstpath}`, done => {
+      const callback = err => {
         if (err) return done(err)
-        var relative = symlinkPathsSync(srcpath, dstpath)
-        var srcContent = fs.readFileSync(relative.toCwd, 'utf8')
-        var dstDir = path.dirname(dstpath)
-        var dstBasename = path.basename(dstpath)
-        var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-        var dstContent = fs.readFileSync(dstpath, 'utf8')
-        var dstDirContents = fs.readdirSync(dstDir)
+        const relative = symlinkPathsSync(srcpath, dstpath)
+        const srcContent = fs.readFileSync(relative.toCwd, 'utf8')
+        const dstDir = path.dirname(dstpath)
+        const dstBasename = path.basename(dstpath)
+        const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+        const dstContent = fs.readFileSync(dstpath, 'utf8')
+        const dstDirContents = fs.readdirSync(dstDir)
         assert.equal(isSymlink, true)
         assert.equal(srcContent, dstContent)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -105,21 +102,18 @@ describe('fse-ensure-symlink', function () {
   }
 
   function fileBroken (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create broken symlink file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create broken symlink file using src ${srcpath} and dst ${dstpath}`, done => {
+      const callback = err => {
         if (err) return done(err)
-        var dstDir = path.dirname(dstpath)
-        var dstBasename = path.basename(dstpath)
-        var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-        var dstDirContents = fs.readdirSync(dstDir)
+        const dstDir = path.dirname(dstpath)
+        const dstBasename = path.basename(dstpath)
+        const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+        const dstDirContents = fs.readdirSync(dstDir)
         assert.equal(isSymlink, true)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
-        assert.throws(function () {
-          return fs.readFileSync(dstpath, 'utf8')
-        }, Error)
+        assert.throws(() => fs.readFileSync(dstpath, 'utf8'), Error)
         return done()
       }
       args.push(callback)
@@ -128,15 +122,14 @@ describe('fse-ensure-symlink', function () {
   }
 
   function fileError (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should return error when creating symlink file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      function callback (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should return error when creating symlink file using src ${srcpath} and dst ${dstpath}`, done => {
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      const callback = err => {
         assert.equal(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
-        var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+        const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
         assert.equal(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
@@ -146,14 +139,13 @@ describe('fse-ensure-symlink', function () {
   }
 
   function fileDestExists (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, done => {
+      const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
+      const callback = err => {
         if (err) return done(err)
-        var destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
+        const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
         assert.equal(destinationContentBefore, destinationContentAfter)
         return done()
       }
@@ -163,19 +155,18 @@ describe('fse-ensure-symlink', function () {
   }
 
   function dirSuccess (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create symlink dir using src ${srcpath} and dst ${dstpath}`, done => {
+      const callback = err => {
         if (err) return done(err)
-        var relative = symlinkPathsSync(srcpath, dstpath)
-        var srcContents = fs.readdirSync(relative.toCwd)
-        var dstDir = path.dirname(dstpath)
-        var dstBasename = path.basename(dstpath)
-        var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-        var dstContents = fs.readdirSync(dstpath)
-        var dstDirContents = fs.readdirSync(dstDir)
+        const relative = symlinkPathsSync(srcpath, dstpath)
+        const srcContents = fs.readdirSync(relative.toCwd)
+        const dstDir = path.dirname(dstpath)
+        const dstBasename = path.basename(dstpath)
+        const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+        const dstContents = fs.readdirSync(dstpath)
+        const dstDirContents = fs.readdirSync(dstDir)
         assert.equal(isSymlink, true)
         assert.deepEqual(srcContents, dstContents)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -187,21 +178,18 @@ describe('fse-ensure-symlink', function () {
   }
 
   function dirBroken (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create broken symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create broken symlink dir using src ${srcpath} and dst ${dstpath}`, done => {
+      const callback = err => {
         if (err) return done(err)
-        var dstDir = path.dirname(dstpath)
-        var dstBasename = path.basename(dstpath)
-        var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-        var dstDirContents = fs.readdirSync(dstDir)
+        const dstDir = path.dirname(dstpath)
+        const dstBasename = path.basename(dstpath)
+        const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+        const dstDirContents = fs.readdirSync(dstDir)
         assert.equal(isSymlink, true)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
-        assert.throws(function () {
-          return fs.readdirSync(dstpath)
-        }, Error)
+        assert.throws(() => fs.readdirSync(dstpath), Error)
         return done()
       }
       args.push(callback)
@@ -210,15 +198,14 @@ describe('fse-ensure-symlink', function () {
   }
 
   function dirError (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should return error when creating symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      function callback (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should return error when creating symlink dir using src ${srcpath} and dst ${dstpath}`, done => {
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      const callback = err => {
         assert.equal(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
-        var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+        const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
         assert.equal(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
@@ -228,14 +215,13 @@ describe('fse-ensure-symlink', function () {
   }
 
   function dirDestExists (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function (done) {
-      var destinationContentBefore = fs.readdirSync(dstpath)
-      var callback = function (err) {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, done => {
+      const destinationContentBefore = fs.readdirSync(dstpath)
+      const callback = err => {
         if (err) return done(err)
-        var destinationContentAfter = fs.readdirSync(dstpath)
+        const destinationContentAfter = fs.readdirSync(dstpath)
         assert.deepEqual(destinationContentBefore, destinationContentAfter)
         return done()
       }
@@ -245,18 +231,17 @@ describe('fse-ensure-symlink', function () {
   }
 
   function fileSuccessSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create symlink file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create symlink file using src ${srcpath} and dst ${dstpath}`, () => {
       fn.apply(null, args)
-      var relative = symlinkPathsSync(srcpath, dstpath)
-      var srcContent = fs.readFileSync(relative.toCwd, 'utf8')
-      var dstDir = path.dirname(dstpath)
-      var dstBasename = path.basename(dstpath)
-      var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-      var dstContent = fs.readFileSync(dstpath, 'utf8')
-      var dstDirContents = fs.readdirSync(dstDir)
+      const relative = symlinkPathsSync(srcpath, dstpath)
+      const srcContent = fs.readFileSync(relative.toCwd, 'utf8')
+      const dstDir = path.dirname(dstpath)
+      const dstBasename = path.basename(dstpath)
+      const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+      const dstContent = fs.readFileSync(dstpath, 'utf8')
+      const dstDirContents = fs.readdirSync(dstDir)
       assert.equal(isSymlink, true)
       assert.equal(srcContent, dstContent)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -264,66 +249,60 @@ describe('fse-ensure-symlink', function () {
   }
 
   function fileBrokenSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create broken symlink file using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create broken symlink file using src ${srcpath} and dst ${dstpath}`, () => {
       fn.apply(null, args)
-      var dstDir = path.dirname(dstpath)
-      var dstBasename = path.basename(dstpath)
-      var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-      var dstDirContents = fs.readdirSync(dstDir)
+      const dstDir = path.dirname(dstpath)
+      const dstBasename = path.basename(dstpath)
+      const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+      const dstDirContents = fs.readdirSync(dstDir)
       assert.equal(isSymlink, true)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
-      assert.throws(function () {
-        return fs.readFileSync(dstpath, 'utf8')
-      }, Error)
+      assert.throws(() => fs.readFileSync(dstpath, 'utf8'), Error)
     })
   }
 
   function fileErrorSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should throw error using` src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      var err = null
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should throw error using src ${srcpath} and dst ${dstpath}`, () => {
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      let err = null
       try {
         fn.apply(null, args)
       } catch (e) {
         err = e
       }
       assert.equal(err instanceof Error, true)
-      var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+      const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
       assert.equal(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
   function fileDestExistsSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
-      var destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, () => {
+      const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
       fn.apply(null, args)
-      var destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
+      const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
       assert.equal(destinationContentBefore, destinationContentAfter)
     })
   }
 
   function dirSuccessSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create symlink dir using src ${srcpath} and dst ${dstpath}`, () => {
       fn.apply(null, args)
-      var relative = symlinkPathsSync(srcpath, dstpath)
-      var srcContents = fs.readdirSync(relative.toCwd)
-      var dstDir = path.dirname(dstpath)
-      var dstBasename = path.basename(dstpath)
-      var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-      var dstContents = fs.readdirSync(dstpath)
-      var dstDirContents = fs.readdirSync(dstDir)
+      const relative = symlinkPathsSync(srcpath, dstpath)
+      const srcContents = fs.readdirSync(relative.toCwd)
+      const dstDir = path.dirname(dstpath)
+      const dstBasename = path.basename(dstpath)
+      const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+      const dstContents = fs.readdirSync(dstpath)
+      const dstDirContents = fs.readdirSync(dstDir)
       assert.equal(isSymlink, true)
       assert.deepEqual(srcContents, dstContents)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
@@ -331,59 +310,54 @@ describe('fse-ensure-symlink', function () {
   }
 
   function dirBrokenSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should create broken symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should create broken symlink dir using src ${srcpath} and dst ${dstpath}`, () => {
       fn.apply(null, args)
-      var dstDir = path.dirname(dstpath)
-      var dstBasename = path.basename(dstpath)
-      var isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
-      var dstDirContents = fs.readdirSync(dstDir)
+      const dstDir = path.dirname(dstpath)
+      const dstBasename = path.basename(dstpath)
+      const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
+      const dstDirContents = fs.readdirSync(dstDir)
       assert.equal(isSymlink, true)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
-      assert.throws(function () {
-        return fs.readdirSync(dstpath)
-      }, Error)
+      assert.throws(() => fs.readdirSync(dstpath), Error)
     })
   }
 
   function dirErrorSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should throw error when creating symlink dir using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
-      var dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
-      var err = null
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should throw error when creating symlink dir using src ${srcpath} and dst ${dstpath}`, () => {
+      const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
+      let err = null
       try {
         fn.apply(null, args)
       } catch (e) {
         err = e
       }
       assert.equal(err instanceof Error, true)
-      var dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
+      const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
       assert.equal(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
   function dirDestExistsSync (args, fn) {
-    var srcpath = args[0]
-    var dstpath = args[1]
-    var should = util.format('should do nothing using src `%s` and dst `%s`', srcpath, dstpath)
-    it(should, function () {
-      var destinationContentBefore = fs.readdirSync(dstpath)
+    const srcpath = args[0]
+    const dstpath = args[1]
+    it(`should do nothing using src ${srcpath} and dst ${dstpath}`, () => {
+      const destinationContentBefore = fs.readdirSync(dstpath)
       fn.apply(null, args)
-      var destinationContentAfter = fs.readdirSync(dstpath)
+      const destinationContentAfter = fs.readdirSync(dstpath)
       assert.deepEqual(destinationContentBefore, destinationContentAfter)
     })
   }
 
-  describe('fs.symlink()', function () {
-    var fn = fs.symlink
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var nativeBehavior = test[1]
-      // var newBehavior = test[2]
+  describe('fs.symlink()', () => {
+    const fn = fs.symlink
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const nativeBehavior = test[1]
+      // const newBehavior = test[2]
       if (nativeBehavior === 'file-success') fileSuccess(args, fn)
       if (nativeBehavior === 'file-broken') fileBroken(args, fn)
       if (nativeBehavior === 'file-error') fileError(args, fn)
@@ -396,12 +370,12 @@ describe('fse-ensure-symlink', function () {
     })
   })
 
-  describe('ensureSymlink()', function () {
-    var fn = ensureSymlink
-    tests.forEach(function (test) {
-      var args = test[0]
-      // var nativeBehavior = test[1]
-      var newBehavior = test[2]
+  describe('ensureSymlink()', () => {
+    const fn = ensureSymlink
+    tests.forEach(test => {
+      const args = test[0]
+      // const nativeBehavior = test[1]
+      const newBehavior = test[2]
       if (newBehavior === 'file-success') fileSuccess(args, fn)
       if (newBehavior === 'file-broken') fileBroken(args, fn)
       if (newBehavior === 'file-error') fileError(args, fn)
@@ -413,12 +387,12 @@ describe('fse-ensure-symlink', function () {
     })
   })
 
-  describe('fs.symlinkSync()', function () {
-    var fn = fs.symlinkSync
-    tests.forEach(function (test) {
-      var args = test[0].slice(0)
-      var nativeBehavior = test[1]
-      // var newBehavior = test[2]
+  describe('fs.symlinkSync()', () => {
+    const fn = fs.symlinkSync
+    tests.forEach(test => {
+      const args = test[0].slice(0)
+      const nativeBehavior = test[1]
+      // const newBehavior = test[2]
       if (nativeBehavior === 'file-success') fileSuccessSync(args, fn)
       if (nativeBehavior === 'file-broken') fileBrokenSync(args, fn)
       if (nativeBehavior === 'file-error') fileErrorSync(args, fn)
@@ -431,12 +405,12 @@ describe('fse-ensure-symlink', function () {
     })
   })
 
-  describe('ensureSymlinkSync()', function () {
-    var fn = ensureSymlinkSync
-    tests.forEach(function (test) {
-      var args = test[0]
-      // var nativeBehavior = test[1]
-      var newBehavior = test[2]
+  describe('ensureSymlinkSync()', () => {
+    const fn = ensureSymlinkSync
+    tests.forEach(test => {
+      const args = test[0]
+      // const nativeBehavior = test[1]
+      const newBehavior = test[2]
       if (newBehavior === 'file-success') fileSuccessSync(args, fn)
       if (newBehavior === 'file-broken') fileBrokenSync(args, fn)
       if (newBehavior === 'file-error') fileErrorSync(args, fn)

--- a/lib/json/__tests__/jsonfile-integration.test.js
+++ b/lib/json/__tests__/jsonfile-integration.test.js
@@ -1,36 +1,36 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('jsonfile-integration', function () {
-  var TEST_DIR
+describe('jsonfile-integration', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'json')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ writeJsonSync / spaces', function () {
-    it('should read a file and parse the json', function () {
-      var obj1 = {
+  describe('+ writeJsonSync / spaces', () => {
+    it('should read a file and parse the json', () => {
+      const obj1 = {
         firstName: 'JP',
         lastName: 'Richardson'
       }
 
-      var oldSpaces = fse.jsonfile.spaces
+      const oldSpaces = fse.jsonfile.spaces
       fse.jsonfile.spaces = 4
 
-      var file = path.join(TEST_DIR, 'file.json')
+      const file = path.join(TEST_DIR, 'file.json')
       fse.writeJsonSync(file, obj1)
-      var data = fs.readFileSync(file, 'utf8')
+      const data = fs.readFileSync(file, 'utf8')
       assert.strictEqual(data, JSON.stringify(obj1, null, 4) + '\n')
 
       fse.jsonfile.spaces = oldSpaces

--- a/lib/json/__tests__/output-json-sync.test.js
+++ b/lib/json/__tests__/output-json-sync.test.js
@@ -1,45 +1,49 @@
-var assert = require('assert')
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
+const outputJsonSync = require('../output-json-sync')
 
 /* global beforeEach, describe, it */
 
-describe('json', function () {
-  var TEST_DIR
+describe('json', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  describe('+ outputJsonSync(file, data)', function () {
-    var outputJsonSync = require('../output-json-sync')
-
-    it('should write the file regardless of whether the directory exists or not', function () {
-      var file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'file.json')
+  describe('+ outputJsonSync(file, data)', () => {
+    it('should write the file regardless of whether the directory exists or not', () => {
+      const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'file.json')
       assert(!fs.existsSync(file))
 
-      var data = {name: 'JP'}
+      const data = {name: 'JP'}
       outputJsonSync(file, data)
 
       assert(fs.existsSync(file))
-      var newData = JSON.parse(fs.readFileSync(file, 'utf8'))
+      const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
       assert.equal(data.name, newData.name)
     })
 
-    describe('> when an option is passed, like JSON replacer', function () {
-      it('should pass the option along to jsonfile module', function () {
-        var file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
+    describe('> when an option is passed, like JSON replacer', () => {
+      it('should pass the option along to jsonfile module', () => {
+        const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
         assert(!fs.existsSync(file))
 
-        var replacer = function (k, v) { if (v === 'JP') return 'Jon Paul'; else return v }
-        var data = {name: 'JP'}
+        const replacer = (k, v) => {
+          if (v === 'JP') return 'Jon Paul'
+          return v
+        }
+        const data = {name: 'JP'}
 
-        outputJsonSync(file, data, {replacer: replacer})
-        var newData = JSON.parse(fs.readFileSync(file, 'utf8'))
+        outputJsonSync(file, data, { replacer })
+        const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
         assert.equal(newData.name, 'Jon Paul')
       })

--- a/lib/json/__tests__/output-json-sync.test.js
+++ b/lib/json/__tests__/output-json-sync.test.js
@@ -36,10 +36,7 @@ describe('json', () => {
         const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
         assert(!fs.existsSync(file))
 
-        const replacer = (k, v) => {
-          if (v === 'JP') return 'Jon Paul'
-          return v
-        }
+        const replacer = (k, v) => v === 'JP' ? 'Jon Paul' : v
         const data = {name: 'JP'}
 
         outputJsonSync(file, data, { replacer })

--- a/lib/json/__tests__/output-json.test.js
+++ b/lib/json/__tests__/output-json.test.js
@@ -1,49 +1,53 @@
-var assert = require('assert')
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
+const outputJson = require('../output-json')
 
 /* global beforeEach, describe, it */
 
-describe('json', function () {
-  var TEST_DIR
+describe('json', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  describe('+ outputJson(file, data)', function () {
-    var outputJson = require('../output-json')
-
-    it('should write the file regardless of whether the directory exists or not', function (done) {
-      var file = path.join(TEST_DIR, 'this-dir', 'prob-does-not', 'exist', 'file.json')
+  describe('+ outputJson(file, data)', () => {
+    it('should write the file regardless of whether the directory exists or not', done => {
+      const file = path.join(TEST_DIR, 'this-dir', 'prob-does-not', 'exist', 'file.json')
       assert(!fs.existsSync(file))
 
-      var data = {name: 'JP'}
-      outputJson(file, data, function (err) {
+      const data = {name: 'JP'}
+      outputJson(file, data, err => {
         if (err) return done(err)
 
         assert(fs.existsSync(file))
-        var newData = JSON.parse(fs.readFileSync(file, 'utf8'))
+        const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
         assert.equal(data.name, newData.name)
         done()
       })
     })
 
-    describe('> when an option is passed, like JSON replacer', function () {
-      it('should pass the option along to jsonfile module', function (done) {
-        var file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
+    describe('> when an option is passed, like JSON replacer', () => {
+      it('should pass the option along to jsonfile module', done => {
+        const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
         assert(!fs.existsSync(file))
 
-        var replacer = function (k, v) { if (v === 'JP') return 'Jon Paul'; else return v }
-        var data = {name: 'JP'}
+        const replacer = (k, v) => {
+          if (v === 'JP') return 'Jon Paul'
+          return v
+        }
+        const data = {name: 'JP'}
 
-        outputJson(file, data, {replacer: replacer}, function (err) {
+        outputJson(file, data, { replacer }, err => {
           assert.ifError(err)
-          var newData = JSON.parse(fs.readFileSync(file, 'utf8'))
+          const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
           assert.equal(newData.name, 'Jon Paul')
           done()
         })

--- a/lib/json/__tests__/output-json.test.js
+++ b/lib/json/__tests__/output-json.test.js
@@ -39,10 +39,7 @@ describe('json', () => {
         const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'really', 'file.json')
         assert(!fs.existsSync(file))
 
-        const replacer = (k, v) => {
-          if (v === 'JP') return 'Jon Paul'
-          return v
-        }
+        const replacer = (k, v) => v === 'JP' ? 'Jon Paul' : v
         const data = {name: 'JP'}
 
         outputJson(file, data, { replacer }, err => {

--- a/lib/json/__tests__/read.test.js
+++ b/lib/json/__tests__/read.test.js
@@ -1,45 +1,44 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('read', function () {
-  var TEST_DIR
+describe('read', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'read-json')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ readJSON', function () {
-    it('should read a file and parse the json', function (done) {
-      var obj1 = {
+  describe('+ readJSON', () => {
+    it('should read a file and parse the json', done => {
+      const obj1 = {
         firstName: 'JP',
         lastName: 'Richardson'
       }
 
-      var file = path.join(TEST_DIR, 'file.json')
+      const file = path.join(TEST_DIR, 'file.json')
       fs.writeFileSync(file, JSON.stringify(obj1))
-      fse.readJSON(file, function (err, obj2) {
+      fse.readJSON(file, (err, obj2) => {
         assert.ifError(err)
         assert.strictEqual(obj1.firstName, obj2.firstName)
         assert.strictEqual(obj1.lastName, obj2.lastName)
-
         done()
       })
     })
 
-    it('should error if it cant parse the json', function (done) {
-      var file = path.join(TEST_DIR, 'file2.json')
+    it('should error if it cant parse the json', done => {
+      const file = path.join(TEST_DIR, 'file2.json')
       fs.writeFileSync(file, '%asdfasdff444')
-      fse.readJSON(file, function (err, obj) {
+      fse.readJSON(file, (err, obj) => {
         assert(err)
         assert(!obj)
         done()

--- a/lib/json/__tests__/spaces.test.js
+++ b/lib/json/__tests__/spaces.test.js
@@ -1,34 +1,34 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require('../../')
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 // trinity: mocha
 
-describe('json spaces', function () {
-  var TEST_DIR
+describe('json spaces', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'json-spaces')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should write out the file with appropriate spacing (2)', function () {
+  it('should write out the file with appropriate spacing (2)', () => {
     fse.spaces = 2 // for legacy compatibility
     assert.strictEqual(fse.spaces, 2)
 
-    var tempFile = path.join(TEST_DIR, 'temp.json')
+    const tempFile = path.join(TEST_DIR, 'temp.json')
 
-    var data = { first: 'JP', last: 'Richardson' }
+    const data = { first: 'JP', last: 'Richardson' }
     fse.outputJsonSync(tempFile, data)
 
-    var dataRead = fs.readFileSync(tempFile, 'utf8')
+    const dataRead = fs.readFileSync(tempFile, 'utf8')
     assert.strictEqual(dataRead, JSON.stringify(data, null, 2) + '\n')
   })
 })

--- a/lib/output/__tests__/output.test.js
+++ b/lib/output/__tests__/output.test.js
@@ -1,29 +1,29 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('output', function () {
-  var TEST_DIR
+describe('output', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'output')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ outputFile', function () {
-    describe('> when the file and directory does not exist', function () {
-      it('should create the file', function (done) {
-        var file = path.join(TEST_DIR, Math.random() + 't-ne', Math.random() + '.txt')
+  describe('+ outputFile', () => {
+    describe('> when the file and directory does not exist', () => {
+      it('should create the file', done => {
+        const file = path.join(TEST_DIR, Math.random() + 't-ne', Math.random() + '.txt')
         assert(!fs.existsSync(file))
-        fse.outputFile(file, 'hi jp', function (err) {
+        fse.outputFile(file, 'hi jp', err => {
           assert.ifError(err)
           assert(fs.existsSync(file))
           assert.equal(fs.readFileSync(file, 'utf8'), 'hi jp')
@@ -32,12 +32,12 @@ describe('output', function () {
       })
     })
 
-    describe('> when the file does exist', function () {
-      it('should still modify the file', function (done) {
-        var file = path.join(TEST_DIR, Math.random() + 't-e', Math.random() + '.txt')
+    describe('> when the file does exist', () => {
+      it('should still modify the file', done => {
+        const file = path.join(TEST_DIR, Math.random() + 't-e', Math.random() + '.txt')
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
-        fse.outputFile(file, 'hello jp', function (err) {
+        fse.outputFile(file, 'hello jp', err => {
           if (err) return done(err)
           assert.equal(fs.readFileSync(file, 'utf8'), 'hello jp')
           done()
@@ -46,10 +46,10 @@ describe('output', function () {
     })
   })
 
-  describe('+ outputFileSync', function () {
-    describe('> when the file and directory does not exist', function () {
-      it('should create the file', function () {
-        var file = path.join(TEST_DIR, Math.random() + 'ts-ne', Math.random() + '.txt')
+  describe('+ outputFileSync', () => {
+    describe('> when the file and directory does not exist', () => {
+      it('should create the file', () => {
+        const file = path.join(TEST_DIR, Math.random() + 'ts-ne', Math.random() + '.txt')
         assert(!fs.existsSync(file))
         fse.outputFileSync(file, 'hello man')
         assert(fs.existsSync(file))
@@ -57,9 +57,9 @@ describe('output', function () {
       })
     })
 
-    describe('> when the file does exist', function () {
-      it('should still modify the file', function () {
-        var file = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
+    describe('> when the file does exist', () => {
+      it('should still modify the file', () => {
+        const file = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
         fse.outputFileSync(file, 'hello man')

--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -1,22 +1,20 @@
-var assert = require('assert')
-var path = require('path')
-var os = require('os')
-var fs = require('fs')
-var fse = require(process.cwd())
-var semver = require('semver')
-var proxyquire = require('proxyquire')
-var gracefulFsStub
-var utimes
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
+const proxyquire = require('proxyquire')
+let gracefulFsStub
+let utimes
 
 /* global beforeEach, describe, it */
 
-describe('utimes', function () {
-  var TEST_DIR
+describe('utimes', () => {
+  let TEST_DIR
 
-  // ignore Node.js v0.10.x
-  if (semver.lt(process.version, '0.11.0')) return
-
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'utimes')
     fse.emptyDir(TEST_DIR, done)
     // reset stubs
@@ -24,54 +22,48 @@ describe('utimes', function () {
     utimes = proxyquire('../utimes', {'graceful-fs': gracefulFsStub})
   })
 
-  describe('hasMillisResSync()', function () {
-    it('should return a boolean indicating whether it has support', function () {
-      var res = utimes.hasMillisResSync()
+  describe('hasMillisResSync()', () => {
+    it('should return a boolean indicating whether it has support', () => {
+      const res = utimes.hasMillisResSync()
       assert.equal(typeof res, 'boolean')
 
       // HFS => false
-      if (process.platform === 'darwin') {
-        assert.equal(res, false)
-      }
+      if (process.platform === 'darwin') assert.equal(res, false)
 
       // does anyone use FAT anymore?
-      /* if (process.platform === 'win32') {
-        assert.equal(res, true)
-      } */
+      // if (process.platform === 'win32') assert.equal(res, true)
       // fails on appveyor... could appveyor be using FAT?
 
       // this would fail if ext2/ext3
-      if (process.platform === 'linux') {
-        assert.equal(res, true)
-      }
+      if (process.platform === 'linux') assert.equal(res, true)
     })
   })
 
-  describe('timeRemoveMills()', function () {
-    it('should remove millisecond precision from a timestamp', function () {
-      var ts = 1334990868773
-      var ets = 1334990868000
+  describe('timeRemoveMills()', () => {
+    it('should remove millisecond precision from a timestamp', () => {
+      const ts = 1334990868773
+      const ets = 1334990868000
       assert.strictEqual(utimes.timeRemoveMillis(ts), ets)
       assert.strictEqual(utimes.timeRemoveMillis(new Date(ts)).getTime(), ets)
     })
   })
 
-  describe('utimesMillis()', function () {
+  describe('utimesMillis()', () => {
     // see discussion https://github.com/jprichardson/node-fs-extra/pull/141
-    it('should set the utimes w/ millisecond precision', function (done) {
-      var tmpFile = path.join(TEST_DIR, 'someFile')
+    it('should set the utimes w/ millisecond precision', done => {
+      const tmpFile = path.join(TEST_DIR, 'someFile')
       fs.writeFileSync(tmpFile, 'hello')
 
-      var stats = fs.lstatSync(tmpFile)
+      let stats = fs.lstatSync(tmpFile)
 
       // Apr 21st, 2012
-      var awhileAgo = new Date(1334990868773)
-      var awhileAgoNoMillis = new Date(1334990868000)
+      const awhileAgo = new Date(1334990868773)
+      const awhileAgoNoMillis = new Date(1334990868000)
 
       assert.notDeepEqual(stats.mtime, awhileAgo)
       assert.notDeepEqual(stats.atime, awhileAgo)
 
-      utimes.utimesMillis(tmpFile, awhileAgo, awhileAgo, function (err) {
+      utimes.utimesMillis(tmpFile, awhileAgo, awhileAgo, err => {
         assert.ifError(err)
         stats = fs.statSync(tmpFile)
         if (utimes.hasMillisResSync()) {
@@ -85,34 +77,30 @@ describe('utimes', function () {
       })
     })
 
-    it('should close open file desciptors after encountering an error', function (done) {
-      var fakeFd = Math.random()
+    it('should close open file desciptors after encountering an error', done => {
+      const fakeFd = Math.random()
 
-      gracefulFsStub.open = function (pathIgnored, flagsIgnored, modeIgnored, callback) {
-        if (typeof modeIgnored === 'function') {
-          callback = modeIgnored
-        }
-        process.nextTick(function () {
-          callback(null, fakeFd)
-        })
+      gracefulFsStub.open = (pathIgnored, flagsIgnored, modeIgnored, callback) => {
+        if (typeof modeIgnored === 'function') callback = modeIgnored
+        process.nextTick(() => callback(null, fakeFd))
       }
 
-      var closeCalled = false
-      gracefulFsStub.close = function (fd, callback) {
+      let closeCalled = false
+      gracefulFsStub.close = (fd, callback) => {
         assert.equal(fd, fakeFd)
         closeCalled = true
         if (callback) process.nextTick(callback)
       }
 
-      var testError
-      gracefulFsStub.futimes = function (fd, atimeIgnored, mtimeIgnored, callback) {
-        process.nextTick(function () {
+      let testError
+      gracefulFsStub.futimes = (fd, atimeIgnored, mtimeIgnored, callback) => {
+        process.nextTick(() => {
           testError = new Error('A test error')
           callback(testError)
         })
       }
 
-      utimes.utimesMillis('ignored', 'ignored', 'ignored', function (err) {
+      utimes.utimesMillis('ignored', 'ignored', 'ignored', err => {
         assert.equal(err, testError)
         assert(closeCalled)
         done()

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "read-dir-files": "^0.1.1",
     "rimraf": "^2.2.8",
     "secure-random": "^1.1.1",
-    "semver": "^5.3.0",
     "standard": "^8.5.0"
   },
   "main": "./lib/index",


### PR DESCRIPTION
(#355)
In commit https://github.com/jprichardson/node-fs-extra/commit/55aadcf1f1871200535c349e82e33c4b55c3337f I removed `semver`, as dependency as it was just used to ignore Node v0.10.  