### PR TITLE
Refactor tests to ES6

### DIFF
--- a/lib/mkdirs/__tests__/chmod.test.js
+++ b/lib/mkdirs/__tests__/chmod.test.js
@@ -1,24 +1,26 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require('../../')
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o744 = parseInt('744', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o744 = parseInt('744', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / chmod', function () {
-  var TEST_DIR
-  var TEST_SUBDIR
+describe('mkdirp / chmod', () => {
+  let TEST_DIR
+  let TEST_SUBDIR
 
-  beforeEach(function (done) {
-    var ps = []
-    for (var i = 0; i < 15; i++) {
-      var dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+  beforeEach(done => {
+    const ps = []
+    for (let i = 0; i < 15; i++) {
+      const dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
       ps.push(dir)
     }
 
@@ -30,16 +32,14 @@ describe('mkdirp / chmod', function () {
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('chmod-pre', function (done) {
-    var mode = o744
-    fse.mkdirp(TEST_SUBDIR, mode, function (er) {
-      assert.ifError(er, 'should not error')
-      fs.stat(TEST_SUBDIR, function (er, stat) {
-        assert.ifError(er, 'should exist')
+  it('chmod-pre', done => {
+    const mode = o744
+    fse.mkdirp(TEST_SUBDIR, mode, err => {
+      assert.ifError(err, 'should not error')
+      fs.stat(TEST_SUBDIR, (err, stat) => {
+        assert.ifError(err, 'should exist')
         assert.ok(stat && stat.isDirectory(), 'should be directory')
 
         if (os.platform().indexOf('win') === 0) {
@@ -53,12 +53,12 @@ describe('mkdirp / chmod', function () {
     })
   })
 
-  it('chmod', function (done) {
-    var mode = o755
-    fse.mkdirp(TEST_SUBDIR, mode, function (er) {
-      assert.ifError(er, 'should not error')
-      fs.stat(TEST_SUBDIR, function (er, stat) {
-        assert.ifError(er, 'should exist')
+  it('chmod', done => {
+    const mode = o755
+    fse.mkdirp(TEST_SUBDIR, mode, err => {
+      assert.ifError(err, 'should not error')
+      fs.stat(TEST_SUBDIR, (err, stat) => {
+        assert.ifError(err, 'should exist')
         assert.ok(stat && stat.isDirectory(), 'should be directory')
         done()
       })

--- a/lib/mkdirs/__tests__/clobber.test.js
+++ b/lib/mkdirs/__tests__/clobber.test.js
@@ -1,46 +1,48 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global before, describe, it */
 
-var o755 = parseInt('755', 8)
+const o755 = parseInt('755', 8)
 
-describe('mkdirp / clobber', function () {
-  var TEST_DIR
-  var file
+describe('mkdirp / clobber', () => {
+  let TEST_DIR
+  let file
 
-  before(function (done) {
+  before(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-clobber')
-    fse.emptyDir(TEST_DIR, function (err) {
+    fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      var ps = [TEST_DIR]
+      const ps = [ TEST_DIR ]
 
-      for (var i = 0; i < 15; i++) {
-        var dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      for (let i = 0; i < 15; i++) {
+        const dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
         ps.push(dir)
       }
 
       file = ps.join(path.sep)
 
       // a file in the way
-      var itw = ps.slice(0, 2).join(path.sep)
+      const itw = ps.slice(0, 2).join(path.sep)
 
       fs.writeFileSync(itw, 'I AM IN THE WAY, THE TRUTH, AND THE LIGHT.')
 
-      fs.stat(itw, function (er, stat) {
-        assert.ifError(er)
+      fs.stat(itw, (err, stat) => {
+        assert.ifError(err)
         assert.ok(stat && stat.isFile(), 'should be file')
         done()
       })
     })
   })
 
-  it('should clobber', function (done) {
-    fse.mkdirp(file, o755, function (err) {
+  it('should clobber', done => {
+    fse.mkdirp(file, o755, err => {
       assert.ok(err)
       if (os.platform().indexOf('win') === 0) {
         assert.equal(err.code, 'EEXIST')

--- a/lib/mkdirs/__tests__/issue-209.test.js
+++ b/lib/mkdirs/__tests__/issue-209.test.js
@@ -1,20 +1,22 @@
-var assert = require('assert')
-var fse = require(process.cwd())
+'use strict'
+
+const assert = require('assert')
+const fse = require(process.cwd())
 
 /* global describe, it */
 
-describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error', function () {
+describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error', () => {
   // only seems to be an issue on Windows.
   if (process.platform !== 'win32') return
 
-  it('should return a callback', function (done) {
-    var file = './bad?dir'
-    fse.mkdirp(file, function (err) {
+  it('should return a callback', done => {
+    const file = './bad?dir'
+    fse.mkdirp(file, err => {
       assert(err, 'error is present')
       assert.strictEqual(err.code, 'EINVAL')
 
-      var file2 = 'c:\\tmp\foo:moo'
-      fse.mkdirp(file2, function (err) {
+      const file2 = 'c:\\tmp\foo:moo'
+      fse.mkdirp(file2, err => {
         assert(err, 'error is present')
         assert.strictEqual(err.code, 'EINVAL')
         done()
@@ -22,11 +24,11 @@ describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error
     })
   })
 
-  describe('> sync', function () {
-    it('should throw an error', function () {
-      var didErr
+  describe('> sync', () => {
+    it('should throw an error', () => {
+      let didErr
       try {
-        var file = 'c:\\tmp\foo:moo'
+        const file = 'c:\\tmp\foo:moo'
         fse.mkdirpSync(file)
       } catch (err) {
         // console.error(err)

--- a/lib/mkdirs/__tests__/issue-93.test.js
+++ b/lib/mkdirs/__tests__/issue-93.test.js
@@ -1,27 +1,29 @@
-var assert = require('assert')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global before, describe, it */
 
-describe('mkdirp: issue-93, win32, when drive does not exist, it should return a cleaner error', function () {
-  var TEST_DIR
+describe('mkdirp: issue-93, win32, when drive does not exist, it should return a cleaner error', () => {
+  let TEST_DIR
 
   // only seems to be an issue on Windows.
   if (process.platform !== 'win32') return
 
-  before(function (done) {
+  before(done => {
     TEST_DIR = path.join(os.tmpdir(), 'tests', 'fs-extra', 'mkdirp-issue-93')
-    fse.emptyDir(TEST_DIR, function (err) {
+    fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
       done()
     })
   })
 
-  it('should return a cleaner error than inifinite loop, stack crash', function (done) {
-    var file = 'R:\\afasd\\afaff\\fdfd' // hopefully drive 'r' does not exist on appveyor
-    fse.mkdirp(file, function (err) {
+  it('should return a cleaner error than inifinite loop, stack crash', done => {
+    const file = 'R:\\afasd\\afaff\\fdfd' // hopefully drive 'r' does not exist on appveyor
+    fse.mkdirp(file, err => {
       assert.strictEqual(err.code, 'ENOENT')
 
       try {

--- a/lib/mkdirs/__tests__/mkdir.test.js
+++ b/lib/mkdirs/__tests__/mkdir.test.js
@@ -1,43 +1,43 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('fs-extra', function () {
-  var TEST_DIR
+describe('fs-extra', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdir')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ mkdirs()', function () {
-    it('should make the directory', function (done) {
-      var dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
+  describe('+ mkdirs()', () => {
+    it('should make the directory', done => {
+      const dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
 
       assert(!fs.existsSync(dir))
 
-      fse.mkdirs(dir, function (err) {
+      fse.mkdirs(dir, err => {
         assert.ifError(err)
         assert(fs.existsSync(dir))
         done()
       })
     })
 
-    it('should make the entire directory path', function (done) {
-      var dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
-      var newDir = path.join(TEST_DIR, 'dfdf', 'ffff', 'aaa')
+    it('should make the entire directory path', done => {
+      const dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
+      const newDir = path.join(TEST_DIR, 'dfdf', 'ffff', 'aaa')
 
       assert(!fs.existsSync(dir))
 
-      fse.mkdirs(newDir, function (err) {
+      fse.mkdirs(newDir, err => {
         assert.ifError(err)
         assert(fs.existsSync(newDir))
         done()
@@ -45,9 +45,9 @@ describe('fs-extra', function () {
     })
   })
 
-  describe('+ mkdirsSync()', function () {
-    it('should make the directory', function (done) {
-      var dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
+  describe('+ mkdirsSync()', () => {
+    it('should make the directory', done => {
+      const dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
 
       assert(!fs.existsSync(dir))
       fse.mkdirsSync(dir)
@@ -56,9 +56,9 @@ describe('fs-extra', function () {
       done()
     })
 
-    it('should make the entire directory path', function (done) {
-      var dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
-      var newDir = path.join(dir, 'dfdf', 'ffff', 'aaa')
+    it('should make the entire directory path', done => {
+      const dir = path.join(TEST_DIR, 'tmp-' + Date.now() + Math.random())
+      const newDir = path.join(dir, 'dfdf', 'ffff', 'aaa')
 
       assert(!fs.existsSync(newDir))
       fse.mkdirsSync(newDir)

--- a/lib/mkdirs/__tests__/mkdirp.test.js
+++ b/lib/mkdirs/__tests__/mkdirp.test.js
@@ -1,39 +1,39 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / mkdirp', function () {
-  var TEST_DIR
+describe('mkdirp / mkdirp', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should make the dir', function (done) {
-    var x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+  it('should make the dir', done => {
+    const x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
 
-    var file = path.join(TEST_DIR, x, y, z)
+    const file = path.join(TEST_DIR, x, y, z)
 
-    fse.mkdirp(file, o755, function (err) {
+    fse.mkdirp(file, o755, err => {
       assert.ifError(err)
-      fs.exists(file, function (ex) {
+      fs.exists(file, ex => {
         assert.ok(ex, 'file created')
-        fs.stat(file, function (err, stat) {
+        fs.stat(file, (err, stat) => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {

--- a/lib/mkdirs/__tests__/opts-undef.test.js
+++ b/lib/mkdirs/__tests__/opts-undef.test.js
@@ -1,26 +1,28 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
-var mkdirs = require('../mkdirs')
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
+const mkdirs = require('../mkdirs')
 
 /* global beforeEach, describe, it */
 
-describe('mkdirs / opts-undef', function () {
-  var TEST_DIR
+describe('mkdirs / opts-undef', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirs')
     fse.emptyDir(TEST_DIR, done)
   })
 
   // https://github.com/substack/node-mkdirp/issues/45
-  it('should not hang', function (done) {
-    var newDir = path.join(TEST_DIR, 'doest', 'not', 'exist')
+  it('should not hang', done => {
+    const newDir = path.join(TEST_DIR, 'doest', 'not', 'exist')
     assert(!fs.existsSync(newDir))
 
-    mkdirs(newDir, undefined, function (err) {
+    mkdirs(newDir, undefined, err => {
       assert.ifError(err)
       assert(fs.existsSync(newDir))
       done()

--- a/lib/mkdirs/__tests__/perm.test.js
+++ b/lib/mkdirs/__tests__/perm.test.js
@@ -1,35 +1,35 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require('../../')
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / perm', function () {
-  var TEST_DIR
+describe('mkdirp / perm', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-perm')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('async perm', function (done) {
-    var file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16))
+  it('async perm', done => {
+    let file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16))
 
-    fse.mkdirp(file, o755, function (err) {
+    fse.mkdirp(file, o755, err => {
       assert.ifError(err)
-      fs.exists(file, function (ex) {
+      fs.exists(file, ex => {
         assert.ok(ex, 'file created')
-        fs.stat(file, function (err, stat) {
+        fs.stat(file, (err, stat) => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {
@@ -45,8 +45,8 @@ describe('mkdirp / perm', function () {
     })
   })
 
-  it('async root perm', function (done) {
-    fse.mkdirp(path.join(os.tmpdir(), 'tmp'), o755, function (err) {
+  it('async root perm', done => {
+    fse.mkdirp(path.join(os.tmpdir(), 'tmp'), o755, err => {
       assert.ifError(err)
       done()
     })

--- a/lib/mkdirs/__tests__/perm_sync.test.js
+++ b/lib/mkdirs/__tests__/perm_sync.test.js
@@ -1,34 +1,34 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / perm_sync', function () {
-  var TEST_DIR
+describe('mkdirp / perm_sync', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-perm-sync')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('sync perm', function (done) {
-    var file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16) + '.json')
+  it('sync perm', done => {
+    const file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16) + '.json')
 
     fse.mkdirpSync(file, o755)
-    fs.exists(file, function (ex) {
+    fs.exists(file, ex => {
       assert.ok(ex, 'file created')
-      fs.stat(file, function (err, stat) {
+      fs.stat(file, (err, stat) => {
         assert.ifError(err)
 
         if (os.platform().indexOf('win') === 0) {
@@ -43,12 +43,12 @@ describe('mkdirp / perm_sync', function () {
     })
   })
 
-  it('sync root perm', function (done) {
-    var file = TEST_DIR
+  it('sync root perm', done => {
+    const file = TEST_DIR
     fse.mkdirpSync(file, o755)
-    fs.exists(file, function (ex) {
+    fs.exists(file, ex => {
       assert.ok(ex, 'file created')
-      fs.stat(file, function (err, stat) {
+      fs.stat(file, (err, stat) => {
         assert.ifError(err)
         assert.ok(stat.isDirectory(), 'target not a directory')
         done()

--- a/lib/mkdirs/__tests__/race.test.js
+++ b/lib/mkdirs/__tests__/race.test.js
@@ -1,27 +1,30 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / race', function () {
-  var TEST_DIR, file
+describe('mkdirp / race', () => {
+  let TEST_DIR
+  let file
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-race')
-    fse.emptyDir(TEST_DIR, function (err) {
+    fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      var ps = [TEST_DIR]
+      const ps = [ TEST_DIR ]
 
-      for (var i = 0; i < 15; i++) {
-        var dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      for (let i = 0; i < 15; i++) {
+        const dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
         ps.push(dir)
       }
 
@@ -30,26 +33,20 @@ describe('mkdirp / race', function () {
     })
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('race', function (done) {
-    var res = 2
-    mk(file, function () {
-      if (--res === 0) done()
-    })
+  it('race', done => {
+    let res = 2
 
-    mk(file, function () {
-      if (--res === 0) done()
-    })
+    mk(file, () => --res === 0 ? done() : undefined)
+    mk(file, () => --res === 0 ? done() : undefined)
 
     function mk (file, callback) {
-      fse.mkdirp(file, o755, function (err) {
+      fse.mkdirp(file, o755, err => {
         assert.ifError(err)
-        fs.exists(file, function (ex) {
+        fs.exists(file, ex => {
           assert.ok(ex, 'file created')
-          fs.stat(file, function (err, stat) {
+          fs.stat(file, (err, stat) => {
             assert.ifError(err)
 
             if (os.platform().indexOf('win') === 0) {

--- a/lib/mkdirs/__tests__/rel.test.js
+++ b/lib/mkdirs/__tests__/rel.test.js
@@ -1,26 +1,31 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const CWD = process.cwd()
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(CWD)
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / relative', function () {
-  var TEST_DIR, file
+describe('mkdirp / relative', () => {
+  let TEST_DIR
+  let file
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-relative')
-    fse.emptyDir(TEST_DIR, function (err) {
+    fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      var x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-      var y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-      var z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
 
       // relative path
       file = path.join(x, y, z)
@@ -29,22 +34,19 @@ describe('mkdirp / relative', function () {
     })
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should make the directory with relative path', function (done) {
-    var cwd = process.cwd()
+  it('should make the directory with relative path', done => {
     process.chdir(TEST_DIR)
 
-    fse.mkdirp(file, o755, function (err) {
+    fse.mkdirp(file, o755, err => {
       assert.ifError(err)
-      fs.exists(file, function (ex) {
+      fs.exists(file, ex => {
         assert.ok(ex, 'file created')
-        fs.stat(file, function (err, stat) {
+        fs.stat(file, (err, stat) => {
           assert.ifError(err)
           // restore
-          process.chdir(cwd)
+          process.chdir(CWD)
 
           if (os.platform().indexOf('win') === 0) {
             assert.equal(stat.mode & o777, o666)

--- a/lib/mkdirs/__tests__/return.test.js
+++ b/lib/mkdirs/__tests__/return.test.js
@@ -1,37 +1,37 @@
-var assert = require('assert')
-var os = require('os')
-var path = require('path')
-var fse = require('../../')
+'use strict'
+
+const os = require('os')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('mkdirp / return value', function () {
-  var TEST_DIR
+describe('mkdirp / return value', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-return')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should', function (done) {
-    var x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+  it('should', done => {
+    const x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
 
-    var dir = TEST_DIR + path.sep
-    var file = dir + [x, y, z].join(path.sep)
+    const dir = TEST_DIR + path.sep
+    const file = dir + [x, y, z].join(path.sep)
 
     // should return the first dir created.
     // By this point, it would be profoundly surprising if /tmp didn't
     // already exist, since every other test makes things in there.
-    fse.mkdirp(file, function (err, made) {
+    fse.mkdirp(file, (err, made) => {
       assert.ifError(err)
       assert.equal(made, dir + x)
-      fse.mkdirp(file, function (err, made) {
+      fse.mkdirp(file, (err, made) => {
         assert.ifError(err)
         assert.equal(made, null)
         done()

--- a/lib/mkdirs/__tests__/return_sync.test.js
+++ b/lib/mkdirs/__tests__/return_sync.test.js
@@ -1,35 +1,35 @@
-var assert = require('assert')
-var os = require('os')
-var path = require('path')
-var fse = require('../../')
+'use strict'
+
+const os = require('os')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-describe('mkdirp / return value', function () {
-  var TEST_DIR
+describe('mkdirp / return value', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-return')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should', function () {
-    var x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-    var z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+  it('should', () => {
+    const x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+    const z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
 
-    var dir = TEST_DIR + path.sep
-    var file = dir + [x, y, z].join(path.sep)
+    const dir = TEST_DIR + path.sep
+    const file = dir + [x, y, z].join(path.sep)
 
     // should return the first dir created.
     // By this point, it would be profoundly surprising if /tmp didn't
     // already exist, since every other test makes things in there.
     // Note that this will throw on failure, which will fail the test.
-    var made = fse.mkdirpSync(file)
+    let made = fse.mkdirpSync(file)
     assert.equal(made, dir + x)
 
     // making the same file again should have no effect.

--- a/lib/mkdirs/__tests__/root.test.js
+++ b/lib/mkdirs/__tests__/root.test.js
@@ -1,23 +1,25 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var fse = require('../../')
+'use strict'
+
+const fs = require('fs')
+const fse = require('../../')
+const path = require('path')
+const assert = require('assert')
 
 /* global describe, it */
 
-var o755 = parseInt('755', 8)
+const o755 = parseInt('755', 8)
 
-describe('mkdirp / root', function () {
+describe('mkdirp / root', () => {
   // '/' on unix, 'c:/' on windows.
-  var dir = path.normalize(path.resolve(path.sep)).toLowerCase()
+  const dir = path.normalize(path.resolve(path.sep)).toLowerCase()
 
   // if not 'c:\\' or 'd:\\', it's probably a network mounted drive, this fails then. TODO: investigate
   if (process.platform === 'win32' && (dir.indexOf('c:\\') === -1) && (dir.indexOf('d:\\') === -1)) return
 
-  it('should', function (done) {
-    fse.mkdirp(dir, o755, function (err) {
+  it('should', done => {
+    fse.mkdirp(dir, o755, err => {
       if (err) throw err
-      fs.stat(dir, function (er, stat) {
+      fs.stat(dir, (er, stat) => {
         if (er) throw er
         assert.ok(stat.isDirectory(), 'target is a directory')
         done()

--- a/lib/mkdirs/__tests__/sync.test.js
+++ b/lib/mkdirs/__tests__/sync.test.js
@@ -1,26 +1,29 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o755 = parseInt('755', 8)
-var o777 = parseInt('777', 8)
-var o666 = parseInt('666', 8)
+const o755 = parseInt('755', 8)
+const o777 = parseInt('777', 8)
+const o666 = parseInt('666', 8)
 
-describe('mkdirp / sync', function () {
-  var TEST_DIR, file
+describe('mkdirp / sync', () => {
+  let TEST_DIR
+  let file
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'mkdirp-sync')
-    fse.emptyDir(TEST_DIR, function (err) {
+    fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      var x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-      var y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
-      var z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const x = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const y = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
+      const z = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)
 
       file = path.join(TEST_DIR, x, y, z)
 
@@ -28,20 +31,18 @@ describe('mkdirp / sync', function () {
     })
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should', function (done) {
+  it('should', done => {
     try {
       fse.mkdirpSync(file, o755)
     } catch (err) {
       assert.fail(err)
     }
 
-    fs.exists(file, function (ex) {
+    fs.exists(file, ex => {
       assert.ok(ex, 'file created')
-      fs.stat(file, function (err, stat) {
+      fs.stat(file, (err, stat) => {
         assert.ifError(err)
         // http://stackoverflow.com/questions/592448/c-how-to-set-file-permissions-cross-platform
         if (os.platform().indexOf('win') === 0) {

--- a/lib/mkdirs/__tests__/umask.test.js
+++ b/lib/mkdirs/__tests__/umask.test.js
@@ -1,27 +1,29 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require('../../')
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const path = require('path')
+const os = require('os')
+const fse = require('../../')
 
 /* global afterEach, beforeEach, describe, it */
 
-var o777 = parseInt('777', 8)
+const o777 = parseInt('777', 8)
 
-describe('mkdirp', function () {
-  var TEST_DIR
-  var _rndDir
+describe('mkdirp', () => {
+  let TEST_DIR
+  let _rndDir
 
   // should investigate this test and file more
   if (os.platform().indexOf('win') === 0) return
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'mkdirp')
-    fse.emptyDir(TEST_DIR, function () {
+    fse.emptyDir(TEST_DIR, () => {
       // for actual tests
-      var x = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
-      var y = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
-      var z = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
+      const x = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
+      const y = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
+      const z = Math.floor(Math.random() * Math.pow(16, 6)).toString(16)
 
       _rndDir = path.join(TEST_DIR, [x, y, z].join(path.sep))
 
@@ -31,20 +33,18 @@ describe('mkdirp', function () {
     })
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('umask', function () {
-    describe('async', function () {
-      it('should have proper umask', function (done) {
+  describe('umask', () => {
+    describe('async', () => {
+      it('should have proper umask', done => {
         process.umask(0)
 
-        fse.mkdirp(_rndDir, function (err) {
+        fse.mkdirp(_rndDir, err => {
           assert.ifError(err)
-          fs.exists(_rndDir, function (ex) {
+          fs.exists(_rndDir, ex => {
             assert.ok(ex, 'file created')
-            fs.stat(_rndDir, function (err, stat) {
+            fs.stat(_rndDir, (err, stat) => {
               assert.ifError(err)
               assert.equal(stat.mode & o777, o777 & (~process.umask()))
               assert.ok(stat.isDirectory(), 'target not a directory')
@@ -55,8 +55,8 @@ describe('mkdirp', function () {
       })
     })
 
-    describe('sync', function () {
-      it('should have proper umask', function (done) {
+    describe('sync', () => {
+      it('should have proper umask', done => {
         process.umask(0)
 
         try {
@@ -65,9 +65,9 @@ describe('mkdirp', function () {
           return done(err)
         }
 
-        fs.exists(_rndDir, function (ex) {
+        fs.exists(_rndDir, ex => {
           assert.ok(ex, 'file created')
-          fs.stat(_rndDir, function (err, stat) {
+          fs.stat(_rndDir, (err, stat) => {
             assert.ifError(err)
             assert.equal(stat.mode & o777, (o777 & (~process.umask())))
             assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -1,18 +1,20 @@
-var assert = require('assert')
-var os = require('os')
-var path = require('path')
-var rimraf = require('rimraf')
-var fs = require('graceful-fs')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('graceful-fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
+const rimraf = require('rimraf')
 
 /* global afterEach, beforeEach, describe, it */
 
 function createAsyncErrFn (errCode) {
-  var fn = function () {
+  const fn = function () {
     fn.callCount++
-    var callback = arguments[arguments.length - 1]
-    setTimeout(function () {
-      var err = new Error()
+    const callback = arguments[arguments.length - 1]
+    setTimeout(() => {
+      const err = new Error()
       err.code = errCode
       callback(err)
     }, 10)
@@ -21,8 +23,8 @@ function createAsyncErrFn (errCode) {
   return fn
 }
 
-var originalRename = fs.rename
-var originalLink = fs.link
+const originalRename = fs.rename
+const originalLink = fs.link
 
 function setUpMockFs (errCode) {
   fs.rename = createAsyncErrFn(errCode)
@@ -34,10 +36,10 @@ function tearDownMockFs () {
   fs.link = originalLink
 }
 
-describe('move', function () {
-  var TEST_DIR
+describe('move', () => {
+  let TEST_DIR
 
-  beforeEach(function () {
+  beforeEach(() => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move')
 
     fse.emptyDirSync(TEST_DIR)
@@ -50,18 +52,16 @@ describe('move', function () {
     fs.writeFileSync(path.join(TEST_DIR, 'a-folder/another-folder/file3'), 'knuckles\n')
   })
 
-  afterEach(function (done) {
-    rimraf(TEST_DIR, done)
-  })
+  afterEach(done => rimraf(TEST_DIR, done))
 
-  it('should rename a file on the same device', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/a-file-dest'
+  it('should rename a file on the same device', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/a-file-dest`
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
-      fs.readFile(dest, 'utf8', function (err, contents) {
-        var expected = /^sonic the hedgehog\r?\n$/
+      fs.readFile(dest, 'utf8', (err, contents) => {
+        const expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
         done()
@@ -69,43 +69,43 @@ describe('move', function () {
     })
   })
 
-  it('should not overwrite the destination by default', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/a-folder/another-file'
+  it('should not overwrite the destination by default', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/a-folder/another-file`
 
     // verify file exists already
     assert(fs.existsSync(dest))
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ok(err && err.code === 'EEXIST', 'throw EEXIST')
       done()
     })
   })
 
-  it('should not overwrite if overwrite = false', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/a-folder/another-file'
+  it('should not overwrite if overwrite = false', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/a-folder/another-file`
 
     // verify file exists already
     assert(fs.existsSync(dest))
 
-    fse.move(src, dest, {overwrite: false}, function (err) {
+    fse.move(src, dest, {overwrite: false}, err => {
       assert.ok(err && err.code === 'EEXIST', 'throw EEXIST')
       done()
     })
   })
 
-  it('should overwrite file if overwrite = true', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/a-folder/another-file'
+  it('should overwrite file if overwrite = true', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/a-folder/another-file`
 
     // verify file exists already
     assert(fs.existsSync(dest))
 
-    fse.move(src, dest, {overwrite: true}, function (err) {
+    fse.move(src, dest, {overwrite: true}, err => {
       assert.ifError(err)
-      fs.readFile(dest, 'utf8', function (err, contents) {
-        var expected = /^sonic the hedgehog\r?\n$/
+      fs.readFile(dest, 'utf8', (err, contents) => {
+        const expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
         done()
@@ -121,23 +121,23 @@ describe('move', function () {
     this.timeout(90000)
 
     // Create src
-    var src = path.join(TEST_DIR, 'src')
+    const src = path.join(TEST_DIR, 'src')
     fse.ensureDirSync(src)
     fse.mkdirsSync(path.join(src, 'some-folder'))
     fs.writeFileSync(path.join(src, 'some-file'), 'hi')
 
-    var dest = path.join(TEST_DIR, 'a-folder')
+    const dest = path.join(TEST_DIR, 'a-folder')
 
     // verify dest has stuff in it
-    var paths = fs.readdirSync(dest)
+    const paths = fs.readdirSync(dest)
     assert(paths.indexOf('another-file') >= 0)
     assert(paths.indexOf('another-folder') >= 0)
 
-    fse.move(src, dest, {overwrite: true}, function (err) {
+    fse.move(src, dest, {overwrite: true}, err => {
       assert.ifError(err)
 
       // verify dest does not have old stuff
-      var paths = fs.readdirSync(dest)
+      const paths = fs.readdirSync(dest)
       assert.strictEqual(paths.indexOf('another-file'), -1)
       assert.strictEqual(paths.indexOf('another-folder'), -1)
 
@@ -149,30 +149,30 @@ describe('move', function () {
     })
   })
 
-  it('should not create directory structure if mkdirp is false', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/does/not/exist/a-file-dest'
+  it('should not create directory structure if mkdirp is false', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/does/not/exist/a-file-dest`
 
     // verify dest directory does not exist
     assert(!fs.existsSync(path.dirname(dest)))
 
-    fse.move(src, dest, {mkdirp: false}, function (err) {
+    fse.move(src, dest, {mkdirp: false}, err => {
       assert.strictEqual(err.code, 'ENOENT')
       done()
     })
   })
 
-  it('should create directory structure by default', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/does/not/exist/a-file-dest'
+  it('should create directory structure by default', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/does/not/exist/a-file-dest`
 
     // verify dest directory does not exist
     assert(!fs.existsSync(path.dirname(dest)))
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
-      fs.readFile(dest, 'utf8', function (err, contents) {
-        var expected = /^sonic the hedgehog\r?\n$/
+      fs.readFile(dest, 'utf8', (err, contents) => {
+        const expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
         done()
@@ -180,18 +180,18 @@ describe('move', function () {
     })
   })
 
-  it('should work across devices', function (done) {
-    var src = TEST_DIR + '/a-file'
-    var dest = TEST_DIR + '/a-file-dest'
+  it('should work across devices', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = `${TEST_DIR}/a-file-dest`
 
     setUpMockFs('EXDEV')
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
       assert.strictEqual(fs.link.callCount, 1)
 
-      fs.readFile(dest, 'utf8', function (err, contents) {
-        var expected = /^sonic the hedgehog\r?\n$/
+      fs.readFile(dest, 'utf8', (err, contents) => {
+        const expected = /^sonic the hedgehog\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
 
@@ -201,17 +201,17 @@ describe('move', function () {
     })
   })
 
-  it('should move folders', function (done) {
-    var src = TEST_DIR + '/a-folder'
-    var dest = TEST_DIR + '/a-folder-dest'
+  it('should move folders', done => {
+    const src = `${TEST_DIR}/a-folder`
+    const dest = `${TEST_DIR}/a-folder-dest`
 
     // verify it doesn't exist
     assert(!fs.existsSync(dest))
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
-      fs.readFile(dest + '/another-file', 'utf8', function (err, contents) {
-        var expected = /^tails\r?\n$/
+      fs.readFile(dest + '/another-file', 'utf8', (err, contents) => {
+        const expected = /^tails\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
         done()
@@ -219,18 +219,18 @@ describe('move', function () {
     })
   })
 
-  it('should move folders across devices with EISDIR error', function (done) {
-    var src = TEST_DIR + '/a-folder'
-    var dest = TEST_DIR + '/a-folder-dest'
+  it('should move folders across devices with EISDIR error', done => {
+    const src = `${TEST_DIR}/a-folder`
+    const dest = `${TEST_DIR}/a-folder-dest`
 
     setUpMockFs('EISDIR')
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
       assert.strictEqual(fs.link.callCount, 1)
 
-      fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
-        var expected = /^knuckles\r?\n$/
+      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
+        const expected = /^knuckles\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
 
@@ -241,20 +241,20 @@ describe('move', function () {
     })
   })
 
-  it('should overwrite folders across devices', function (done) {
-    var src = TEST_DIR + '/a-folder'
-    var dest = TEST_DIR + '/a-folder-dest'
+  it('should overwrite folders across devices', done => {
+    const src = `${TEST_DIR}/a-folder`
+    const dest = `${TEST_DIR}/a-folder-dest`
 
     fs.mkdirSync(dest)
 
     setUpMockFs('EXDEV')
 
-    fse.move(src, dest, {overwrite: true}, function (err) {
+    fse.move(src, dest, {overwrite: true}, err => {
       assert.ifError(err)
       assert.strictEqual(fs.rename.callCount, 1)
 
-      fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
-        var expected = /^knuckles\r?\n$/
+      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
+        const expected = /^knuckles\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
 
@@ -265,18 +265,18 @@ describe('move', function () {
     })
   })
 
-  it('should move folders across devices with EXDEV error', function (done) {
-    var src = TEST_DIR + '/a-folder'
-    var dest = TEST_DIR + '/a-folder-dest'
+  it('should move folders across devices with EXDEV error', done => {
+    const src = `${TEST_DIR}/a-folder`
+    const dest = `${TEST_DIR}/a-folder-dest`
 
     setUpMockFs('EXDEV')
 
-    fse.move(src, dest, function (err) {
+    fse.move(src, dest, err => {
       assert.ifError(err)
       assert.strictEqual(fs.link.callCount, 1)
 
-      fs.readFile(dest + '/another-folder/file3', 'utf8', function (err, contents) {
-        var expected = /^knuckles\r?\n$/
+      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
+        const expected = /^knuckles\r?\n$/
         assert.ifError(err)
         assert.ok(contents.match(expected), `${contents} match ${expected}`)
 
@@ -287,18 +287,18 @@ describe('move', function () {
     })
   })
 
-  describe('clobber', function () {
-    it('should be an alias for overwrite', function (done) {
-      var src = TEST_DIR + '/a-file'
-      var dest = TEST_DIR + '/a-folder/another-file'
+  describe('clobber', () => {
+    it('should be an alias for overwrite', done => {
+      const src = `${TEST_DIR}/a-file`
+      const dest = `${TEST_DIR}/a-folder/another-file`
 
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.move(src, dest, {overwrite: true}, function (err) {
+      fse.move(src, dest, {overwrite: true}, err => {
         assert.ifError(err)
-        fs.readFile(dest, 'utf8', function (err, contents) {
-          var expected = /^sonic the hedgehog\r?\n$/
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
           assert.ok(contents.match(expected), `${contents} match ${expected}`)
           done()
@@ -307,16 +307,16 @@ describe('move', function () {
     })
   })
 
-  describe.skip('> when trying to a move a folder into itself', function () {
-    it('should produce an error', function (done) {
-      var SRC_DIR = path.join(TEST_DIR, 'test')
-      var DEST_DIR = path.join(TEST_DIR, 'test', 'test')
+  describe.skip('> when trying to a move a folder into itself', () => {
+    it('should produce an error', done => {
+      const SRC_DIR = path.join(TEST_DIR, 'test')
+      const DEST_DIR = path.join(TEST_DIR, 'test', 'test')
 
       assert(!fs.existsSync(SRC_DIR))
       fs.mkdirSync(SRC_DIR)
       assert(fs.existsSync(SRC_DIR))
 
-      fse.move(SRC_DIR, DEST_DIR, function (err) {
+      fse.move(SRC_DIR, DEST_DIR, err => {
         assert(fs.existsSync(SRC_DIR))
         assert(err)
         done()
@@ -327,9 +327,9 @@ describe('move', function () {
   // tested on Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP i686 i686 GNU/Linux
   // this won't trigger a bug on Mac OS X Yosimite with a USB drive (/Volumes)
   // see issue #108
-  describe('> when actually trying to a move a folder across devices', function () {
-    var differentDevice = '/mnt'
-    var __skipTests = false
+  describe('> when actually trying to a move a folder across devices', () => {
+    const differentDevice = '/mnt'
+    let __skipTests = false
 
     // must set this up, if not, exit silently
     if (!fs.existsSync(differentDevice)) {
@@ -345,12 +345,12 @@ describe('move', function () {
       __skipTests = true
     }
 
-    var _it = __skipTests ? it.skip : it
+    const _it = __skipTests ? it.skip : it
 
-    describe('> just the folder', function () {
-      _it('should move the folder', function (done) {
-        var src = '/mnt/some/weird/dir-really-weird'
-        var dest = path.join(TEST_DIR, 'device-weird')
+    describe('> just the folder', () => {
+      _it('should move the folder', done => {
+        const src = '/mnt/some/weird/dir-really-weird'
+        const dest = path.join(TEST_DIR, 'device-weird')
 
         if (!fs.existsSync(src)) {
           fse.mkdirpSync(src)
@@ -360,7 +360,7 @@ describe('move', function () {
 
         assert(fs.lstatSync(src).isDirectory())
 
-        fse.move(src, dest, function (err) {
+        fse.move(src, dest, err => {
           assert.ifError(err)
           assert(fs.existsSync(dest))
           // console.log(path.normalize(dest))

--- a/lib/remove/__tests__/remove-dir.test.js
+++ b/lib/remove/__tests__/remove-dir.test.js
@@ -1,24 +1,26 @@
-var assert = require('assert')
-var fs = require('fs')
-var path = require('path')
-var os = require('os')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global beforeEach, describe, it */
 
-describe('remove / async / dir', function () {
-  var TEST_DIR
+describe('remove / async / dir', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove-async-dir')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  describe('> when dir does not exist', function () {
-    it('should not throw an error', function (done) {
-      var someDir = path.join(TEST_DIR, 'some-dir/')
+  describe('> when dir does not exist', () => {
+    it('should not throw an error', done => {
+      const someDir = path.join(TEST_DIR, 'some-dir/')
       assert.equal(fs.existsSync(someDir), false)
-      fse.remove(someDir, function (err) {
+      fse.remove(someDir, err => {
         assert.ifError(err)
         done()
       })

--- a/lib/remove/__tests__/remove-sync-dir.test.js
+++ b/lib/remove/__tests__/remove-sync-dir.test.js
@@ -1,28 +1,30 @@
-var assert = require('assert')
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global beforeEach, describe, it */
 
-describe('remove/sync', function () {
-  var TEST_DIR
+describe('remove/sync', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove-sync')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  describe('+ removeSync()', function () {
-    it('should delete directories and files synchronously', function () {
+  describe('+ removeSync()', () => {
+    it('should delete directories and files synchronously', () => {
       assert(fs.existsSync(TEST_DIR))
       fs.writeFileSync(path.join(TEST_DIR, 'somefile'), 'somedata')
       fse.removeSync(TEST_DIR)
       assert(!fs.existsSync(TEST_DIR))
     })
 
-    it('should delete an empty directory synchronously', function () {
+    it('should delete an empty directory synchronously', () => {
       assert(fs.existsSync(TEST_DIR))
       fse.removeSync(TEST_DIR)
       assert(!fs.existsSync(TEST_DIR))

--- a/lib/remove/__tests__/remove-sync-file.test.js
+++ b/lib/remove/__tests__/remove-sync-file.test.js
@@ -1,22 +1,24 @@
-var assert = require('assert')
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var fse = require(process.cwd())
+'use strict'
+
+const fs = require('fs')
+const os = require('os')
+const fse = require(process.cwd())
+const path = require('path')
+const assert = require('assert')
 
 /* global beforeEach, describe, it */
 
-describe('remove/sync', function () {
-  var TEST_DIR
+describe('remove/sync', () => {
+  let TEST_DIR
 
-  beforeEach(function (done) {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove-sync')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  describe('+ removeSync()', function () {
-    it('should delete a file synchronously', function () {
-      var file = path.join(TEST_DIR, 'file')
+  describe('+ removeSync()', () => {
+    it('should delete a file synchronously', () => {
+      const file = path.join(TEST_DIR, 'file')
       fs.writeFileSync(file, 'hello')
       assert(fs.existsSync(file))
       fse.removeSync(file)

--- a/lib/remove/__tests__/remove.test.js
+++ b/lib/remove/__tests__/remove.test.js
@@ -1,77 +1,77 @@
-var assert = require('assert')
-var fs = require('fs')
-var os = require('os')
-var path = require('path')
-var sr = require('secure-random')
-var fse = require(process.cwd())
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const sr = require('secure-random')
+const fse = require(process.cwd())
 
 /* global afterEach, beforeEach, describe, it */
 
-var TEST_DIR
+let TEST_DIR
 
 function buildFixtureDir () {
-  var buf = sr.randomBuffer(5)
-  var baseDir = path.join(TEST_DIR, 'TEST_fs-extra_remove-' + Date.now())
+  const buf = sr.randomBuffer(5)
+  const baseDir = path.join(TEST_DIR, `TEST_fs-extra_remove-${Date.now()}`)
 
   fs.mkdirSync(baseDir)
   fs.writeFileSync(path.join(baseDir, Math.random() + ''), buf)
   fs.writeFileSync(path.join(baseDir, Math.random() + ''), buf)
 
-  var subDir = path.join(TEST_DIR, Math.random() + '')
+  const subDir = path.join(TEST_DIR, Math.random() + '')
   fs.mkdirSync(subDir)
   fs.writeFileSync(path.join(subDir, Math.random() + ''))
   return baseDir
 }
 
-describe('remove', function () {
-  beforeEach(function (done) {
+describe('remove', () => {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove')
     fse.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(function (done) {
-    fse.remove(TEST_DIR, done)
-  })
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  describe('+ remove()', function () {
-    it('should delete an empty directory', function (done) {
+  describe('+ remove()', () => {
+    it('should delete an empty directory', done => {
       assert(fs.existsSync(TEST_DIR))
-      fse.remove(TEST_DIR, function (err) {
+      fse.remove(TEST_DIR, err => {
         assert.ifError(err)
         assert(!fs.existsSync(TEST_DIR))
         done()
       })
     })
 
-    it('should delete a directory full of directories and files', function (done) {
+    it('should delete a directory full of directories and files', done => {
       buildFixtureDir()
       assert(fs.existsSync(TEST_DIR))
-      fse.remove(TEST_DIR, function (err) {
+      fse.remove(TEST_DIR, err => {
         assert.ifError(err)
         assert(!fs.existsSync(TEST_DIR))
         done()
       })
     })
 
-    it('should delete a file', function (done) {
-      var file = path.join(TEST_DIR, 'file')
+    it('should delete a file', done => {
+      const file = path.join(TEST_DIR, 'file')
       fs.writeFileSync(file, 'hello')
 
       assert(fs.existsSync(file))
-      fse.remove(file, function (err) {
+      fse.remove(file, err => {
         assert.ifError(err)
         assert(!fs.existsSync(file))
         done()
       })
     })
 
-    it('should delete without a callback', function (done) {
-      var file = path.join(TEST_DIR, 'file')
+    it('should delete without a callback', done => {
+      const file = path.join(TEST_DIR, 'file')
       fs.writeFileSync(file, 'hello')
 
       assert(fs.existsSync(file))
-      var existsChecker = setInterval(function () {
-        fs.exists(file, function (itDoes) {
+      const existsChecker = setInterval(() => {
+        fs.exists(file, (itDoes) => {
           if (!itDoes) {
             clearInterval(existsChecker)
             done()
@@ -82,22 +82,20 @@ describe('remove', function () {
     })
 
     it('shouldn’t delete glob matches', function (done) {
-      var file = path.join(TEST_DIR, 'file?')
+      const file = path.join(TEST_DIR, 'file?')
       try {
         fs.writeFileSync(file, 'hello')
       } catch (ex) {
-        if (ex.code === 'ENOENT') {
-          return this.skip('Windows does not support filenames with ‘?’ or ‘*’ in them.')
-        }
+        if (ex.code === 'ENOENT') return this.skip('Windows does not support filenames with ‘?’ or ‘*’ in them.')
         throw ex
       }
 
-      var wrongFile = path.join(TEST_DIR, 'file1')
+      const wrongFile = path.join(TEST_DIR, 'file1')
       fs.writeFileSync(wrongFile, 'yo')
 
       assert(fs.existsSync(file))
       assert(fs.existsSync(wrongFile))
-      fse.remove(file, function (err) {
+      fse.remove(file, err => {
         assert.ifError(err)
         assert(!fs.existsSync(file))
         assert(fs.existsSync(wrongFile))
@@ -105,15 +103,15 @@ describe('remove', function () {
       })
     })
 
-    it('shouldn’t delete glob matches when file doesn’t exist', function (done) {
-      var nonexistentFile = path.join(TEST_DIR, 'file?')
+    it('shouldn’t delete glob matches when file doesn’t exist', done => {
+      const nonexistentFile = path.join(TEST_DIR, 'file?')
 
-      var wrongFile = path.join(TEST_DIR, 'file1')
+      const wrongFile = path.join(TEST_DIR, 'file1')
       fs.writeFileSync(wrongFile, 'yo')
 
       assert(!fs.existsSync(nonexistentFile))
       assert(fs.existsSync(wrongFile))
-      fse.remove(nonexistentFile, function (err) {
+      fse.remove(nonexistentFile, err => {
         assert.ifError(err)
         assert(!fs.existsSync(nonexistentFile))
         assert(fs.existsSync(wrongFile))


### PR DESCRIPTION
Everything should be refactored to Node v4 ES6. This should close #355 

**EDIT:**
Everything except `copy/ncp` as discussed in https://github.com/jprichardson/node-fs-extra/pull/360#issuecomment-280857354 