### PR TITLE
Add filter option to remove() and removeSync()

### DIFF
--- a/lib/remove/__tests__/remove-filter.test.js
+++ b/lib/remove/__tests__/remove-filter.test.js
@@ -1,0 +1,118 @@
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const fse = require(process.cwd())
+
+/* global afterEach, beforeEach, describe, it */
+
+let TEST_DIR
+
+describe('+ remove() - filter option', () => {
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove-filter')
+    fse.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(done => fse.remove(TEST_DIR, done))
+
+  describe('> when filter is used', () => {
+    it('should only remove files allowed by filter fn when path is a file', done => {
+      const f1 = path.join(TEST_DIR, '1.css')
+      fse.outputFileSync(f1, '')
+
+      const filter = p => path.extname(p) !== '.css'
+
+      fse.remove(f1, {filter: filter}, err => {
+        assert.ifError(err)
+        assert(fs.existsSync(f1))
+        done()
+      })
+    })
+
+    it('should only remove files allowed by filter fn when path is a directory', done => {
+      const src = path.join(TEST_DIR, 'src')
+      const f1 = path.join(src, '1.css')
+      const f2 = path.join(src, '2.js')
+      fse.outputFileSync(f1, '')
+      fse.outputFileSync(f2, '')
+
+      const filter = p => path.extname(p) !== '.css' && p !== src
+
+      fse.remove(src, {filter: filter}, err => {
+        assert.ifError(err)
+        assert(fs.existsSync(f1))
+        assert(!fs.existsSync(f2))
+        done()
+      })
+    })
+
+    it('should not remove and return when nothing matched', done => {
+      const src = path.join(TEST_DIR, 'src')
+      const f1 = path.join(src, '1.md')
+      const f2 = path.join(src, '2.js')
+      fse.outputFileSync(f1, '')
+      fse.outputFileSync(f2, '')
+
+      const filter = p => path.extname(p) === '.css'
+
+      fse.remove(src, {filter: filter}, err => {
+        assert.ifError(err)
+        assert(fs.existsSync(f1))
+        assert(fs.existsSync(f2))
+        done()
+      })
+    })
+
+    it('should apply filter recursively when applied on file', done => {
+      const src = path.join(TEST_DIR, 'src')
+      const srcFile1 = path.join(src, '1.js')
+      const srcFile2 = path.join(src, '2.css')
+      const srcFile3 = path.join(src, 'node_modules', '3.css')
+      fse.outputFileSync(srcFile1, 'file 1 stuff')
+      fse.outputFileSync(srcFile2, 'file 2 stuff')
+      fse.outputFileSync(srcFile3, 'file 3 stuff')
+
+      const filter = p => path.extname(p) === '.css'
+
+      fse.remove(src, {filter: filter}, err => {
+        assert.ifError(err)
+        assert(fs.existsSync(srcFile1))
+        assert(!fs.existsSync(srcFile2))
+        assert(!fs.existsSync(srcFile3))
+        done()
+      })
+    })
+
+    it('should apply filter recursively when applied on dir', done => {
+      const src = path.join(TEST_DIR, 'src')
+      const srcFile1 = path.join(src, '1.js')
+      const subdir1 = path.join(src, 'subdir1')
+      // one subdir in root (should be reomved)
+      const subdir2 = path.join(src, 'subdir2')
+      const srcFile2 = path.join(subdir2, '2.css')
+      // other subdir in some subdir (should be removed)
+      const subdir22 = path.join(subdir1, 'subdir2')
+      const srcFile22 = path.join(subdir22, '22.css')
+      const subdir3 = path.join(subdir1, 'subdir3')
+      fse.outputFileSync(srcFile1, 'file 1 stuff')
+      fse.outputFileSync(srcFile2, 'file 2 stuff')
+      fse.outputFileSync(srcFile22, 'file 22 stuff')
+      fse.ensureDir(subdir3)
+
+      const filter = p => p.indexOf('subdir2') > -1
+
+      fse.remove(src, {filter: filter}, err => {
+        assert.ifError(err)
+        assert(fs.existsSync(srcFile1))
+        assert(fs.existsSync(subdir1))
+        assert(!fs.existsSync(subdir2))
+        assert(!fs.existsSync(subdir22))
+        assert(fs.existsSync(subdir3))
+        done()
+      })
+    })
+  })
+})

--- a/lib/remove/__tests__/remove-sync-filter.test.js
+++ b/lib/remove/__tests__/remove-sync-filter.test.js
@@ -1,0 +1,103 @@
+'use strict'
+
+const assert = require('assert')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const fse = require(process.cwd())
+
+/* global afterEach, beforeEach, describe, it */
+
+let TEST_DIR
+
+describe('+ removeSync() - filter option', () => {
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'remove-filter')
+    fse.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(done => fse.remove(TEST_DIR, done))
+
+  describe('> when filter is used', () => {
+    it('should only remove files allowed by filter fn when path is a file', () => {
+      const f1 = path.join(TEST_DIR, '1.css')
+      fse.outputFileSync(f1, '')
+
+      const filter = p => path.extname(p) !== '.css'
+
+      fse.removeSync(f1, {filter: filter})
+      assert(fs.existsSync(f1))
+    })
+
+    it('should only remove files allowed by filter fn when path is a directory', () => {
+      const src = path.join(TEST_DIR, 'src')
+      const f1 = path.join(src, '1.css')
+      const f2 = path.join(src, '2.js')
+      fse.outputFileSync(f1, '')
+      fse.outputFileSync(f2, '')
+
+      const filter = p => path.extname(p) !== '.css' && p !== src
+
+      fse.removeSync(src, {filter: filter})
+      assert(fs.existsSync(f1))
+      assert(!fs.existsSync(f2))
+    })
+
+    it('should not remove and return when nothing matched', () => {
+      const src = path.join(TEST_DIR, 'src')
+      const f1 = path.join(src, '1.md')
+      const f2 = path.join(src, '2.js')
+      fse.outputFileSync(f1, '')
+      fse.outputFileSync(f2, '')
+
+      const filter = p => path.extname(p) === '.css'
+
+      fse.removeSync(src, {filter: filter})
+      assert(fs.existsSync(f1))
+      assert(fs.existsSync(f2))
+    })
+
+    it('should apply filter recursively when applied on file', () => {
+      const src = path.join(TEST_DIR, 'src')
+      const srcFile1 = path.join(src, '1.js')
+      const srcFile2 = path.join(src, '2.css')
+      const srcFile3 = path.join(src, 'node_modules', '3.css')
+      fse.outputFileSync(srcFile1, 'file 1 stuff')
+      fse.outputFileSync(srcFile2, 'file 2 stuff')
+      fse.outputFileSync(srcFile3, 'file 3 stuff')
+
+      const filter = p => path.extname(p) === '.css'
+
+      fse.removeSync(src, {filter: filter})
+      assert(fs.existsSync(srcFile1))
+      assert(!fs.existsSync(srcFile2))
+      assert(!fs.existsSync(srcFile3))
+    })
+
+    it('should apply filter recursively when applied on dir', () => {
+      const src = path.join(TEST_DIR, 'src')
+      const srcFile1 = path.join(src, '1.js')
+      const subdir1 = path.join(src, 'subdir1')
+      // one subdir in root (should be reomved)
+      const subdir2 = path.join(src, 'subdir2')
+      const srcFile2 = path.join(subdir2, '2.css')
+      // other subdir in some subdir (should be removed)
+      const subdir22 = path.join(subdir1, 'subdir2')
+      const srcFile22 = path.join(subdir22, '22.css')
+      const subdir3 = path.join(subdir1, 'subdir3')
+      fse.outputFileSync(srcFile1, 'file 1 stuff')
+      fse.outputFileSync(srcFile2, 'file 2 stuff')
+      fse.outputFileSync(srcFile22, 'file 22 stuff')
+      fse.ensureDir(subdir3)
+
+      const filter = p => p.indexOf('subdir2') > -1
+
+      fse.removeSync(src, {filter: filter})
+      assert(fs.existsSync(srcFile1))
+      assert(fs.existsSync(subdir1))
+      assert(!fs.existsSync(subdir2))
+      assert(!fs.existsSync(subdir22))
+      assert(fs.existsSync(subdir3))
+    })
+  })
+})

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -87,26 +87,56 @@ function rimraf_ (p, options, cb) {
     }
 
     if (st && st.isDirectory()) {
+      if (options.filter) return filterDir(p, options, er, cb)
       return rmdir(p, options, er, cb)
     }
 
-    options.unlink(p, er => {
-      if (er) {
-        if (er.code === 'ENOENT') {
-          return cb(null)
-        }
-        if (er.code === 'EPERM') {
-          return (isWindows)
-            ? fixWinEPERM(p, options, er, cb)
-            : rmdir(p, options, er, cb)
-        }
-        if (er.code === 'EISDIR') {
-          return rmdir(p, options, er, cb)
-        }
-      }
-      return cb(er)
-    })
+    if (options.filter) return filterFile(p, options, cb)
+    return rmFile(p, options, cb)
   })
+}
+
+function rmFile (p, options, cb) {
+  options.unlink(p, er => {
+    if (er) {
+      if (er.code === 'ENOENT') {
+        return cb(null)
+      }
+      if (er.code === 'EPERM') {
+        return (isWindows)
+          ? fixWinEPERM(p, options, er, cb)
+          : rmdir(p, options, er, cb)
+      }
+      if (er.code === 'EISDIR') {
+        return rmdir(p, options, er, cb)
+      }
+    }
+    return cb(er)
+  })
+}
+
+function filterDir (p, options, originalEr, cb) {
+  if (!options.filter(p)) return readFailedDir()
+  return rmdir(p, options, originalEr, cb)
+
+  function readFailedDir () {
+    options.readdir(p, (err, items) => {
+      if (err) return cb(err)
+      Promise.all(items.map(item => {
+        return new Promise((resolve, reject) => {
+          rimraf(path.join(p, item), options, err => {
+            if (err) reject(err)
+            else resolve()
+          })
+        })
+      })).then(() => cb()).catch(cb)
+    })
+  }
+}
+
+function filterFile (p, options, cb) {
+  if (!options.filter(p)) return cb()
+  return rmFile(p, options, cb)
 }
 
 function fixWinEPERM (p, options, er, cb) {
@@ -125,8 +155,10 @@ function fixWinEPERM (p, options, er, cb) {
         if (er3) {
           cb(er3.code === 'ENOENT' ? null : er)
         } else if (stats.isDirectory()) {
+          if (options.filter) return filterDir(p, options, er, cb)
           rmdir(p, options, er, cb)
         } else {
+          if (options.filter) return filterFile(p, options, cb)
           options.unlink(p, cb)
         }
       })
@@ -164,8 +196,10 @@ function fixWinEPERMSync (p, options, er) {
   }
 
   if (stats.isDirectory()) {
+    if (options.filter) return filterDirSync(p, options, er)
     rmdirSync(p, options, er)
   } else {
+    if (options.filter) return filterFileSync(p, options)
     options.unlinkSync(p)
   }
 }
@@ -249,8 +283,10 @@ function rimrafSync (p, options) {
   try {
     // sunos lets the root user unlink directories, which is... weird.
     if (st && st.isDirectory()) {
+      if (options.filter) return filterDirSync(p, options, null)
       rmdirSync(p, options, null)
     } else {
+      if (options.filter) return filterFileSync(p, options)
       options.unlinkSync(p)
     }
   } catch (er) {
@@ -290,6 +326,16 @@ function rmkidsSync (p, options) {
   assert(options)
   options.readdirSync(p).forEach(f => rimrafSync(path.join(p, f), options))
   options.rmdirSync(p, options)
+}
+
+function filterDirSync (p, options, originalEr) {
+  if (!options.filter(p)) return options.readdirSync(p).forEach(f => rimrafSync(path.join(p, f), options))
+  return rmdirSync(p, options, originalEr)
+}
+
+function filterFileSync (p, options) {
+  if (!options.filter(p)) return
+  options.unlinkSync(p)
 }
 
 module.exports = rimraf


### PR DESCRIPTION
Added `filter` option to `remove()` and `removeSync()`. I am not sure if you like it. But, I figured it's worth of proposing.

This `filter` option accepts a function that returns `true` to include (remove) and `false` to exclude (not remove). The same as `copy()`. It operates recursively as well. 

I think `filter` option can be useful for `remove` as well. One useful example is when you want to remove only certain files and/or directories. For instance, with this option, users can run something as simple as this to remove only `.js` files:

```js
const path = require('path')
const fs = require('fs-extra')

const fn = p => path.extname(p) === '.js'

fs.remove('/some/dir', {filter: fn}, err => {
  if (err) return console.log(err)
  console.log('done.')
})
```

I'd like to know your thoughts on this please! :grin: 