### PR TITLE
Don't override move test timeout

### DIFF
--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -115,12 +115,6 @@ describe('moveSync()', () => {
   })
 
   it('should overwrite the destination directory if overwrite = true', function (done) {
-    // Tests fail on appveyor/Windows due to
-    // https://github.com/isaacs/node-graceful-fs/issues/98.
-    // Workaround by increasing the timeout by a minute (because
-    // graceful times out after a minute).
-    this.timeout(90000)
-
     // Create src
     const src = path.join(TEST_DIR, 'src')
     fse.ensureDirSync(src)

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -134,12 +134,6 @@ describe('move', () => {
   })
 
   it('should overwrite the destination directory if overwrite = true', function (done) {
-    // Tests fail on appveyor/Windows due to
-    // https://github.com/isaacs/node-graceful-fs/issues/98.
-    // Workaround by increasing the timeout by a minute (because
-    // graceful times out after a minute).
-    this.timeout(90000)
-
     // Create src
     const src = path.join(TEST_DIR, 'src')
     fse.ensureDirSync(src)


### PR DESCRIPTION
This issue with graceful-fs has been fixed, so no need for this.