### PR TITLE
move() should error when src & dest are the same and src doesn't exist

### DIFF
--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -61,6 +61,13 @@ describe('moveSync()', () => {
     assert.ok(contents.match(expected), `${contents} match ${expected}`)
   })
 
+  it('should error if src and dest are the same and src does not exist', () => {
+    const src = `${TEST_DIR}/non-existent`
+    const dest = src
+
+    assert.throws(() => fse.moveSync(src, dest))
+  })
+
   it('should rename a file on the same device', () => {
     const src = `${TEST_DIR}/a-file`
     const dest = `${TEST_DIR}/a-file-dest`

--- a/lib/move-sync/index.js
+++ b/lib/move-sync/index.js
@@ -14,7 +14,7 @@ function moveSync (src, dest, options) {
   src = path.resolve(src)
   dest = path.resolve(dest)
 
-  if (src === dest) return
+  if (src === dest) return fs.accessSync(src)
 
   if (isSrcSubdir(src, dest)) throw new Error(`Cannot move '${src}' into itself '${dest}'.`)
 

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -79,6 +79,16 @@ describe('move', () => {
     })
   })
 
+  it('should error if source and destination are the same and source does not exist', done => {
+    const src = `${TEST_DIR}/non-existent`
+    const dest = src
+
+    fse.move(src, dest, err => {
+      assert(err)
+      done()
+    })
+  })
+
   it('should not move a directory if source and destination are the same', done => {
     const src = `${TEST_DIR}/a-folder`
     const dest = src

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -37,7 +37,7 @@ function move (source, dest, options, callback) {
 
   function doRename () {
     if (path.resolve(source) === path.resolve(dest)) {
-      setImmediate(callback)
+      fs.access(source, callback)
     } else if (overwrite) {
       fs.rename(source, dest, err => {
         if (!err) return callback()


### PR DESCRIPTION
Fixes #414; bug introduced in #378

@jprichardson What's your opinion on semver for this patch?