### PR TITLE
add fs-extra-debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ If you want to watch for changes to files or directories, then you should use [c
 
 ### Misc.
 
+- [fs-extra-debug](https://github.com/jdxcode/fs-extra-debug) - Send your fs-extra calls to [debug](https://npmjs.org/package/debug).
 - [mfs](https://github.com/cadorn/mfs) - Monitor your fs-extra calls.
 
 


### PR DESCRIPTION
`mfs` uses a very outdated version of `fs-extra` that it requires in `dependencies`. I think it should probably be removed.

My package isn't quite as flexible (yet), but it solves my problem for now.