### PR TITLE
Fixes fs-extra on linux

### DIFF
--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -9,6 +9,7 @@ const api = [
   'chmod',
   'chown',
   'close',
+  'copyFile',
   'fchmod',
   'fchown',
   'fdatasync',
@@ -20,6 +21,7 @@ const api = [
   'link',
   'lstat',
   'mkdir',
+  'mkdtemp',
   'open',
   'readFile',
   'readdir',
@@ -33,12 +35,13 @@ const api = [
   'unlink',
   'utimes',
   'writeFile'
-]
-// Add methods that are only in some Node.js versions
-// fs.copyFile was added in Node.js v8.5.0
-typeof fs.copyFile === 'function' && api.push('copyFile')
-// fs.mkdtemp() was added in Node.js v5.10.0
-typeof fs.mkdtemp === 'function' && api.push('mkdtemp')
+].filter(key => {
+  // Some commands are not available on some systems. Ex:
+  // fs.copyFile was added in Node.js v8.5.0
+  // fs.mkdtemp was added in Node.js v5.10.0
+  // fs.lchown is not available on at least some Linux
+  return typeof fs[key] === 'function'
+})
 
 // Export all keys:
 Object.keys(fs).forEach(key => {


### PR DESCRIPTION
The `lchown` function is [not available on some systems](https://github.com/nodejs/node/blob/master/lib/fs.js#L1150-L1166). Using `fs-extra` there causes a crash:

    TypeError: Cannot read property 'name' of undefined
      
      at Object.<anonymous>.exports.fromCallback (../node_modules/universalify/index.js:16:26)
      at Object.<anonymous>.api.forEach.method (../node_modules/fs-extra/lib/fs/index.js:50:21)
          at Array.forEach (<anonymous>)

This PR makes sure that all commands exist before trying to convert them.