### PR TITLE
Docs: add copy note for src

### DIFF
--- a/docs/copy-sync.md
+++ b/docs/copy-sync.md
@@ -2,8 +2,8 @@
 
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 
-- `src` `<String>`
-- `dest` `<String>`
+- `src` `<String>` Note that if `src` is a directory it will copy everything inside of this directory, not the entire directory itself (see [issue #537](https://github.com/jprichardson/node-fs-extra/issues/537)).
+- `dest` `<String>` Note that if `src` is a file, `dest` cannot be a directory (see [issue #323](https://github.com/jprichardson/node-fs-extra/issues/323)).
 - `options` `<Object>`
   - `overwrite` `<boolean>`: overwrite existing file or directory, default is `true`. _Note that the copy operation will silently fail if you set this to `false` and the destination exists._ Use the `errorOnExist` option to change this behavior.
   - `errorOnExist` `<boolean>`: when `overwrite` is `false` and the destination exists, throw an error. Default is `false`.

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -2,7 +2,7 @@
 
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 
-- `src` `<String>`
+- `src` `<String>` Note that if `src` is a directory it will copy everything inside of this directory, not the entire directory itself (see [issue #537](https://github.com/jprichardson/node-fs-extra/issues/537)).
 - `dest` `<String>` Note that if `src` is a file, `dest` cannot be a directory (see [issue #323](https://github.com/jprichardson/node-fs-extra/issues/323)).
 - `options` `<Object>`
   - `overwrite` `<boolean>`: overwrite existing file or directory, default is `true`. _Note that the copy operation will silently fail if you set this to `false` and the destination exists._ Use the `errorOnExist` option to change this behavior.


### PR DESCRIPTION
Could finally made the PR after the Github downtime 👍 

I hope the note for clarifying #537 is understandable. It's also right after the `src`, I took the `dest` note as an example (which I also added in `copy-sync`)