### PR TITLE
Document `outputFile()` only supports a file path

### DIFF
--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -1,6 +1,6 @@
 # outputFile(file, data, [options], callback)
 
-Almost the same as `writeFile` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `options` are what you'd pass to [`fs.writeFile()`](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).
+Almost the same as `writeFile` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed). `options` are what you'd pass to [`fs.writeFile()`](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).
 
 **Sync:** `outputFileSync()`
 


### PR DESCRIPTION
`fs.writeFile()` supports a buffer or a file descriptor as 1st  argument (`file`), but `fs-extra.outputFile()` does not. Because it sends `file` parameter to `path.dirname()` that requires `String`.
