### PR TITLE
fs.copy, handle e.g. EBUSY

### DIFF
--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -101,9 +101,9 @@ function ncp (source, dest, options, callback) {
 
     readStream.once('open', function () {
       var writeStream = fs.createWriteStream(target, { mode: file.mode })
-      
+
       writeStream.on('error', onError)
-      
+
       if (transform) {
         transform(readStream, writeStream, file)
       } else {

--- a/lib/copy/ncp.js
+++ b/lib/copy/ncp.js
@@ -96,30 +96,34 @@ function ncp (source, dest, options, callback) {
 
   function copyFile (file, target) {
     var readStream = fs.createReadStream(file.name)
-    var writeStream = fs.createWriteStream(target, { mode: file.mode })
 
     readStream.on('error', onError)
-    writeStream.on('error', onError)
 
-    if (transform) {
-      transform(readStream, writeStream, file)
-    } else {
-      writeStream.on('open', function () {
-        readStream.pipe(writeStream)
-      })
-    }
+    readStream.once('open', function () {
+      var writeStream = fs.createWriteStream(target, { mode: file.mode })
+      
+      writeStream.on('error', onError)
+      
+      if (transform) {
+        transform(readStream, writeStream, file)
+      } else {
+        writeStream.on('open', function () {
+          readStream.pipe(writeStream)
+        })
+      }
 
-    writeStream.once('close', function () {
-      fs.chmod(target, file.mode, function (err) {
-        if (err) return onError(err)
-        if (preserveTimestamps) {
-          utimes.utimesMillis(target, file.atime, file.mtime, function (err) {
-            if (err) return onError(err)
-            return doneOne()
-          })
-        } else {
-          doneOne()
-        }
+      writeStream.once('close', function () {
+        fs.chmod(target, file.mode, function (err) {
+          if (err) return onError(err)
+          if (preserveTimestamps) {
+            utimes.utimesMillis(target, file.atime, file.mtime, function (err) {
+              if (err) return onError(err)
+              return doneOne()
+            })
+          } else {
+            doneOne()
+          }
+        })
       })
     })
   }


### PR DESCRIPTION
Hi!

The function [`copyFile` in lib/copy/ncp.js](https://github.com/jprichardson/node-fs-extra/blob/master/lib/copy/ncp.js#L97) _assumes_ that the `readStream` was opened properly. When this assumption happens to be false, the `writeStream` associated with the operation will never close. Causing a lock on the _"targetFilename"_ which in turn blocks (EPERM) all operations on _"targetFilename"_ during the remainder of the application lifetime.

[This is the relevant line in the `ReadStream` class method `open`.](https://github.com/nodejs/node/blob/master/lib/fs.js#L2028) Notice that if an error occurred while opening the file, the stream is destroyed and an error is emitted. This is what `copyFile` doesn't handle.

It's hard to recreate this behaviour.. but in my [test case](https://pastebin.com/F9E28ae5), I monkey patched the `ReadStream.prototype.open` so that it fails with 'EBUSY' on the first call. Simulating an intrusive AV or whatnot.

This is the output when running the test case:
```javascript
trying to copy file (attempt 1)
(opening read stream, simulating EBUSY)
an error occurred during copy, trying again in 1 sec
 { Error: 'EBUSY: resource busy or locked, open test/file.txt',
  code: 'EBUSY',
  path: 'test/file.txt' }

trying to copy file (attempt 2) // Using the unpatched version of ReadStream
an error occurred during copy, trying again in 2 sec
 { Error: EPERM: operation not permitted, open 'test/file-copy.txt' // <-- Destination is now locked
  errno: -4048,
  code: 'EPERM',
  syscall: 'open', // <-- Another attempt to open a read stream, this time using the original ReadStream.open.
                   //     It's probably lstat or something as a prelude to check if the target already exists.
  path: 'test/file-copy.txt' }

trying to copy file (attempt 3)
an error occurred during copy, trying again in 3 sec
 { Error: EPERM: operation not permitted, unlink 'test/file-copy.txt'
  errno: -4048,
  code: 'EPERM',
  syscall: 'unlink', // <-- This is ncp.js rmFile that's trying to remove the target file ({overwrite: true})
  path: 'test/file-copy.txt' }

trying to copy file (attempt 4) // <-- ncp.js rmFile, again, can't delete a file with an open write stream
trying to copy file (attempt 5) // <-- and again..
trying to copy file (attempt ..............) // <-- and again, and again, and again...
```
This commit simply waits for `readStream` to emit an `open` event ([which happens after error checking](https://github.com/nodejs/node/blob/master/lib/fs.js#L2037)) before initializing a write stream. 

After commit:

```javascript
trying to copy file (attempt 1)
(opening read stream, simulating EBUSY)
an error occurred during copy, trying again in 1 sec
 { Error: 'EBUSY: resource busy or locked, open test/file.txt',
  code: 'EBUSY',
  path: 'test/file.txt' }

trying to copy file (attempt 2)
succesfully copied file.txt
```

(I'm not that experienced in contributing to open source projects via GitHub, so I'm sorry beforehand if I've misunderstood this whole pull request thing =))