### PR TITLE
Add standard-markdown to lint js code in markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,7 @@ const fs = require('fs-extra')
 // Async with promises:
 fs.copy('/tmp/myfile', '/tmp/mynewfile')
   .then(() => console.log('success!'))
-  .catch(err => {
-    // Handle error
-  })
+  .catch(err => console.error(err))
 
 // Async with callbacks:
 fs.copy('/tmp/myfile', '/tmp/mynewfile', err => {

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -35,7 +35,7 @@ fs.copy('/tmp/myfile', '/tmp/mynewfile')
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```
 

--- a/docs/emptyDir.md
+++ b/docs/emptyDir.md
@@ -25,6 +25,6 @@ fs.emptyDir('/tmp/some/dir')
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/ensureDir.md
+++ b/docs/ensureDir.md
@@ -24,6 +24,6 @@ fs.ensureDir(dir)
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/ensureFile.md
+++ b/docs/ensureFile.md
@@ -24,6 +24,6 @@ fs.ensureFile(file)
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/ensureLink.md
+++ b/docs/ensureLink.md
@@ -24,6 +24,6 @@ fs.ensureLink(srcpath, dstpath)
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/ensureSymlink.md
+++ b/docs/ensureSymlink.md
@@ -25,6 +25,6 @@ fs.ensureSymlink(srcpath, dstpath)
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/move.md
+++ b/docs/move.md
@@ -24,7 +24,7 @@ fs.move('/tmp/somefile', '/tmp/does/not/exist/yet/somefile')
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```
 

--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -17,6 +17,7 @@ fs.outputFile(file, 'hello!', err => {
   console.log(err) // => null
 
   fs.readFile(file, 'utf8', (err, data) => {
+    if (err) return console.error(err)
     console.log(data) // => hello!
   })
 })
@@ -28,6 +29,6 @@ fs.outputFile(file, 'hello!')
   console.log(data) // => hello!
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/outputJson.md
+++ b/docs/outputJson.md
@@ -20,6 +20,7 @@ fs.outputJson(file, {name: 'JP'}, err => {
   console.log(err) // => null
 
   fs.readJson(file, (err, data) => {
+    if (err) return console.error(err)
     console.log(data.name) // => JP
   })
 })
@@ -31,6 +32,6 @@ fs.outputJson(file, {name: 'JP'})
   console.log(data.name) // => JP
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/readJson.md
+++ b/docs/readJson.md
@@ -26,7 +26,7 @@ fs.readJson('./package.json')
   console.log(packageObj.version) // => 0.1.3
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```
 
@@ -53,6 +53,6 @@ fs.readJson(file, { throws: false })
   console.log(obj) // => null
 })
 .catch(err => {
-  // Not called
+  console.error(err) // Not called
 })
 ```

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -29,6 +29,6 @@ fs.remove('/tmp/myfile')
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```

--- a/docs/writeJson.md
+++ b/docs/writeJson.md
@@ -27,7 +27,7 @@ fs.writeJson('./package.json', {name: 'fs-extra'})
   console.log('success!')
 })
 .catch(err => {
-  // handle error
+  console.error(err)
 })
 ```
 

--- a/package.json
+++ b/package.json
@@ -48,13 +48,14 @@
     "read-dir-files": "^0.1.1",
     "rimraf": "^2.2.8",
     "secure-random": "^1.1.1",
-    "standard": "^10.0.2"
+    "standard": "^10.0.2",
+    "standard-markdown": "^2.3.0"
   },
   "main": "./lib/index",
   "scripts": {
     "coverage": "istanbul cover -i 'lib/**' -x '**/__tests__/**' test.js",
     "coveralls": "npm run coverage && coveralls < coverage/lcov.info",
-    "lint": "standard",
+    "lint": "standard && standard-markdown",
     "test-find": "find ./lib/**/__tests__ -name *.test.js | xargs mocha",
     "test": "npm run lint && npm run unit",
     "unit": "node test.js"


### PR DESCRIPTION
Added [standard-markdown](https://github.com/zeke/standard-markdown) to lint js code blocks inside our markdown files. Since `standard-markdown` uses `standard`, we have a consistent linter for both js and markdown files.

`standard-markdown` by default comes with a few eslint rules disabled. Just added one more rule [handle-callback-err](http://eslint.org/docs/rules/handle-callback-err) to the list of `disabledRules` in `standard-markdown` source code. I guess for us, it makes sense to disable that rule on markdown files.