### PR TITLE
move(): fall back to streams when hard links aren't supported

### DIFF
--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -66,7 +66,7 @@ function move (source, dest, options, callback) {
     } else {
       fs.link(source, dest, err => {
         if (err) {
-          if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'EPERM') {
+          if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'EPERM' || err.code === 'ENOTSUP') {
             moveAcrossDevice(source, dest, overwrite, callback)
             return
           }


### PR DESCRIPTION
`move()` should fall back to using streams when `fs.link()` fails with `ENOTSUP`, just as it already does for `EPERM` and other errors.

(As discussed in nodejs/node#11663, hard links aren't supported on ReFS.)