### PR TITLE
Added '.js' extension to the <main> attribute in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "standard": "^10.0.2",
     "standard-markdown": "^4.0.1"
   },
-  "main": "./lib/index",
+  "main": "./lib/index.js",
   "scripts": {
     "coverage": "istanbul cover -i 'lib/**' -x '**/__tests__/**' test.js",
     "coveralls": "coveralls < coverage/lcov.info",


### PR DESCRIPTION
Added '.js' extension to the `main` attribute in package.json, for commpatibility with various loaders or bundlers (webpack, systemjs, browserify,...) or  any other independent lib which may use package.json.