### PR TITLE
fix: windows fs.copy with preserveTimestamps

### DIFF
--- a/lib/copy/__tests__/copy-preserve-time.test.js
+++ b/lib/copy/__tests__/copy-preserve-time.test.js
@@ -14,16 +14,16 @@ if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp 
 const describeIf64 = process.arch === 'ia32' ? describe.skip : describe
 
 describeIf64('copy', () => {
-  let TEST_DIR
+  const TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy')
 
   beforeEach(done => {
-    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy')
     require(process.cwd()).emptyDir(TEST_DIR, done)
   })
 
   describe('> modification option', () => {
     const SRC_FIXTURES_DIR = path.join(__dirname, '/fixtures')
     const FILES = ['a-file', path.join('a-folder', 'another-file'), path.join('a-folder', 'another-folder', 'file3')]
+    const readOnlyFile = 'b-file'
 
     describe('> when modified option is turned off', () => {
       it('should have different timestamps on copy', done => {
@@ -47,7 +47,34 @@ describeIf64('copy', () => {
           done()
         })
       })
+
+      describe('> with a read-only file', () => {
+        const src = path.join(SRC_FIXTURES_DIR, readOnlyFile)
+        const dest = path.join(TEST_DIR, readOnlyFile)
+
+        beforeEach(() => assertPermission(src, '444', {
+          tryToSet: true,
+          message: `Couldn't assert read-only permission`
+        }))
+
+        it('should have the same timestamps on copy', done => {
+          copy(src, dest, { preserveTimestamps: true }, () => {
+            testFile({ preserveTimestamps: true })(readOnlyFile)
+            done()
+          })
+        })
+      })
     })
+
+    function assertPermission (file, permissionString, options) {
+      options = options || {}
+      const stat = fs.statSync(file)
+      const statPerm = (stat.mode & parseInt('777', 8)).toString(8)
+      if (statPerm !== permissionString && options.tryToSet) {
+        fs.chmodSync(file, permissionString)
+      }
+      assert.equal(permissionString, statPerm, options.message)
+    }
 
     function testFile (options) {
       return function (file) {

--- a/lib/copy/__tests__/fixtures/b-file
+++ b/lib/copy/__tests__/fixtures/b-file
@@ -1,0 +1,1 @@
+shadow the hedgehog

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -96,7 +96,7 @@ function ncp (source, dest, options, callback) {
 
   function copyFile (file, target) {
     var readStream = fs.createReadStream(file.name)
-    var writeStream = fs.createWriteStream(target, { mode: file.mode })
+    var writeStream = fs.createWriteStream(target)
 
     readStream.on('error', onError)
     writeStream.on('error', onError)
@@ -110,17 +110,14 @@ function ncp (source, dest, options, callback) {
     }
 
     writeStream.once('close', function () {
-      fs.chmod(target, file.mode, function (err) {
-        if (err) return onError(err)
-        if (preserveTimestamps) {
-          utimes.utimesMillis(target, file.atime, file.mtime, function (err) {
-            if (err) return onError(err)
-            return doneOne()
-          })
-        } else {
-          doneOne()
-        }
-      })
+      const chmod = (cb) => fs.chmod(target, file.mode, cb)
+      const utimesMillis = (cb) => utimes.utimesMillis(target, file.atime, file.mtime, cb)
+      const done = (err) => err ? onError(err) : doneOne()
+      if (preserveTimestamps) {
+        utimesMillis((err) => err ? onError(err) : chmod(done))
+      } else {
+        chmod(done)
+      }
     })
   }
 


### PR DESCRIPTION
Fixes an issue (#478) on Windows when the destination file had read-only attribute set.

* Do not write {file.mode} when writing (it's done later with fs.chmod anyways)
* Do utimesMillis *before* chmod

