### PR TITLE
specify minimum node version (4.5)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/jprichardson/node-fs-extra"
   },
+  "engines": {
+    "node": ">=4.5"
+  },
   "keywords": [
     "fs",
     "file",


### PR DESCRIPTION
With node 4.4 or earlier, tar fails on `Buffer.alloc` which was added in [4.5](https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#4.5.0)