### PR TITLE
copySync, moveSync: remove extra step in reading loop

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -91,11 +91,10 @@ function copyFileFallback (srcStat, src, dest, opts) {
 
   const fdr = fs.openSync(src, 'r')
   const fdw = fs.openSync(dest, 'w', srcStat.mode)
-  let bytesRead = 1
   let pos = 0
 
-  while (bytesRead > 0) {
-    bytesRead = fs.readSync(fdr, _buff, 0, BUF_LENGTH, pos)
+  while (pos < srcStat.size) {
+    const bytesRead = fs.readSync(fdr, _buff, 0, BUF_LENGTH, pos)
     fs.writeSync(fdw, _buff, 0, bytesRead)
     pos += bytesRead
   }

--- a/lib/move-sync/index.js
+++ b/lib/move-sync/index.js
@@ -68,11 +68,10 @@ function moveFileSyncAcrossDevice (src, dest, overwrite) {
   const fdr = fs.openSync(src, 'r')
   const stat = fs.fstatSync(fdr)
   const fdw = fs.openSync(dest, flags, stat.mode)
-  let bytesRead = 1
   let pos = 0
 
-  while (bytesRead > 0) {
-    bytesRead = fs.readSync(fdr, _buff, 0, BUF_LENGTH, pos)
+  while (pos < stat.size) {
+    const bytesRead = fs.readSync(fdr, _buff, 0, BUF_LENGTH, pos)
     fs.writeSync(fdw, _buff, 0, bytesRead)
     pos += bytesRead
   }


### PR DESCRIPTION
By some reasons on our environment `fs.readSync` from node 8.x throws error when try to read data from position which more than size of file. Here is the test script with logs in comments:
https://gist.github.com/wontem/da867f66324e1cbe712c717b5fefb944

Since we start using node 8.x and fs-extra 5.x - the issue is disappeared (fs-extra uses `copyFileSync` from node) but with node 8.x and fs-extra 3.0.1 the issue is reproducible.
While investigating the problem I've noticed that the method `copySync` from fs-extra 3.0.1 uses extra step in its read loop. To be more safe I want to suggest remove this step from fallback logic for `copySync` and for `moveSync` in fs-extra 5.x