### PR TITLE
Improve filter option in copy()

### DIFF
--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -324,7 +324,7 @@ describe('fs-extra', () => {
         }, 1000)
       })
 
-      it('should apply filter recursively on failed dirs by default', done => {
+      it('should apply filter recursively on failed dirs', done => {
         const srcDir = path.join(TEST_DIR, 'src')
         const srcFile1 = path.join(srcDir, '1.js')
         const srcFile2 = path.join(srcDir, '2.css')
@@ -344,30 +344,6 @@ describe('fs-extra', () => {
           assert(!fs.existsSync(destFile1))
           assert(fs.existsSync(destFile2))
           assert(fs.existsSync(destFile3))
-          done()
-        })
-      })
-
-      it('should not apply filter recursively on failed dirs when noRecurseOnFailedFilter is true', done => {
-        const srcDir = path.join(TEST_DIR, 'src')
-        const srcFile1 = path.join(srcDir, '1.js')
-        const srcFile2 = path.join(srcDir, '2.css')
-        const srcFile3 = path.join(srcDir, 'node_modules', '3.css')
-        fse.outputFileSync(srcFile1, 'file 1 stuff')
-        fse.outputFileSync(srcFile2, 'file 2 stuff')
-        fse.outputFileSync(srcFile3, 'file 3 stuff')
-        const destDir = path.join(TEST_DIR, 'dest')
-        const destFile1 = path.join(destDir, '1.js')
-        const destFile2 = path.join(destDir, '2.css')
-        const destFile3 = path.join(destDir, 'node_modules', '3.css')
-
-        const filter = s => path.extname(s) === '.css' || s === srcDir
-
-        fse.copy(srcDir, destDir, {filter: filter, noRecurseOnFailedFilter: true}, err => {
-          assert(!err)
-          assert(!fs.existsSync(destFile1))
-          assert(fs.existsSync(destFile2))
-          assert(!fs.existsSync(destFile3))
           done()
         })
       })

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -196,7 +196,7 @@ describe('fs-extra', () => {
         })
       })
 
-      it('should should apply filter recursively', done => {
+      it('should apply filter recursively', done => {
         const FILES = 2
         // Don't match anything that ends with a digit higher than 0:
         const filter = s => /(0|\D)$/i.test(s)
@@ -266,7 +266,7 @@ describe('fs-extra', () => {
       it('should apply filter when it is applied only to dest', done => {
         const timeCond = new Date().getTime()
 
-        const filter = (s, d) => fs.statSync(d).birthtime.getTime() < timeCond
+        const filter = (s, d) => fs.existsSync(d) && fs.statSync(d).birthtime.getTime() < timeCond
 
         const src = path.join(TEST_DIR, 'src')
         fse.mkdirsSync(src)
@@ -322,6 +322,54 @@ describe('fs-extra', () => {
             })
           })
         }, 1000)
+      })
+
+      it('should apply filter recursively on failed dirs by default', done => {
+        const srcDir = path.join(TEST_DIR, 'src')
+        const srcFile1 = path.join(srcDir, '1.js')
+        const srcFile2 = path.join(srcDir, '2.css')
+        const srcFile3 = path.join(srcDir, 'node_modules', '3.css')
+        fse.outputFileSync(srcFile1, 'file 1 stuff')
+        fse.outputFileSync(srcFile2, 'file 2 stuff')
+        fse.outputFileSync(srcFile3, 'file 3 stuff')
+        const destDir = path.join(TEST_DIR, 'dest')
+        const destFile1 = path.join(destDir, '1.js')
+        const destFile2 = path.join(destDir, '2.css')
+        const destFile3 = path.join(destDir, 'node_modules', '3.css')
+
+        const filter = s => path.extname(s) === '.css'
+
+        fse.copy(srcDir, destDir, filter, err => {
+          assert(!err)
+          assert(!fs.existsSync(destFile1))
+          assert(fs.existsSync(destFile2))
+          assert(fs.existsSync(destFile3))
+          done()
+        })
+      })
+
+      it('should not apply filter recursively on failed dirs when noRecurseOnFailedFilter is true', done => {
+        const srcDir = path.join(TEST_DIR, 'src')
+        const srcFile1 = path.join(srcDir, '1.js')
+        const srcFile2 = path.join(srcDir, '2.css')
+        const srcFile3 = path.join(srcDir, 'node_modules', '3.css')
+        fse.outputFileSync(srcFile1, 'file 1 stuff')
+        fse.outputFileSync(srcFile2, 'file 2 stuff')
+        fse.outputFileSync(srcFile3, 'file 3 stuff')
+        const destDir = path.join(TEST_DIR, 'dest')
+        const destFile1 = path.join(destDir, '1.js')
+        const destFile2 = path.join(destDir, '2.css')
+        const destFile3 = path.join(destDir, 'node_modules', '3.css')
+
+        const filter = s => path.extname(s) === '.css' || s === srcDir
+
+        fse.copy(srcDir, destDir, {filter: filter, noRecurseOnFailedFilter: true}, err => {
+          assert(!err)
+          assert(!fs.existsSync(destFile1))
+          assert(fs.existsSync(destFile2))
+          assert(!fs.existsSync(destFile3))
+          done()
+        })
       })
     })
   })

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -4,7 +4,6 @@ var fs = require('graceful-fs')
 var path = require('path')
 var utimes = require('../util/utimes')
 var mkdirp = require('../mkdirs').mkdirs
-var pathExists = require('../path-exists').pathExists
 
 function ncp (source, dest, options, callback) {
   if (!callback) {
@@ -17,7 +16,6 @@ function ncp (source, dest, options, callback) {
   var targetPath = path.resolve(basePath, dest)
 
   var filter = options.filter
-  var noRecurseOnFailedFilter = options.noRecurseOnFailedFilter
   var transform = options.transform
   var overwrite = options.overwrite
   // If overwrite is undefined, use clobber, otherwise default to true:
@@ -56,29 +54,23 @@ function ncp (source, dest, options, callback) {
       }
 
       if (stats.isDirectory()) {
-        if (filter) return applyFilterOnDir()
+        if (filter) return filterDir()
         return onDir(item)
       } else if (stats.isFile() || stats.isCharacterDevice() || stats.isBlockDevice()) {
-        if (filter) return applyFilterOnFile()
+        if (filter) return filterFile()
         return onFile(item)
       } else if (stats.isSymbolicLink()) {
         // Symlinks don't really need to know about the mode.
         return onLink(source)
       }
 
-      function applyFilterOnDir () {
+      function filterDir () {
         if (filter instanceof RegExp) {
           console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-          if (!filter.test(source)) {
-            if (noRecurseOnFailedFilter) return doneOne()
-            return readFailedDir()
-          }
+          if (!filter.test(source)) return readFailedDir()
           return mkParentDir()
         } else if (typeof filter === 'function') {
-          if (!filter(source, dest)) {
-            if (noRecurseOnFailedFilter) return doneOne()
-            return readFailedDir()
-          }
+          if (!filter(source, dest)) return readFailedDir()
           return mkParentDir()
         }
 
@@ -97,19 +89,14 @@ function ncp (source, dest, options, callback) {
         }
 
         function mkParentDir () {
-          var destParent = path.dirname(dest)
-          pathExists(destParent, (err, dirExists) => {
+          mkdirp(path.dirname(dest), err => {
             if (err) return callback(err)
-            if (dirExists) return onDir(item)
-            mkdirp(destParent, err => {
-              if (err) return callback(err)
-              return onDir(item)
-            })
+            return onDir(item)
           })
         }
       }
 
-      function applyFilterOnFile () {
+      function filterFile () {
         if (filter instanceof RegExp) {
           if (!filter(source)) return doneOne()
           return mkParentDir()
@@ -119,14 +106,9 @@ function ncp (source, dest, options, callback) {
         }
 
         function mkParentDir () {
-          var destParent = path.dirname(dest)
-          pathExists(destParent, (err, dirExists) => {
+          mkdirp(path.dirname(dest), err => {
             if (err) return callback(err)
-            if (dirExists) return onFile(item)
-            mkdirp(destParent, err => {
-              if (err) return callback(err)
-              return onFile(item)
-            })
+            return onFile(item)
           })
         }
       }

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -3,6 +3,8 @@
 var fs = require('graceful-fs')
 var path = require('path')
 var utimes = require('../util/utimes')
+var mkdirp = require('../mkdirs').mkdirs
+var pathExists = require('../path-exists').pathExists
 
 function ncp (source, dest, options, callback) {
   if (!callback) {
@@ -15,6 +17,7 @@ function ncp (source, dest, options, callback) {
   var targetPath = path.resolve(basePath, dest)
 
   var filter = options.filter
+  var noRecurseOnFailedFilter = options.noRecurseOnFailedFilter
   var transform = options.transform
   var overwrite = options.overwrite
   // If overwrite is undefined, use clobber, otherwise default to true:
@@ -34,18 +37,6 @@ function ncp (source, dest, options, callback) {
 
   function startCopy (source) {
     started++
-    if (filter) {
-      if (filter instanceof RegExp) {
-        console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-        if (!filter.test(source)) {
-          return doneOne(true)
-        }
-      } else if (typeof filter === 'function') {
-        if (!filter(source, dest)) {
-          return doneOne(true)
-        }
-      }
-    }
     return getStats(source)
   }
 
@@ -65,12 +56,79 @@ function ncp (source, dest, options, callback) {
       }
 
       if (stats.isDirectory()) {
+        if (filter) return applyFilterOnDir()
         return onDir(item)
       } else if (stats.isFile() || stats.isCharacterDevice() || stats.isBlockDevice()) {
+        if (filter) return applyFilterOnFile()
         return onFile(item)
       } else if (stats.isSymbolicLink()) {
         // Symlinks don't really need to know about the mode.
         return onLink(source)
+      }
+
+      function applyFilterOnDir () {
+        if (filter instanceof RegExp) {
+          console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
+          if (!filter.test(source)) {
+            if (noRecurseOnFailedFilter) return doneOne()
+            return readFailedDir()
+          }
+          return mkParentDir()
+        } else if (typeof filter === 'function') {
+          if (!filter(source, dest)) {
+            if (noRecurseOnFailedFilter) return doneOne()
+            return readFailedDir()
+          }
+          return mkParentDir()
+        }
+
+        function readFailedDir () {
+          fs.readdir(source, (err, items) => {
+            if (err) return callback(err)
+            Promise.all(items.map(item => {
+              return new Promise((resolve, reject) => {
+                ncp(path.join(source, item), path.join(dest, item), options, err => {
+                  if (err) reject(err)
+                  else resolve()
+                })
+              })
+            })).then(() => callback()).catch(callback)
+          })
+        }
+
+        function mkParentDir () {
+          var destParent = path.dirname(dest)
+          pathExists(destParent, (err, dirExists) => {
+            if (err) return callback(err)
+            if (dirExists) return onDir(item)
+            mkdirp(destParent, err => {
+              if (err) return callback(err)
+              return onDir(item)
+            })
+          })
+        }
+      }
+
+      function applyFilterOnFile () {
+        if (filter instanceof RegExp) {
+          if (!filter(source)) return doneOne()
+          return mkParentDir()
+        } else if (typeof filter === 'function') {
+          if (!filter(source, dest)) return doneOne()
+          return mkParentDir()
+        }
+
+        function mkParentDir () {
+          var destParent = path.dirname(dest)
+          pathExists(destParent, (err, dirExists) => {
+            if (err) return callback(err)
+            if (dirExists) return onFile(item)
+            mkdirp(destParent, err => {
+              if (err) return callback(err)
+              return onFile(item)
+            })
+          })
+        }
       }
     })
   }


### PR DESCRIPTION
Ref: Started #419.

Renamed branch to `filter-copy` to be more specific.

Also removed `noRecurseOnFailedFilter` for the sake of simplicity. If you think still need it, I will add it again.

Just a quick summary:

I believe `filter` option is a very useful option. However, it currently doesn't behave consistently for all cases. One example is #350. Therefore, it requires extra efforts from users to achieve what they want. Sometimes it's so difficult to get what you want simply because of a complex directory structure and/or maybe you even don't have any knowledge of the src directory structure. I believe there should be a way to provide a filter option that behaves consistently and intuitively for all cases and with minimal efforts from users.

In general, one use case that `filter` option comes very handy is to copy certain files and/or directories, and most of the time we want it recursively.

With these changes, users can use `filter` option as simple as this and expect to get the correct results:
```js
const path = require('path')
const fs = require('fs-extra')

const fn = s => path.extname(s) === '.js'

fs.copy('src', 'dest', {filter: fn}, err => {
  if (err) return console.log(err)
  console.log('done.')
})
```