### PR TITLE
fix function isSrcSubdir in the copy-sync.js and copy.js

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
@@ -63,6 +63,14 @@ describe('+ copySync() - prevent copying into itself', () => {
 
   describe('> when source is a directory', () => {
     describe('>> when dest is a directory', () => {
+      it(`of not itself`, done => {
+        const dest = path.join(TEST_DIR, src.replace(/^\w:/, ''))
+        return testSuccess(src, dest, done)
+      })
+      it(`of itself`, done => {
+        const dest = path.join(src, 'dest')
+        return testError(src, dest, done)
+      })
       it(`should copy the directory successfully when dest is 'src_dest'`, done => {
         const dest = path.join(TEST_DIR, 'src_dest')
         return testSuccess(src, dest, done)

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -195,15 +195,12 @@ function checkDest (dest) {
 // return true if dest is a subdir of src, otherwise false.
 // extract dest base dir and check if that is the same as src basename
 function isSrcSubdir (src, dest) {
-  const baseDir = dest.split(path.dirname(src) + path.sep)[1]
-  if (baseDir) {
-    const destBasename = baseDir.split(path.sep)[0]
-    if (destBasename) {
-      return src !== dest && dest.indexOf(src) > -1 && destBasename === path.basename(src)
-    }
-    return false
-  }
-  return false
+  let srcArray = src.split(path.sep)
+  let destArray = dest.split(path.sep)
+
+  return srcArray.reduce((acc, current, i) => {
+    return acc && destArray[i] === current
+  }, true)
 }
 
 module.exports = copySync

--- a/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
@@ -63,6 +63,14 @@ describe('+ copy() - prevent copying into itself', () => {
 
   describe('> when source is a directory', () => {
     describe('>> when dest is a directory', () => {
+      it(`of not itself`, done => {
+        const dest = path.join(TEST_DIR, src.replace(/^\w:/, ''))
+        return testSuccess(src, dest, done)
+      })
+      it(`of itself`, done => {
+        const dest = path.join(src, 'dest')
+        return testError(src, dest, done)
+      })
       it(`should copy the directory successfully when dest is 'src_dest'`, done => {
         const dest = path.join(TEST_DIR, 'src_dest')
         return testSuccess(src, dest, done)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -250,15 +250,12 @@ function checkDest (dest, cb) {
 // return true if dest is a subdir of src, otherwise false.
 // extract dest base dir and check if that is the same as src basename
 function isSrcSubdir (src, dest) {
-  const baseDir = dest.split(path.dirname(src) + path.sep)[1]
-  if (baseDir) {
-    const destBasename = baseDir.split(path.sep)[0]
-    if (destBasename) {
-      return src !== dest && dest.indexOf(src) > -1 && destBasename === path.basename(src)
-    }
-    return false
-  }
-  return false
+  let srcArray = src.split(path.sep)
+  let destArray = dest.split(path.sep)
+
+  return srcArray.reduce((acc, current, i) => {
+    return acc && destArray[i] === current
+  }, true)
 }
 
 module.exports = copy


### PR DESCRIPTION
The problem occurs when:
`src = /tmp/path/src`
`dest = /prefix/tmp/path/src`