### PR TITLE
Add async/await usage example (closes #506)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ const fs = require('fs')
 const fse = require('fs-extra')
 ```
 
-Sync vs Async
+Sync vs Async vs Async/Await
 -------------
 Most methods are async by default. All async methods will return a promise if the callback isn't passed.
 
 Sync methods on the other hand will throw if an error occurs.
+
+Also Async/Await will throw an error if one occurs.
 
 Example:
 
@@ -87,6 +89,18 @@ try {
 } catch (err) {
   console.error(err)
 }
+
+// Async/Await:
+const copyFiles = async () => {
+  try {
+    await fs.copy('/tmp/myfile', '/tmp/mynewfile')
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+copyFiles()
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ try {
 }
 
 // Async/Await:
-const copyFiles = async () => {
+async function copyFiles () {
   try {
     await fs.copy('/tmp/myfile', '/tmp/mynewfile')
     console.log('success!')

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -17,6 +17,7 @@ Copy a file or directory. The directory can have contents. Like `cp -r`.
 ```js
 const fs = require('fs-extra')
 
+// With a callback:
 fs.copy('/tmp/myfile', '/tmp/mynewfile', err => {
   if (err) return console.error(err)
 
@@ -29,7 +30,7 @@ fs.copy('/tmp/mydir', '/tmp/mynewdir', err => {
   console.log('success!')
 }) // copies directory, even if it has subdirectories or files
 
-// Promise usage:
+// With Promises:
 fs.copy('/tmp/myfile', '/tmp/mynewfile')
 .then(() => {
   console.log('success!')
@@ -37,6 +38,18 @@ fs.copy('/tmp/myfile', '/tmp/mynewfile')
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example () {
+  try {
+    await fs.copy('/tmp/myfile', '/tmp/mynewfile')
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example()
 ```
 
 **Using filter function**

--- a/docs/emptyDir.md
+++ b/docs/emptyDir.md
@@ -13,13 +13,14 @@ Ensures that a directory is empty. Deletes directory contents if the directory i
 const fs = require('fs-extra')
 
 // assume this directory has a lot of files and folders
+// With a callback:
 fs.emptyDir('/tmp/some/dir', err => {
   if (err) return console.error(err)
 
   console.log('success!')
 })
 
-// With promises
+// With Promises:
 fs.emptyDir('/tmp/some/dir')
 .then(() => {
   console.log('success!')
@@ -27,4 +28,16 @@ fs.emptyDir('/tmp/some/dir')
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example () {
+  try {
+    await fs.emptyDir('/tmp/some/dir')
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example()
 ```

--- a/docs/ensureDir.md
+++ b/docs/ensureDir.md
@@ -13,6 +13,8 @@ Ensures that the directory exists. If the directory structure does not exist, it
 const fs = require('fs-extra')
 
 const dir = '/tmp/this/path/does/not/exist'
+
+// With a callback:
 fs.ensureDir(dir, err => {
   console.log(err) // => null
   // dir has now been created, including the directory it is to be placed in
@@ -26,4 +28,16 @@ fs.ensureDir(dir)
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (directory) {
+  try {
+    await fs.ensureDir(directory)
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(dir)
 ```

--- a/docs/ensureFile.md
+++ b/docs/ensureFile.md
@@ -13,6 +13,8 @@ Ensures that the file exists. If the file that is requested to be created is in 
 const fs = require('fs-extra')
 
 const file = '/tmp/this/path/does/not/exist/file.txt'
+
+// With a callback:
 fs.ensureFile(file, err => {
   console.log(err) // => null
   // file has now been created, including the directory it is to be placed in
@@ -26,4 +28,16 @@ fs.ensureFile(file)
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (f) {
+  try {
+    await fs.ensureFile(f)
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(file)
 ```

--- a/docs/ensureLink.md
+++ b/docs/ensureLink.md
@@ -13,6 +13,8 @@ const fs = require('fs-extra')
 
 const srcpath = '/tmp/file.txt'
 const dstpath = '/tmp/this/path/does/not/exist/file.txt'
+
+// With a callback:
 fs.ensureLink(srcpath, dstpath, err => {
   console.log(err) // => null
   // link has now been created, including the directory it is to be placed in
@@ -26,4 +28,16 @@ fs.ensureLink(srcpath, dstpath)
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (src, dest) {
+  try {
+    await fs.ensureLink(src, dest)
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(srcpath, dstpath)
 ```

--- a/docs/ensureSymlink.md
+++ b/docs/ensureSymlink.md
@@ -14,6 +14,8 @@ const fs = require('fs-extra')
 
 const srcpath = '/tmp/file.txt'
 const dstpath = '/tmp/this/path/does/not/exist/file.txt'
+
+// With a callback:
 fs.ensureSymlink(srcpath, dstpath, err => {
   console.log(err) // => null
   // symlink has now been created, including the directory it is to be placed in
@@ -27,4 +29,16 @@ fs.ensureSymlink(srcpath, dstpath)
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (src, dest) {
+  try {
+    await fs.ensureSymlink(src, dest)
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(srcpath, dstpath)
 ```

--- a/docs/fs-read-write.md
+++ b/docs/fs-read-write.md
@@ -9,14 +9,14 @@ Here's the example promise usage:
 ## `fs.read()`
 
 ```js
-// Basic promises
+// With Promises:
 fs.read(fd, buffer, offset, length, position)
   .then(results => {
     console.log(results)
     // { bytesRead: 20, buffer: <Buffer 0f 34 5d ...> }
   })
 
-// Async/await usage:
+// With async/await:
 async function example () {
   const { bytesRead, buffer } = await fs.read(fd, Buffer.alloc(length), offset, length, position)
 }
@@ -25,14 +25,14 @@ async function example () {
 ## `fs.write()`
 
 ```js
-// Basic promises
+// With Promises:
 fs.write(fd, buffer, offset, length, position)
   .then(results => {
     console.log(results)
     // { bytesWritten: 20, buffer: <Buffer 0f 34 5d ...> }
   })
 
-// Async/await usage:
+// With async/await:
 async function example () {
   const { bytesWritten, buffer } = await fs.write(fd, Buffer.alloc(length), offset, length, position)
 }

--- a/docs/move.md
+++ b/docs/move.md
@@ -13,19 +13,36 @@ Moves a file or directory, even across devices.
 ```js
 const fs = require('fs-extra')
 
-fs.move('/tmp/somefile', '/tmp/does/not/exist/yet/somefile', err => {
+const srcpath = '/tmp/file.txt'
+const dstpath = '/tmp/this/path/does/not/exist/file.txt'
+
+// With a callback:
+fs.move(srcpath, dstpath, err => {
   if (err) return console.error(err)
 
   console.log('success!')
 })
 
-fs.move('/tmp/somefile', '/tmp/does/not/exist/yet/somefile')
+// With Promises:
+fs.move(srcpath, dstpath)
 .then(() => {
   console.log('success!')
 })
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (src, dest) {
+  try {
+    await fs.move(srcpath, dstpath)
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(srcpath, dstpath)
 ```
 
 **Using `overwrite` option**

--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -13,6 +13,8 @@ Almost the same as `writeFile` (i.e. it [overwrites](http://pages.citebite.com/v
 const fs = require('fs-extra')
 
 const file = '/tmp/this/path/does/not/exist/file.txt'
+
+// With a callback:
 fs.outputFile(file, 'hello!', err => {
   console.log(err) // => null
 
@@ -31,4 +33,19 @@ fs.outputFile(file, 'hello!')
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (f) {
+  try {
+    await fs.outputFile(f, 'hello!')
+
+    const data = await fs.readFile(f, 'utf8')
+
+    console.log(data) // => hello!
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(file)
 ```

--- a/docs/outputJson.md
+++ b/docs/outputJson.md
@@ -19,6 +19,8 @@ Almost the same as [`writeJson`](writeJson.md), except that if the directory doe
 const fs = require('fs-extra')
 
 const file = '/tmp/this/path/does/not/exist/file.json'
+
+// With a callback:
 fs.outputJson(file, {name: 'JP'}, err => {
   console.log(err) // => null
 
@@ -37,4 +39,19 @@ fs.outputJson(file, {name: 'JP'})
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (f) {
+  try {
+    await fs.outputJson(f, {name: 'JP'})
+
+    const data = await fs.readJson(f)
+
+    console.log(data.name) // => JP
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example(file)
 ```

--- a/docs/pathExists.md
+++ b/docs/pathExists.md
@@ -11,12 +11,23 @@ Test whether or not the given path exists by checking with the file system. Like
 const fs = require('fs-extra')
 
 const file = '/tmp/this/path/does/not/exist/file.txt'
-// Promise usage:
-fs.pathExists(file)
-  .then(exists => console.log(exists)) // => false
-// Callback usage:
+
+// With a callback:
 fs.pathExists(file, (err, exists) => {
   console.log(err) // => null
   console.log(exists) // => false
 })
+
+// Promise usage:
+fs.pathExists(file)
+  .then(exists => console.log(exists)) // => false
+
+// With async/await:
+async function example (f) {
+  const exists = await fs.pathExists(f)
+
+  console.error(exists) // => false
+}
+
+example(file)
 ```

--- a/docs/pathExists.md
+++ b/docs/pathExists.md
@@ -26,7 +26,7 @@ fs.pathExists(file)
 async function example (f) {
   const exists = await fs.pathExists(f)
 
-  console.error(exists) // => false
+  console.log(exists) // => false
 }
 
 example(file)

--- a/docs/readJson.md
+++ b/docs/readJson.md
@@ -14,13 +14,14 @@ that you'd pass to [`jsonFile.readFile`](https://github.com/jprichardson/node-js
 ```js
 const fs = require('fs-extra')
 
+// With a callback:
 fs.readJson('./package.json', (err, packageObj) => {
   if (err) console.error(err)
 
   console.log(packageObj.version) // => 0.1.3
 })
 
-// Promise Usage
+// With Promises:
 fs.readJson('./package.json')
 .then(packageObj => {
   console.log(packageObj.version) // => 0.1.3
@@ -28,6 +29,19 @@ fs.readJson('./package.json')
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example () {
+  try {
+    const packageObj = await fs.readJson('./package.json')
+
+    console.log(packageObj.version) // => 0.1.3
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example()
 ```
 
 ---
@@ -41,13 +55,14 @@ const file = '/tmp/some-invalid.json'
 const data = '{not valid JSON'
 fs.writeFileSync(file, data)
 
+// With a callback:
 fs.readJson(file, { throws: false }, (err, obj) => {
   if (err) console.error(err)
 
   console.log(obj) // => null
 })
 
-// Promise Usage
+// Wtih Promises:
 fs.readJson(file, { throws: false })
 .then(obj => {
   console.log(obj) // => null
@@ -55,4 +70,13 @@ fs.readJson(file, { throws: false })
 .catch(err => {
   console.error(err) // Not called
 })
+
+// With async/await:
+async function example (f) {
+  const obj = await fs.readJson(f, { throws: false })
+
+  console.log(obj) // => null
+}
+
+example(file)
 ```

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -11,6 +11,7 @@ Removes a file or directory. The directory can have contents. Like `rm -rf`.
 const fs = require('fs-extra')
 
 // remove file
+// With a callback:
 fs.remove('/tmp/myfile', err => {
   if (err) return console.error(err)
 
@@ -23,7 +24,7 @@ fs.remove('/home/jprichardson', err => {
   console.log('success!') // I just deleted my entire HOME directory.
 })
 
-// Promise Usage
+// With Promises:
 fs.remove('/tmp/myfile')
 .then(() => {
   console.log('success!')
@@ -31,4 +32,16 @@ fs.remove('/tmp/myfile')
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example (src, dest) {
+  try {
+    await fs.remove('/tmp/myfile')
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example()
 ```

--- a/docs/writeJson.md
+++ b/docs/writeJson.md
@@ -18,13 +18,14 @@ Writes an object to a JSON file.
 ```js
 const fs = require('fs-extra')
 
+// With a callback:
 fs.writeJson('./package.json', {name: 'fs-extra'}, err => {
   if (err) return console.error(err)
 
   console.log('success!')
 })
 
-// With Promises
+// With Promises:
 fs.writeJson('./package.json', {name: 'fs-extra'})
 .then(() => {
   console.log('success!')
@@ -32,6 +33,18 @@ fs.writeJson('./package.json', {name: 'fs-extra'})
 .catch(err => {
   console.error(err)
 })
+
+// With async/await:
+async function example () {
+  try {
+    await fs.writeJson('./package.json', {name: 'fs-extra'})
+    console.log('success!')
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+example()
 ```
 
 ---


### PR DESCRIPTION
Assuming that [runkit](https://runkit.com/jpeer264/5a532978dcd17c00124b836d) works in all cases.

Should a example be added to every method as well (right under the `Promise usage:`)? 