### PR TITLE
Skip copy & copySync timestamp tests on 32-bit computers

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
@@ -9,7 +9,11 @@ const copySync = require('../copy-sync')
 
 /* global beforeEach, describe, it */
 
-describe('copy', () => {
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping copySync timestamp tests')
+
+const describeIf64 = process.arch === 'ia32' ? describe.skip : describe
+
+describeIf64('copySync', () => {
   let TEST_DIR
 
   beforeEach(done => {

--- a/lib/copy/__tests__/copy-preserve-time.test.js
+++ b/lib/copy/__tests__/copy-preserve-time.test.js
@@ -9,7 +9,11 @@ const assert = require('assert')
 
 /* global beforeEach, describe, it */
 
-describe('copy', () => {
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
+
+const describeIf64 = process.arch === 'ia32' ? describe.skip : describe
+
+describeIf64('copy', () => {
   let TEST_DIR
 
   beforeEach(done => {


### PR DESCRIPTION
This should get appveyor passing