### PR TITLE
[draft] flush (OS) write cache with fse.copy() using options.sync

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,13 @@ node_modules/
 .idea
 *.iml
 npm-debug.log
+
+.git/
+.vs/
+
+*.sdf
+*.sln
+*.opendb
+*.user
+*.vcxproj
+*.filters

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -23,6 +23,7 @@ function ncp (source, dest, options, callback) {
   var errorOnExist = options.errorOnExist
   var dereference = options.dereference
   var preserveTimestamps = options.preserveTimestamps === true
+  var sync = options.sync === true
 
   var started = 0
   var finished = 0
@@ -105,7 +106,16 @@ function ncp (source, dest, options, callback) {
       transform(readStream, writeStream, file)
     } else {
       writeStream.on('open', function () {
-        readStream.pipe(writeStream)
+        readStream.pipe(writeStream, sync ? { end: false } : void 0)
+      })
+    }
+
+    if (sync) {
+      readStream.once('end', function () {
+        fs.fsync(writeStream.fd, function (err) {
+          writeStream.end()
+          if (err) return onError(err)
+        })
       })
     }
 

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -250,7 +250,6 @@ function ncp (source, dest, options, callback) {
     else if (sync) {
       var p = path.dirname(target)
       if (--sync[p] === 0) {
-        console.log(p, sync[p])
         started++
         fs.open(p, 'r+', function (err, fd) {
           if (err) return onError(err)

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -25,6 +25,11 @@ function ncp (source, dest, options, callback) {
   var preserveTimestamps = options.preserveTimestamps === true
   var sync = options.sync === true
 
+  if (sync) {
+    sync = []
+    sync[path.dirname(targetPath)] = 0
+  }
+
   var started = 0
   var finished = 0
   var running = 0
@@ -79,6 +84,9 @@ function ncp (source, dest, options, callback) {
   function onFile (file) {
     var target = file.name.replace(currentPath, targetPath.replace('$', '$$$$')) // escapes '$' with '$$'
     isWritable(target, function (writable) {
+      if (sync) {
+        sync[path.dirname(target)]++
+      }
       if (writable) {
         copyFile(file, target)
       } else {
@@ -89,7 +97,7 @@ function ncp (source, dest, options, callback) {
         } else if (errorOnExist) {
           onError(new Error(target + ' already exists'))
         } else {
-          doneOne()
+          doneOne(target)
         }
       }
     })
@@ -125,10 +133,10 @@ function ncp (source, dest, options, callback) {
         if (preserveTimestamps) {
           utimes.utimesMillis(target, file.atime, file.mtime, function (err) {
             if (err) return onError(err)
-            return doneOne()
+            return doneOne(target)
           })
         } else {
-          doneOne()
+          doneOne(target)
         }
       })
     })
@@ -144,6 +152,10 @@ function ncp (source, dest, options, callback) {
   function onDir (dir) {
     var target = dir.name.replace(currentPath, targetPath.replace('$', '$$$$')) // escapes '$' with '$$'
     isWritable(target, function (writable) {
+      if (sync) {
+        sync[target] = 0
+        sync[path.dirname(target)]++
+      }
       if (writable) {
         return mkDir(dir, target)
       }
@@ -169,7 +181,7 @@ function ncp (source, dest, options, callback) {
       items.forEach(function (item) {
         startCopy(path.join(dir, item))
       })
-      return doneOne()
+      return doneOne(dir.replace(currentPath, targetPath))
     })
   }
 
@@ -186,6 +198,9 @@ function ncp (source, dest, options, callback) {
       resolvedPath = path.resolve(basePath, resolvedPath)
     }
     isWritable(target, function (writable) {
+      if (sync) {
+        sync[path.dirname(target)]++
+      }
       if (writable) {
         return makeLink(resolvedPath, target)
       }
@@ -196,7 +211,7 @@ function ncp (source, dest, options, callback) {
           targetDest = path.resolve(basePath, targetDest)
         }
         if (targetDest === resolvedPath) {
-          return doneOne()
+          return doneOne(target)
         }
         return rmFile(target, function () {
           makeLink(resolvedPath, target)
@@ -208,7 +223,7 @@ function ncp (source, dest, options, callback) {
   function makeLink (linkPath, target) {
     fs.symlink(linkPath, target, function (err) {
       if (err) return onError(err)
-      return doneOne()
+      return doneOne(target)
     })
   }
 
@@ -230,9 +245,30 @@ function ncp (source, dest, options, callback) {
     }
   }
 
-  function doneOne (skipped) {
-    if (!skipped) running--
-    finished++
+  function doneOne (target, skipped) {
+    if (typeof target === 'boolean') skipped = target
+    else if (sync) {
+      var p = path.dirname(target)
+      if (--sync[p] === 0) {
+        console.log(p, sync[p])
+        started++
+        fs.open(p, 'r+', function (err, fd) {
+          if (err) return onError(err)
+          fs.fsync(fd, function (err) {
+            fs.close(fd, function (err) {
+              if (err) return onError(err)
+              finished++
+              doneOne(false)
+            })
+            if (err) return onError(err)
+          })
+        })
+      }
+    }
+    if (target) {
+      if (!skipped) running--
+      finished++
+    }
     if ((started === finished) && (running === 0)) {
       if (callback !== undefined) {
         return callback(null)


### PR DESCRIPTION
flushes all copied files and directories including the destination base but not any parent directories (which might be desired if destination parent didn't exist)