### PR TITLE
Don't move when source and dest paths are the same.

### DIFF
--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -69,6 +69,26 @@ describe('move', () => {
     })
   })
 
+  it('should not move a file if source and destination are the same', done => {
+    const src = `${TEST_DIR}/a-file`
+    const dest = src
+
+    fse.move(src, dest, err => {
+      assert.ifError(err)
+      done()
+    })
+  })
+
+  it('should not move a directory if source and destination are the same', done => {
+    const src = `${TEST_DIR}/a-folder`
+    const dest = src
+
+    fse.move(src, dest, err => {
+      assert.ifError(err)
+      done()
+    })
+  })
+
   it('should not overwrite the destination by default', done => {
     const src = `${TEST_DIR}/a-file`
     const dest = `${TEST_DIR}/a-folder/another-file`

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -35,7 +35,9 @@ function move (source, dest, options, callback) {
   }
 
   function doRename () {
-    if (overwrite) {
+    if (path.resolve(source) === path.resolve(dest)) {
+      setImmediate(callback)
+    } else if (overwrite) {
       fs.rename(source, dest, err => {
         if (!err) return callback()
 


### PR DESCRIPTION
This PR addresses #377 to avoid a move operation if the `source` and `dest` paths are the same.

*(I'll add tests too, just wanted to get the ball rolling)*