### PR TITLE
BREAKING: Drop builds for Node 4, 5, & 7; add OSX builds & Node 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
 sudo: false
 language: node_js
+os:
+  - linux
+  - osx
+node_js:
+  - 6
+  - 8
+  - 9
+env: TEST_SUITE=unit
 matrix:
+  exclude:
+    - os: linux
+      node_js: 8
   include:
-    - node_js: "4"
-    - node_js: "5"
-    # We run both lint and unit on Node 6
-    - node_js: "6"
-      env: TEST_SUITE=test
-    - node_js: "7"
-    # We run coverage on Node 8
-    - node_js: "8"
-      env: TEST_SUITE=coverage
-env:
-  - TEST_SUITE=unit
+    - os: linux
+      node_js: 8
+      env: TEST_SUITE=full-ci
 script: npm run-script $TEST_SUITE
 after_success:
-  - if [ $TEST_SUITE = coverage ]; then npm run coveralls; fi
+  - if [ $TEST_SUITE = full-ci ]; then npm run coveralls; fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,6 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "4"
     - nodejs_version: "6"
     - nodejs_version: "8"
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "main": "./lib/index.js",
   "scripts": {
+    "full-ci": "npm run lint && npm run coverage",
     "coverage": "istanbul cover -i 'lib/**' -x '**/__tests__/**' test.js",
     "coveralls": "coveralls < coverage/lcov.info",
     "lint": "standard && standard-markdown",


### PR DESCRIPTION
This is against the `v6-dev` branch.