### PR TITLE
Fix changelog move() notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Changed
 
 - **BREAKING:** The promisified versions of `fs.read()` & `fs.write()` now return objects. See [the docs](docs/fs-read-write.md) for details.
-- `fs.move()` now errors out when source and destination are the same.
+- `fs.move()` now errors out when destination is a subdirectory of source.
 - Applied upstream fixes from `rimraf` to `fs.remove()` & `fs.removeSync()`.
 
 ### Fixed


### PR DESCRIPTION
Fixed `CHANGELOG.md` latest `move()` notes.