### PR TITLE
Use octal notation for chmod values in rimraf.js

### DIFF
--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -117,7 +117,7 @@ function fixWinEPERM (p, options, er, cb) {
     assert(er instanceof Error)
   }
 
-  options.chmod(p, 666, er2 => {
+  options.chmod(p, 0o666, er2 => {
     if (er2) {
       cb(er2.code === 'ENOENT' ? null : er)
     } else {
@@ -144,7 +144,7 @@ function fixWinEPERMSync (p, options, er) {
   }
 
   try {
-    options.chmodSync(p, 666)
+    options.chmodSync(p, 0o666)
   } catch (er2) {
     if (er2.code === 'ENOENT') {
       return


### PR DESCRIPTION
Backports https://github.com/isaacs/rimraf/commit/38b907fd64656923cc4004ce353e1ad101bd8d1c
Fixes #484