### PR TITLE
BREAKING: Don't allow copy()/copySync()'s filter option to be a Regex

### DIFF
--- a/docs/copy-sync.md
+++ b/docs/copy-sync.md
@@ -9,7 +9,7 @@ Copy a file or directory. The directory can have contents. Like `cp -r`.
   - `errorOnExist` `<boolean>`: when `overwrite` is `false` and the destination exists, throw an error. Default is `false`.
   - `dereference` `<boolean>`: dereference symlinks, default is `false`.
   - `preserveTimestamps` `<boolean>`: will set last modification and access times to the ones of the original source files, default is `false`.
-  - `filter` `<Function>`: Function to filter copied files. Return `true` to include, `false` to exclude. This can also be a RegExp, however this is deprecated (See [issue #239](https://github.com/jprichardson/node-fs-extra/issues/239) for background).
+  - `filter` `<Function>`: Function to filter copied files. Return `true` to include, `false` to exclude.
 
 ## Example:
 

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -9,7 +9,7 @@ Copy a file or directory. The directory can have contents. Like `cp -r`.
   - `errorOnExist` `<boolean>`: when `overwrite` is `false` and the destination exists, throw an error. Default is `false`.
   - `dereference` `<boolean>`: dereference symlinks, default is `false`.
   - `preserveTimestamps` `<boolean>`: will set last modification and access times to the ones of the original source files, default is `false`.
-  - `filter` `<Function>`: Function to filter copied files. Return `true` to include, `false` to exclude. This can also be a RegExp, however this is deprecated (See [issue #239](https://github.com/jprichardson/node-fs-extra/issues/239) for background).
+  - `filter` `<Function>`: Function to filter copied files. Return `true` to include, `false` to exclude.
 - `callback` `<Function>`
 
 ## Example:

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -31,21 +31,17 @@ function copySync (src, dest, options) {
   const stats = (options.recursive && !options.dereference) ? fs.lstatSync(src) : fs.statSync(src)
   const destFolder = path.dirname(dest)
   const destFolderExists = fs.existsSync(destFolder)
-  let performCopy = false
 
-  if (options.filter instanceof RegExp) {
-    console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-    performCopy = options.filter.test(src)
-  } else if (typeof options.filter === 'function') performCopy = options.filter(src, dest)
+  if (!options.filter(src, dest)) return
 
-  if (stats.isFile() && performCopy) {
+  if (stats.isFile()) {
     if (!destFolderExists) mkdir.mkdirsSync(destFolder)
     copyFileSync(src, dest, {
       overwrite: options.overwrite,
       errorOnExist: options.errorOnExist,
       preserveTimestamps: options.preserveTimestamps
     })
-  } else if (stats.isDirectory() && performCopy) {
+  } else if (stats.isDirectory()) {
     if (!fs.existsSync(dest)) mkdir.mkdirsSync(dest)
     const contents = fs.readdirSync(src)
     contents.forEach(content => {
@@ -53,7 +49,7 @@ function copySync (src, dest, options) {
       opts.recursive = true
       copySync(path.join(src, content), path.join(dest, content), opts)
     })
-  } else if (options.recursive && stats.isSymbolicLink() && performCopy) {
+  } else if (options.recursive && stats.isSymbolicLink()) {
     const srcPath = fs.readlinkSync(src)
     fs.symlinkSync(srcPath, dest)
   }

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -47,14 +47,7 @@ function copy (src, dest, opts, cb) {
 }
 
 function startCopy (src, dest, opts, cb) {
-  if (opts.filter) {
-    if (opts.filter instanceof RegExp) {
-      console.warn('Warning: fs-extra: Passing a RegExp filter is deprecated, use a function')
-      if (!opts.filter.test(src)) return cb()
-    } else if (typeof opts.filter === 'function') {
-      if (!opts.filter(src, dest)) return cb()
-    }
-  }
+  if (opts.filter && !opts.filter(src, dest)) return cb()
   return getStats(src, dest, opts, cb)
 }
 


### PR DESCRIPTION
This was deprecated previously, and is now removed.