### PR TITLE
Fix typo that broke outputJSONSync()

### DIFF
--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -3,11 +3,11 @@
 const u = require('universalify').fromCallback
 const jsonFile = require('./jsonfile')
 
-jsonFile.outputJsonSync = require('./output-json-sync')
 jsonFile.outputJson = u(require('./output-json'))
+jsonFile.outputJsonSync = require('./output-json-sync')
 // aliases
-jsonFile.outputJSONSync = jsonFile.outputJSONSync
 jsonFile.outputJSON = jsonFile.outputJson
+jsonFile.outputJSONSync = jsonFile.outputJsonSync
 jsonFile.writeJSON = jsonFile.writeJson
 jsonFile.writeJSONSync = jsonFile.writeJsonSync
 jsonFile.readJSON = jsonFile.readJson


### PR DESCRIPTION
Reorganize file to put async methods first

Fixes https://github.com/jprichardson/node-fs-extra/issues/427