### PR TITLE
update copy documentation to show differences with cp

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -3,7 +3,7 @@
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 
 - `src` `<String>`
-- `dest` `<String>`
+- `dest` `<String>` Note that if `src` is a file, `dest` cannot be a directory (see [issue #323](https://github.com/jprichardson/node-fs-extra/issues/323)).
 - `options` `<Object>`
   - `overwrite` `<boolean>`: overwrite existing file or directory, default is `true`. _Note that the copy operation will silently fail if you set this to `false` and the destination exists._ Use the `errorOnExist` option to change this behavior.
   - `errorOnExist` `<boolean>`: when `overwrite` is `false` and the destination exists, throw an error. Default is `false`.


### PR DESCRIPTION
A found myself struggling because I was using the `copy` function with file source and directory destination (as you can do using `cp`). The error was related to an `unlink` system call not working.
After some digging I landed on #323 but I found that the docs has not been updated.

So here are a few words about this topic.
Thank you :)