### PR TITLE
bugfix/492 - Replace fs.link/unlink with fs.rename in fse.move

### DIFF
--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -199,7 +199,7 @@ describe('move', () => {
 
     fse.move(src, dest, err => {
       assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
+      assert.strictEqual(fs.rename.callCount, 1)
 
       fs.readFile(dest, 'utf8', (err, contents) => {
         const expected = /^sonic the hedgehog\r?\n$/
@@ -238,7 +238,7 @@ describe('move', () => {
 
     fse.move(src, dest, err => {
       assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
+      assert.strictEqual(fs.rename.callCount, 1)
 
       fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
         const expected = /^knuckles\r?\n$/
@@ -284,7 +284,7 @@ describe('move', () => {
 
     fse.move(src, dest, err => {
       assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
+      assert.strictEqual(fs.rename.callCount, 1)
 
       fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
         const expected = /^knuckles\r?\n$/

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -66,7 +66,7 @@ function move (src, dest, options, callback) {
           return
         }
 
-        if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'ENOTSUP') {
+        if (err.code === 'EXDEV' || err.code === 'EISDIR') {
           return moveAcrossDevice(src, dest, overwrite, callback)
         }
         callback(err)

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -33,20 +33,28 @@ function move (src, dest, options, callback) {
   function doRename () {
     if (path.resolve(src) === path.resolve(dest)) {
       fs.access(src, callback)
-    } else if (overwrite) {
+    } else {
+      if (!overwrite && fs.existsSync(dest)) {
+        const err = new Error('EEXIST: file already exists')
+        err.code = 'EEXIST'
+        err.path = src
+        err.dest = dest
+        return callback(err)
+      }
+
       fs.rename(src, dest, err => {
         if (!err) return callback()
 
         if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST') {
           remove(dest, err => {
             if (err) return callback(err)
-            options.overwrite = false // just overwriteed it, no need to do it again
+            options.overwrite = false // just removed it, so no need to overwrite
             move(src, dest, options, callback)
           })
           return
         }
 
-        // weird Windows shit
+        // weird Windows issue
         if (err.code === 'EPERM') {
           setTimeout(() => {
             remove(dest, err => {
@@ -58,18 +66,10 @@ function move (src, dest, options, callback) {
           return
         }
 
-        if (err.code !== 'EXDEV') return callback(err)
-        moveAcrossDevice(src, dest, overwrite, callback)
-      })
-    } else {
-      fs.link(src, dest, err => {
-        if (err) {
-          if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'EPERM' || err.code === 'ENOTSUP') {
-            return moveAcrossDevice(src, dest, overwrite, callback)
-          }
-          return callback(err)
+        if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'ENOTSUP') {
+          return moveAcrossDevice(src, dest, overwrite, callback)
         }
-        return fs.unlink(src, callback)
+        callback(err)
       })
     }
   }

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -66,8 +66,10 @@ function move (src, dest, options, callback) {
           return
         }
 
-        if (err.code !== 'EXDEV') return callback(err)
-        moveAcrossDevice(src, dest, overwrite, callback)
+        if (err.code === 'EXDEV' || err.code === 'EISDIR') {
+          return moveAcrossDevice(src, dest, overwrite, callback)
+        }
+        callback(err)
       })
     }
   }

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -66,10 +66,8 @@ function move (src, dest, options, callback) {
           return
         }
 
-        if (err.code === 'EXDEV' || err.code === 'EISDIR') {
-          return moveAcrossDevice(src, dest, overwrite, callback)
-        }
-        callback(err)
+        if (err.code !== 'EXDEV') return callback(err)
+        moveAcrossDevice(src, dest, overwrite, callback)
       })
     }
   }


### PR DESCRIPTION
Fix for: https://github.com/jprichardson/node-fs-extra/issues/492
"Folders become inoperable after fse.move, because fs.link isn't returning EPERM error [Mac]"

Previous move logic:
- If overwriting, use rename
- If not, use fs.link, then fs.unlink. fs.link will throw an EPERM error if it's a directory, in which case, recursively copy.

The downside to the previous logic is that the recursive copy for the folder is a heavy operation, and it took several different fs operations instead of just one. Also, in the case of this bug on Macs, fs.link would partially succeed in moving a folder instead of throwing an error, leading to an inoperable state on the folder.

Updated move logic:
- Use fs.existsSync to prevent overwriting
- Use fs.rename, which should work on both files and folders

Unlike fs.link, fs.rename will overwrite by default, so must do an existence check first to prevent this. I believe this is a decent tradeoff for fixing this bug and avoiding heavy recursive copy operations on folders.

Other Changes:
- Updated tests
- Got rid of ENOTSUP error checking since this isn't returned by rename nor link, and wasn't a unit test case, so not sure what it was doing there: http://man7.org/linux/man-pages/man2/rename.2.html, http://man7.org/linux/man-pages/man2/link.2.html
- Similarly, there was an 'EISDIR' check for fs.link, when that does not appear to be an error thrown by fs.link. There is an 'EISDIR' for rename, though the definition ("newpath is an existing directory, but oldpath is not a directory") does not suit the use case of calling moveAcrossDevice()/recursive copy, so I have removed this check as well.

Ran tests/linter on both Mac and Windows.