### PR TITLE
Refactor docs example for readJson()

### DIFF
--- a/docs/readJson.md
+++ b/docs/readJson.md
@@ -11,20 +11,26 @@ that you'd pass to [`jsonFile.readFile`](https://github.com/jprichardson/node-js
 const fs = require('fs-extra')
 
 fs.readJson('./package.json', (err, packageObj) => {
+  if (err) console.error(err)
+  
   console.log(packageObj.version) // => 0.1.3
 })
 ```
 
 ---
 
-`readJsonSync()` can take a `throws` option set to `false` and it won't throw if the JSON is invalid. Example:
+`readJson()` can take a `throws` option set to `false` and it won't throw if the JSON is invalid. Example:
 
 ```js
 const fs = require('fs-extra')
-const file = path.join('/tmp/some-invalid.json')
+
+const file = '/tmp/some-invalid.json'
 const data = '{not valid JSON'
 fs.writeFileSync(file, data)
 
-const obj = fs.readJsonSync(file, {throws: false})
-console.log(obj) // => null
+fs.readJson(file, { throws: false }, (err, obj) => {
+  if (err) console.error(err)
+
+  console.log(obj) // => null
+})
 ```

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -277,7 +277,7 @@ describe('moveSync()', () => {
     })
   })
 
-  describe('> when trying to a move a folder into itself', () => {
+  describe('> when trying to move a folder into itself', () => {
     it('should produce an error', () => {
       const SRC_DIR = path.join(TEST_DIR, 'src')
       const DEST_DIR = path.join(TEST_DIR, 'src', 'dest')
@@ -296,7 +296,7 @@ describe('moveSync()', () => {
     })
   })
 
-  describe('> when trying to a move a file into its parent subdirectory', () => {
+  describe('> when trying to move a file into its parent subdirectory', () => {
     it('should move successfully', () => {
       const src = `${TEST_DIR}/a-file`
       const dest = `${TEST_DIR}/dest/a-file-dest`
@@ -309,7 +309,7 @@ describe('moveSync()', () => {
     })
   })
 
-  describe('> when actually trying to a move a folder across devices', () => {
+  describe('> when actually trying to move a folder across devices', () => {
     const differentDevice = '/mnt'
     let __skipTests = false
 

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -295,7 +295,7 @@ describe('move', () => {
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.move(src, dest, {overwrite: true}, err => {
+      fse.move(src, dest, {clobber: true}, err => {
         assert.ifError(err)
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
@@ -307,7 +307,7 @@ describe('move', () => {
     })
   })
 
-  describe.skip('> when trying to a move a folder into itself', () => {
+  describe.skip('> when trying to move a folder into itself', () => {
     it('should produce an error', done => {
       const SRC_DIR = path.join(TEST_DIR, 'test')
       const DEST_DIR = path.join(TEST_DIR, 'test', 'test')
@@ -327,7 +327,7 @@ describe('move', () => {
   // tested on Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP i686 i686 GNU/Linux
   // this won't trigger a bug on Mac OS X Yosimite with a USB drive (/Volumes)
   // see issue #108
-  describe('> when actually trying to a move a folder across devices', () => {
+  describe('> when actually trying to move a folder across devices', () => {
     const differentDevice = '/mnt'
     let __skipTests = false
 
@@ -341,7 +341,7 @@ describe('move', () => {
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
     } catch (err) {
-      console.log("Can't write to device. Skipping test.")
+      console.log("Can't write to device. Skipping move test.")
       __skipTests = true
     }
 


### PR DESCRIPTION
This one missed! Plus a few minor refactor for `move` and `moveSync` test descriptions.