### PR TITLE
Use Buffer.alloc() instead of deprecated new Buffer() in copy-file-sync

### DIFF
--- a/lib/copy-sync/copy-file-sync.js
+++ b/lib/copy-sync/copy-file-sync.js
@@ -3,7 +3,7 @@
 const fs = require('graceful-fs')
 
 const BUF_LENGTH = 64 * 1024
-const _buff = new Buffer(BUF_LENGTH)
+const _buff = Buffer.alloc(BUF_LENGTH)
 
 function copyFileSync (srcFile, destFile, options) {
   const overwrite = options.overwrite

--- a/package.json
+++ b/package.json
@@ -56,5 +56,8 @@
     "test-find": "find ./lib/**/__tests__ -name *.test.js | xargs mocha",
     "test": "npm run lint && npm run unit",
     "unit": "node test.js"
+  },
+  "engines": {
+    "node": ">=4.5.0"
   }
 }


### PR DESCRIPTION
Since `new Buffer()` is deprecated, https://nodejs.org/api/buffer.html#buffer_new_buffer_size, I updated `lib/copy-sync/copy-file-sync.js` to use `Buffer.alloc()` instead of deprecated `new Buffer()`.