### PR TITLE
move: rewrite move to use fs.rename

### DIFF
--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -124,6 +124,28 @@ describe('+ move()', () => {
         done()
       })
     })
+
+    it('should overwrite folders across devices', done => {
+      const src = path.join(TEST_DIR, 'a-folder')
+      const dest = path.join(TEST_DIR, 'a-folder-dest')
+
+      fs.mkdirSync(dest)
+
+      setUpMockFs('EXDEV')
+
+      fse.move(src, dest, {overwrite: true}, err => {
+        assert.ifError(err)
+        assert.strictEqual(fs.rename.callCount, 1)
+
+        fs.readFile(path.join(dest, 'another-folder', 'file3'), 'utf8', (err, contents) => {
+          const expected = /^knuckles\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          tearDownMockFs()
+          done()
+        })
+      })
+    })
   })
 
   describe('> when overwrite = false', () => {
@@ -148,6 +170,16 @@ describe('+ move()', () => {
 
       fse.move(src, dest, err => {
         assert.ifError(err)
+        done()
+      })
+    })
+
+    it('should error if source and destination are the same and source does not exist', done => {
+      const src = path.join(TEST_DIR, 'non-existent')
+      const dest = src
+
+      fse.move(src, dest, err => {
+        assert(err)
         done()
       })
     })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -69,32 +69,6 @@ describe('+ move()', () => {
       })
     })
 
-    it('should throw error if src is file and dest is directory', done => {
-      const src = path.join(TEST_DIR, 'a-file')
-      const dest = path.join(TEST_DIR, 'a-folder')
-
-      // verify file exists already
-      assert(fs.existsSync(dest))
-
-      fse.move(src, dest, {overwrite: true}, err => {
-        assert.strictEqual(err.message, `Cannot move file '${src}' to directory '${dest}'.`)
-        done()
-      })
-    })
-
-    it('should throw error if src is directory and dest is file', done => {
-      const src = path.join(TEST_DIR, 'a-folder')
-      const dest = path.join(TEST_DIR, 'a-file')
-
-      // verify file exists already
-      assert(fs.existsSync(dest))
-
-      fse.move(src, dest, {overwrite: true}, err => {
-        assert.strictEqual(err.message, `Cannot move directory '${src}' to file '${dest}'.`)
-        done()
-      })
-    })
-
     it('should overwrite the destination directory', done => {
       // Create src
       const src = path.join(TEST_DIR, 'src')

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -5,7 +5,6 @@ const os = require('os')
 const fse = require(process.cwd())
 const path = require('path')
 const assert = require('assert')
-const rimraf = require('rimraf')
 
 /* global afterEach, beforeEach, describe, it */
 
@@ -24,19 +23,16 @@ function createAsyncErrFn (errCode) {
 }
 
 const originalRename = fs.rename
-const originalLink = fs.link
 
 function setUpMockFs (errCode) {
   fs.rename = createAsyncErrFn(errCode)
-  fs.link = createAsyncErrFn(errCode)
 }
 
 function tearDownMockFs () {
   fs.rename = originalRename
-  fs.link = originalLink
 }
 
-describe('move', () => {
+describe('+ move()', () => {
   let TEST_DIR
 
   beforeEach(() => {
@@ -52,256 +48,227 @@ describe('move', () => {
     fs.writeFileSync(path.join(TEST_DIR, 'a-folder/another-folder/file3'), 'knuckles\n')
   })
 
-  afterEach(done => rimraf(TEST_DIR, done))
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-  it('should rename a file on the same device', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/a-file-dest`
+  describe('> when overwrite = true', () => {
+    it('should overwrite file', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-folder', 'another-file')
 
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      fs.readFile(dest, 'utf8', (err, contents) => {
-        const expected = /^sonic the hedgehog\r?\n$/
+      // verify file exists already
+      assert(fs.existsSync(dest))
+
+      fse.move(src, dest, {overwrite: true}, err => {
         assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          done()
+        })
+      })
+    })
+
+    it('should throw error if src is file and dest is directory', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-folder')
+
+      // verify file exists already
+      assert(fs.existsSync(dest))
+
+      fse.move(src, dest, {overwrite: true}, err => {
+        assert.strictEqual(err.message, `Cannot move file '${src}' to directory '${dest}'.`)
         done()
       })
     })
-  })
 
-  it('should not move a file if source and destination are the same', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = src
+    it('should throw error if src is directory and dest is file', done => {
+      const src = path.join(TEST_DIR, 'a-folder')
+      const dest = path.join(TEST_DIR, 'a-file')
 
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      done()
-    })
-  })
+      // verify file exists already
+      assert(fs.existsSync(dest))
 
-  it('should error if source and destination are the same and source does not exist', done => {
-    const src = `${TEST_DIR}/non-existent`
-    const dest = src
-
-    fse.move(src, dest, err => {
-      assert(err)
-      done()
-    })
-  })
-
-  it('should not move a directory if source and destination are the same', done => {
-    const src = `${TEST_DIR}/a-folder`
-    const dest = src
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      done()
-    })
-  })
-
-  it('should not overwrite the destination by default', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/a-folder/another-file`
-
-    // verify file exists already
-    assert(fs.existsSync(dest))
-
-    fse.move(src, dest, err => {
-      assert.ok(err && err.code === 'EEXIST', 'throw EEXIST')
-      done()
-    })
-  })
-
-  it('should not overwrite if overwrite = false', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/a-folder/another-file`
-
-    // verify file exists already
-    assert(fs.existsSync(dest))
-
-    fse.move(src, dest, {overwrite: false}, err => {
-      assert.ok(err && err.code === 'EEXIST', 'throw EEXIST')
-      done()
-    })
-  })
-
-  it('should overwrite file if overwrite = true', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/a-folder/another-file`
-
-    // verify file exists already
-    assert(fs.existsSync(dest))
-
-    fse.move(src, dest, {overwrite: true}, err => {
-      assert.ifError(err)
-      fs.readFile(dest, 'utf8', (err, contents) => {
-        const expected = /^sonic the hedgehog\r?\n$/
-        assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
+      fse.move(src, dest, {overwrite: true}, err => {
+        assert.strictEqual(err.message, `Cannot move directory '${src}' to file '${dest}'.`)
         done()
       })
     })
-  })
 
-  it('should overwrite the destination directory if overwrite = true', function (done) {
-    // Create src
-    const src = path.join(TEST_DIR, 'src')
-    fse.ensureDirSync(src)
-    fse.mkdirsSync(path.join(src, 'some-folder'))
-    fs.writeFileSync(path.join(src, 'some-file'), 'hi')
+    it('should overwrite the destination directory', done => {
+      // Create src
+      const src = path.join(TEST_DIR, 'src')
+      fse.ensureDirSync(src)
+      fse.mkdirsSync(path.join(src, 'some-folder'))
+      fs.writeFileSync(path.join(src, 'some-file'), 'hi')
 
-    const dest = path.join(TEST_DIR, 'a-folder')
+      const dest = path.join(TEST_DIR, 'a-folder')
 
-    // verify dest has stuff in it
-    const paths = fs.readdirSync(dest)
-    assert(paths.indexOf('another-file') >= 0)
-    assert(paths.indexOf('another-folder') >= 0)
-
-    fse.move(src, dest, {overwrite: true}, err => {
-      assert.ifError(err)
-
-      // verify dest does not have old stuff
+      // verify dest has stuff in it
       const paths = fs.readdirSync(dest)
-      assert.strictEqual(paths.indexOf('another-file'), -1)
-      assert.strictEqual(paths.indexOf('another-folder'), -1)
+      assert(paths.indexOf('another-file') >= 0)
+      assert(paths.indexOf('another-folder') >= 0)
 
-      // verify dest has new stuff
-      assert(paths.indexOf('some-file') >= 0)
-      assert(paths.indexOf('some-folder') >= 0)
-
-      done()
-    })
-  })
-
-  it('should create directory structure by default', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/does/not/exist/a-file-dest`
-
-    // verify dest directory does not exist
-    assert(!fs.existsSync(path.dirname(dest)))
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      fs.readFile(dest, 'utf8', (err, contents) => {
-        const expected = /^sonic the hedgehog\r?\n$/
+      fse.move(src, dest, {overwrite: true}, err => {
         assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
-        done()
-      })
-    })
-  })
 
-  it('should work across devices', done => {
-    const src = `${TEST_DIR}/a-file`
-    const dest = `${TEST_DIR}/a-file-dest`
+        // verify dest does not have old stuff
+        const paths = fs.readdirSync(dest)
+        assert.strictEqual(paths.indexOf('another-file'), -1)
+        assert.strictEqual(paths.indexOf('another-folder'), -1)
 
-    setUpMockFs('EXDEV')
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
-
-      fs.readFile(dest, 'utf8', (err, contents) => {
-        const expected = /^sonic the hedgehog\r?\n$/
-        assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
-
-        tearDownMockFs()
-        done()
-      })
-    })
-  })
-
-  it('should move folders', done => {
-    const src = `${TEST_DIR}/a-folder`
-    const dest = `${TEST_DIR}/a-folder-dest`
-
-    // verify it doesn't exist
-    assert(!fs.existsSync(dest))
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      fs.readFile(dest + '/another-file', 'utf8', (err, contents) => {
-        const expected = /^tails\r?\n$/
-        assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
-        done()
-      })
-    })
-  })
-
-  it('should move folders across devices with EISDIR error', done => {
-    const src = `${TEST_DIR}/a-folder`
-    const dest = `${TEST_DIR}/a-folder-dest`
-
-    setUpMockFs('EISDIR')
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
-
-      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
-        const expected = /^knuckles\r?\n$/
-        assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
-
-        tearDownMockFs('EISDIR')
+        // verify dest has new stuff
+        assert(paths.indexOf('some-file') >= 0)
+        assert(paths.indexOf('some-folder') >= 0)
 
         done()
       })
     })
   })
 
-  it('should overwrite folders across devices', done => {
-    const src = `${TEST_DIR}/a-folder`
-    const dest = `${TEST_DIR}/a-folder-dest`
+  describe('> when overwrite = false', () => {
+    it('should rename a file on the same device', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-file-dest')
 
-    fs.mkdirSync(dest)
-
-    setUpMockFs('EXDEV')
-
-    fse.move(src, dest, {overwrite: true}, err => {
-      assert.ifError(err)
-      assert.strictEqual(fs.rename.callCount, 1)
-
-      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
-        const expected = /^knuckles\r?\n$/
+      fse.move(src, dest, err => {
         assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          done()
+        })
+      })
+    })
 
-        tearDownMockFs('EXDEV')
+    it('should not move a file if source and destination are the same', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = src
 
+      fse.move(src, dest, err => {
+        assert.ifError(err)
         done()
+      })
+    })
+
+    it('should not move a directory if source and destination are the same', done => {
+      const src = path.join(TEST_DIR, 'a-folder')
+      const dest = src
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        done()
+      })
+    })
+
+    it('should not overwrite the destination by default', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-folder', 'another-file')
+
+      // verify file exists already
+      assert(fs.existsSync(dest))
+
+      fse.move(src, dest, err => {
+        assert.ok(err.message, 'dest already exists.')
+        done()
+      })
+    })
+
+    it('should not overwrite if overwrite = false', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-folder', 'another-file')
+
+      // verify file exists already
+      assert(fs.existsSync(dest))
+
+      fse.move(src, dest, {overwrite: false}, err => {
+        assert.ok(err.message, 'dest already exists.')
+        done()
+      })
+    })
+
+    it('should create directory structure by default', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'does', 'not', 'exist', 'a-file-dest')
+
+      // verify dest directory does not exist
+      assert(!fs.existsSync(path.dirname(dest)))
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          done()
+        })
+      })
+    })
+
+    it('should work across devices', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-file-dest')
+
+      setUpMockFs('EXDEV')
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        assert.strictEqual(fs.rename.callCount, 1)
+
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          tearDownMockFs()
+          done()
+        })
+      })
+    })
+
+    it('should move folders', done => {
+      const src = path.join(TEST_DIR, 'a-folder')
+      const dest = path.join(TEST_DIR, 'a-folder-dest')
+
+      // verify it doesn't exist
+      assert(!fs.existsSync(dest))
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        fs.readFile(path.join(dest, 'another-file'), 'utf8', (err, contents) => {
+          const expected = /^tails\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          done()
+        })
+      })
+    })
+
+    it('should move folders across devices with EXDEV error', done => {
+      const src = path.join(TEST_DIR, 'a-folder')
+      const dest = path.join(TEST_DIR, 'a-folder-dest')
+
+      setUpMockFs('EXDEV')
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        assert.strictEqual(fs.rename.callCount, 1)
+
+        fs.readFile(path.join(dest, 'another-folder', 'file3'), 'utf8', (err, contents) => {
+          const expected = /^knuckles\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          tearDownMockFs()
+          done()
+        })
       })
     })
   })
 
-  it('should move folders across devices with EXDEV error', done => {
-    const src = `${TEST_DIR}/a-folder`
-    const dest = `${TEST_DIR}/a-folder-dest`
-
-    setUpMockFs('EXDEV')
-
-    fse.move(src, dest, err => {
-      assert.ifError(err)
-      assert.strictEqual(fs.link.callCount, 1)
-
-      fs.readFile(dest + '/another-folder/file3', 'utf8', (err, contents) => {
-        const expected = /^knuckles\r?\n$/
-        assert.ifError(err)
-        assert.ok(contents.match(expected), `${contents} match ${expected}`)
-
-        tearDownMockFs()
-
-        done()
-      })
-    })
-  })
-
-  describe('clobber', () => {
+  describe('> clobber', () => {
     it('should be an alias for overwrite', done => {
-      const src = `${TEST_DIR}/a-file`
-      const dest = `${TEST_DIR}/a-folder/another-file`
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-folder', 'another-file')
 
       // verify file exists already
       assert(fs.existsSync(dest))
@@ -358,7 +325,7 @@ describe('move', () => {
 
     const _it = __skipTests ? it.skip : it
 
-    describe('> just the folder', () => {
+    describe('>> just the folder', () => {
       _it('should move the folder', done => {
         const src = '/mnt/some/weird/dir-really-weird'
         const dest = path.join(TEST_DIR, 'device-weird')
@@ -374,7 +341,6 @@ describe('move', () => {
         fse.move(src, dest, err => {
           assert.ifError(err)
           assert(fs.existsSync(dest))
-          // console.log(path.normalize(dest))
           assert(fs.lstatSync(dest).isDirectory())
           done()
         })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -202,7 +202,7 @@ describe('+ move()', () => {
       assert(fs.existsSync(dest))
 
       fse.move(src, dest, err => {
-        assert.ok(err.message, 'dest already exists.')
+        assert.strictEqual(err.message, 'dest already exists.')
         done()
       })
     })
@@ -215,7 +215,7 @@ describe('+ move()', () => {
       assert(fs.existsSync(dest))
 
       fse.move(src, dest, {overwrite: false}, err => {
-        assert.ok(err.message, 'dest already exists.')
+        assert.strictEqual(err.message, 'dest already exists.')
         done()
       })
     })

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -1,15 +1,11 @@
 'use strict'
 
-// most of this code was written by Andrew Kelley
-// licensed under the BSD license: see
-// https://github.com/andrewrk/node-mv/blob/master/package.json
-
 const u = require('universalify').fromCallback
 const fs = require('graceful-fs')
 const path = require('path')
 const copy = require('../copy').copy
 const remove = require('../remove').remove
-const mkdirp = require('../mkdirs').mkdirs
+const mkdirp = require('../mkdirs').mkdirp
 
 const destIsFile = Symbol('destIsFile')
 const destIsDir = Symbol('destIsDir')
@@ -24,26 +20,22 @@ function move (src, dest, opts, cb) {
 
   src = path.resolve(src)
   dest = path.resolve(dest)
+
   if (src === dest) return fs.access(src, cb)
 
   fs.stat(src, (err, st) => {
     if (err) return cb(err)
-    if (st.isDirectory()) {
-      if (isSrcSubdir(src, dest)) return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
-      checkDest(dest, (err, res) => {
-        if (err) return cb(err)
-        if (res === destIsFile) return cb(new Error(`Cannot move directory '${src}' to file '${dest}'.`))
-        if (!overwrite && res) return cb(new Error('dest already exists.'))
-        return doRename(src, dest, overwrite, cb)
-      })
-    } else {
-      checkDest(dest, (err, res) => {
-        if (err) return cb(err)
-        if (res === destIsDir) return cb(new Error(`Cannot move file '${src}' to directory '${dest}'.`))
-        if (!overwrite && res) return cb(new Error('dest already exists.'))
-        return doRename(src, dest, overwrite, cb)
-      })
-    }
+
+    const srcIsDir = st.isDirectory()
+    if (srcIsDir && isSrcSubdir(src, dest)) return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
+
+    checkDest(dest, (err, res) => {
+      if (err) return cb(err)
+      if (!overwrite && res) return cb(new Error('dest already exists.'))
+      if (srcIsDir && res === destIsFile) return cb(new Error(`Cannot move directory '${src}' to file '${dest}'.`))
+      if (!srcIsDir && res === destIsDir) return cb(new Error(`Cannot move file '${src}' to directory '${dest}'.`))
+      return doRename(src, dest, overwrite, cb)
+    })
   })
 }
 
@@ -96,8 +88,7 @@ function checkDest (dest, cb) {
       if (err.code === 'ENOENT') return cb()
       return cb(err)
     }
-    if (st.isDirectory()) return cb(null, destIsDir)
-    return cb(null, destIsFile)
+    return cb(null, st.isDirectory() ? destIsDir : destIsFile)
   })
 }
 

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -4,165 +4,110 @@
 // licensed under the BSD license: see
 // https://github.com/andrewrk/node-mv/blob/master/package.json
 
-// this needs a cleanup
-
 const u = require('universalify').fromCallback
 const fs = require('graceful-fs')
-const copy = require('../copy/copy')
 const path = require('path')
+const copy = require('../copy').copy
 const remove = require('../remove').remove
 const mkdirp = require('../mkdirs').mkdirs
 
-function move (src, dest, options, callback) {
-  if (typeof options === 'function') {
-    callback = options
-    options = {}
+const destIsFile = Symbol('destIsFile')
+const destIsDir = Symbol('destIsDir')
+
+function move (src, dest, opts, cb) {
+  if (typeof opts === 'function') {
+    cb = opts
+    opts = {}
   }
 
-  const overwrite = options.overwrite || options.clobber || false
+  const overwrite = opts.overwrite || opts.clobber || false
 
-  isSrcSubdir(src, dest, (err, itIs) => {
-    if (err) return callback(err)
-    if (itIs) return callback(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
-    mkdirp(path.dirname(dest), err => {
-      if (err) return callback(err)
-      doRename()
-    })
-  })
+  src = path.resolve(src)
+  dest = path.resolve(dest)
+  if (src === dest) return cb()
 
-  function doRename () {
-    if (path.resolve(src) === path.resolve(dest)) {
-      fs.access(src, callback)
-    } else if (overwrite) {
-      fs.rename(src, dest, err => {
-        if (!err) return callback()
-
-        if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST') {
-          remove(dest, err => {
-            if (err) return callback(err)
-            options.overwrite = false // just overwriteed it, no need to do it again
-            move(src, dest, options, callback)
-          })
-          return
-        }
-
-        // weird Windows shit
-        if (err.code === 'EPERM') {
-          setTimeout(() => {
-            remove(dest, err => {
-              if (err) return callback(err)
-              options.overwrite = false
-              move(src, dest, options, callback)
-            })
-          }, 200)
-          return
-        }
-
-        if (err.code !== 'EXDEV') return callback(err)
-        moveAcrossDevice(src, dest, overwrite, callback)
-      })
-    } else {
-      fs.link(src, dest, err => {
-        if (err) {
-          if (err.code === 'EXDEV' || err.code === 'EISDIR' || err.code === 'EPERM' || err.code === 'ENOTSUP') {
-            return moveAcrossDevice(src, dest, overwrite, callback)
-          }
-          return callback(err)
-        }
-        return fs.unlink(src, callback)
-      })
-    }
-  }
-}
-
-function moveAcrossDevice (src, dest, overwrite, callback) {
-  fs.stat(src, (err, stat) => {
-    if (err) return callback(err)
-
-    if (stat.isDirectory()) {
-      moveDirAcrossDevice(src, dest, overwrite, callback)
-    } else {
-      moveFileAcrossDevice(src, dest, overwrite, callback)
-    }
-  })
-}
-
-function moveFileAcrossDevice (src, dest, overwrite, callback) {
-  const flags = overwrite ? 'w' : 'wx'
-  const ins = fs.createReadStream(src)
-  const outs = fs.createWriteStream(dest, { flags })
-
-  ins.on('error', err => {
-    ins.destroy()
-    outs.destroy()
-    outs.removeListener('close', onClose)
-
-    // may want to create a directory but `out` line above
-    // creates an empty file for us: See #108
-    // don't care about error here
-    fs.unlink(dest, () => {
-      // note: `err` here is from the input stream errror
-      if (err.code === 'EISDIR' || err.code === 'EPERM') {
-        moveDirAcrossDevice(src, dest, overwrite, callback)
-      } else {
-        callback(err)
-      }
-    })
-  })
-
-  outs.on('error', err => {
-    ins.destroy()
-    outs.destroy()
-    outs.removeListener('close', onClose)
-    callback(err)
-  })
-
-  outs.once('close', onClose)
-  ins.pipe(outs)
-
-  function onClose () {
-    fs.unlink(src, callback)
-  }
-}
-
-function moveDirAcrossDevice (src, dest, overwrite, callback) {
-  const options = {
-    overwrite: false
-  }
-
-  if (overwrite) {
-    remove(dest, err => {
-      if (err) return callback(err)
-      startCopy()
-    })
-  } else {
-    startCopy()
-  }
-
-  function startCopy () {
-    copy(src, dest, options, err => {
-      if (err) return callback(err)
-      remove(src, callback)
-    })
-  }
-}
-
-// return true if dest is a subdir of src, otherwise false.
-// extract dest base dir and check if that is the same as src basename
-function isSrcSubdir (src, dest, cb) {
   fs.stat(src, (err, st) => {
     if (err) return cb(err)
     if (st.isDirectory()) {
-      const baseDir = dest.split(path.dirname(src) + path.sep)[1]
-      if (baseDir) {
-        const destBasename = baseDir.split(path.sep)[0]
-        if (destBasename) return cb(null, src !== dest && dest.indexOf(src) > -1 && destBasename === path.basename(src))
-        return cb(null, false)
-      }
-      return cb(null, false)
+      if (isSrcSubdir(src, dest)) return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
+      checkDest(dest, (err, res) => {
+        if (err) return cb(err)
+        if (res === destIsFile) return cb(new Error(`Cannot move directory '${src}' to file '${dest}'.`))
+        if (!overwrite && res) return cb(new Error('dest already exists.'))
+        return doRename(src, dest, overwrite, cb)
+      })
+    } else {
+      checkDest(dest, (err, res) => {
+        if (err) return cb(err)
+        if (res === destIsDir) return cb(new Error(`Cannot move file '${src}' to directory '${dest}'.`))
+        if (!overwrite && res) return cb(new Error('dest already exists.'))
+        return doRename(src, dest, overwrite, cb)
+      })
     }
-    return cb(null, false)
   })
+}
+
+function doRename (src, dest, overwrite, cb) {
+  mkdirp(path.dirname(dest), err => {
+    if (err) return cb(err)
+    if (overwrite) return renameOverwrite(src, dest, overwrite, cb)
+    return rename(src, dest, overwrite, cb)
+  })
+}
+
+function renameOverwrite (src, dest, overwrite, cb) {
+  fs.rename(src, dest, err => {
+    if (!err) return cb()
+    if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST' || err.code === 'EPERM') {
+      return remove(dest, err => {
+        if (err) return cb(err)
+        return move(src, dest, {overwrite: overwrite}, cb)
+      })
+    }
+    if (err.code !== 'EXDEV') return cb(err)
+    return moveAcrossDevice(src, dest, overwrite, cb)
+  })
+}
+
+function rename (src, dest, overwrite, cb) {
+  fs.rename(src, dest, err => {
+    if (!err) return cb()
+    if (err.code === 'EPERM') return moveAcrossDevice(src, dest, overwrite, cb)
+    if (err.code !== 'EXDEV') return cb(err)
+    return moveAcrossDevice(src, dest, overwrite, cb)
+  })
+}
+
+function moveAcrossDevice (src, dest, overwrite, cb) {
+  const opts = {
+    overwrite: overwrite,
+    errorOnExist: true
+  }
+
+  copy(src, dest, opts, err => {
+    if (err) return cb(err)
+    return remove(src, cb)
+  })
+}
+
+function checkDest (dest, cb) {
+  fs.stat(dest, (err, st) => {
+    if (err) {
+      if (err.code === 'ENOENT') return cb()
+      return cb(err)
+    }
+    if (st.isDirectory()) return cb(null, destIsDir)
+    return cb(null, destIsFile)
+  })
+}
+
+function isSrcSubdir (src, dest) {
+  const srcArray = src.split(path.sep)
+  const destArray = dest.split(path.sep)
+
+  return srcArray.reduce((acc, current, i) => {
+    return acc && destArray[i] === current
+  }, true)
 }
 
 module.exports = {

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -24,7 +24,7 @@ function move (src, dest, opts, cb) {
 
   src = path.resolve(src)
   dest = path.resolve(dest)
-  if (src === dest) return cb()
+  if (src === dest) return fs.access(src, cb)
 
   fs.stat(src, (err, st) => {
     if (err) return cb(err)

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -6,9 +6,7 @@ const path = require('path')
 const copy = require('../copy').copy
 const remove = require('../remove').remove
 const mkdirp = require('../mkdirs').mkdirp
-
-const destIsFile = Symbol('destIsFile')
-const destIsDir = Symbol('destIsDir')
+const pathExists = require('../path-exists').pathExists
 
 function move (src, dest, opts, cb) {
   if (typeof opts === 'function') {
@@ -26,38 +24,27 @@ function move (src, dest, opts, cb) {
   fs.stat(src, (err, st) => {
     if (err) return cb(err)
 
-    const srcIsDir = st.isDirectory()
-    if (srcIsDir && isSrcSubdir(src, dest)) return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
-
-    checkDest(dest, (err, res) => {
+    if (st.isDirectory() && isSrcSubdir(src, dest)) {
+      return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
+    }
+    mkdirp(path.dirname(dest), err => {
       if (err) return cb(err)
-      if (!overwrite && res) return cb(new Error('dest already exists.'))
-      if (srcIsDir && res === destIsFile) return cb(new Error(`Cannot move directory '${src}' to file '${dest}'.`))
-      if (!srcIsDir && res === destIsDir) return cb(new Error(`Cannot move file '${src}' to directory '${dest}'.`))
       return doRename(src, dest, overwrite, cb)
     })
   })
 }
 
 function doRename (src, dest, overwrite, cb) {
-  mkdirp(path.dirname(dest), err => {
+  if (overwrite) {
+    return remove(dest, err => {
+      if (err) return cb(err)
+      return rename(src, dest, overwrite, cb)
+    })
+  }
+  pathExists(dest, (err, destExists) => {
     if (err) return cb(err)
-    if (overwrite) return renameOverwrite(src, dest, overwrite, cb)
+    if (destExists) return cb(new Error('dest already exists.'))
     return rename(src, dest, overwrite, cb)
-  })
-}
-
-function renameOverwrite (src, dest, overwrite, cb) {
-  fs.rename(src, dest, err => {
-    if (!err) return cb()
-    if (err.code === 'ENOTEMPTY' || err.code === 'EEXIST' || err.code === 'EPERM') {
-      return remove(dest, err => {
-        if (err) return cb(err)
-        return move(src, dest, {overwrite: overwrite}, cb)
-      })
-    }
-    if (err.code !== 'EXDEV') return cb(err)
-    return moveAcrossDevice(src, dest, overwrite, cb)
   })
 }
 
@@ -79,16 +66,6 @@ function moveAcrossDevice (src, dest, overwrite, cb) {
   copy(src, dest, opts, err => {
     if (err) return cb(err)
     return remove(src, cb)
-  })
-}
-
-function checkDest (dest, cb) {
-  fs.stat(dest, (err, st) => {
-    if (err) {
-      if (err.code === 'ENOENT') return cb()
-      return cb(err)
-    }
-    return cb(null, st.isDirectory() ? destIsDir : destIsFile)
   })
 }
 

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -51,7 +51,6 @@ function doRename (src, dest, overwrite, cb) {
 function rename (src, dest, overwrite, cb) {
   fs.rename(src, dest, err => {
     if (!err) return cb()
-    if (err.code === 'EPERM') return moveAcrossDevice(src, dest, overwrite, cb)
     if (err.code !== 'EXDEV') return cb(err)
     return moveAcrossDevice(src, dest, overwrite, cb)
   })


### PR DESCRIPTION
This is with the hope to improve `move()` to handle cross platform compatibility better!

Should resolve #492, #526, #548.

Since OSes are not consistent in error codes (please see my comments in #548), we either have to handle this when errors happen on `fs.rename` based on the OS that current process running, or check dest before the code reaches `fs.rename`. IDK, in my mind, checking dest seemed easier both in terms of implementation and also easier to understand when you read the code.

I like the functional approach for `isSrcSubdir` that @kolgotko introduced in #541. So added here too :grin:

Please feel free to leave any feedback! If we think it looks good, I'll apply the corresponding changes to `moveSync()` as well.