### PR TITLE
copy*() case-insensitive paths

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
@@ -1,0 +1,131 @@
+'use strict'
+
+const assert = require('assert')
+const os = require('os')
+const path = require('path')
+const fs = require(process.cwd())
+
+/* global beforeEach, afterEach, describe, it */
+
+describe('+ copySync() - case insensitive paths', () => {
+  let TEST_DIR = ''
+  let src = ''
+  let dest = ''
+
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy-sync-case-insensitive-paths')
+    fs.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(done => fs.remove(TEST_DIR, done))
+
+  describe('> when src is a directory', () => {
+    it('should behave correctly based on the OS', () => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      dest = path.join(TEST_DIR, 'srcDir')
+      let errThrown = false
+
+      try {
+        fs.copySync(src, dest)
+      } catch (err) {
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+          errThrown = true
+        }
+      }
+      if (os === 'darwin' || os === 'win32') assert(errThrown)
+      if (os === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        assert(!errThrown)
+      }
+    })
+  })
+
+  describe('> when src is a file', () => {
+    it('should behave correctly based on the OS', () => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      dest = path.join(TEST_DIR, 'srcFile')
+      let errThrown = false
+
+      try {
+        fs.copySync(src, dest)
+      } catch (err) {
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+          errThrown = true
+        }
+      }
+      if (os === 'darwin' || os === 'win32') assert(errThrown)
+      if (os === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        assert(!errThrown)
+      }
+    })
+  })
+
+  describe('> when src is a symlink', () => {
+    it('should behave correctly based on the OS, symlink dir', () => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'dir')
+      dest = path.join(TEST_DIR, 'srcDir')
+      let errThrown = false
+
+      try {
+        fs.copySync(src, dest)
+      } catch (err) {
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+          errThrown = true
+        }
+      }
+      if (os === 'darwin' || os === 'win32') assert(errThrown)
+      if (os === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        const link = fs.readlinkSync(srcLink)
+        assert.strictEqual(link, dest)
+        assert(!errThrown)
+      }
+    })
+
+    it('should behave correctly based on the OS, symlink file', () => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'file')
+      dest = path.join(TEST_DIR, 'srcFile')
+      let errThrown = false
+
+      try {
+        fs.copySync(src, dest)
+      } catch (err) {
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+          errThrown = true
+        }
+      }
+      if (os === 'darwin' || os === 'win32') assert(errThrown)
+      if (os === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        const link = fs.readlinkSync(srcLink)
+        assert.strictEqual(link, dest)
+        assert(!errThrown)
+      }
+    })
+  })
+})

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -20,7 +20,7 @@ describe('+ copySync()', () => {
     fs.emptyDir(TEST_DIR, done)
   })
 
-  describe('> when the source is a directory', () => {
+  describe('> when src is a directory', () => {
     describe('> when dest exists and is a file', () => {
       it('should throw error', () => {
         const src = path.join(TEST_DIR, 'src')

--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -20,7 +20,7 @@ describe('+ copySync()', () => {
 
   afterEach(done => fs.remove(TEST_DIR, done))
 
-  describe('> when the source is a file', () => {
+  describe('> when src is a file', () => {
     it('should copy the file synchronously', () => {
       const fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_src')
       const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
@@ -104,7 +104,7 @@ describe('+ copySync()', () => {
       })
     })
 
-    describe('> when the source file does not have write permissions', () => {
+    describe('> when src file does not have write permissions', () => {
       it('should be able to copy contents of file', () => {
         const fileSrc = path.join(TEST_DIR, 'file.txt')
         const fileDest = path.join(TEST_DIR, 'file-copy.txt')

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
@@ -35,9 +35,9 @@ describe('+ copySync() - prevent copying identical files and dirs', () => {
   //  src is symlink, dest is regular
   //  src is symlink, dest is symlink
 
-  describe('> when the source is a directory', () => {
+  describe('> when src is a directory', () => {
     describe(`>> when src is regular and dest is a symlink that points to src`, () => {
-      it('should not copy and return', () => {
+      it('should error', () => {
         src = path.join(TEST_DIR, 'src')
         fs.mkdirsSync(src)
         const subdir = path.join(TEST_DIR, 'src', 'subdir')
@@ -49,7 +49,11 @@ describe('+ copySync() - prevent copying identical files and dirs', () => {
 
         const oldlen = klawSync(src).length
 
-        fs.copySync(src, destLink)
+        try {
+          fs.copySync(src, destLink)
+        } catch (err) {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
 
         const newlen = klawSync(src).length
         assert.strictEqual(newlen, oldlen)
@@ -117,9 +121,9 @@ describe('+ copySync() - prevent copying identical files and dirs', () => {
   //  src is symlink, dest is regular
   //  src is symlink, dest is symlink
 
-  describe('> when the source is a file', () => {
+  describe('> when src is a file', () => {
     describe(`>> when src is regular and dest is a symlink that points to src`, () => {
-      it('should not copy and return', () => {
+      it('should error', () => {
         src = path.join(TEST_DIR, 'src', 'somefile.txt')
         fs.ensureFileSync(src)
         fs.writeFileSync(src, 'some data')
@@ -127,7 +131,11 @@ describe('+ copySync() - prevent copying identical files and dirs', () => {
         const destLink = path.join(TEST_DIR, 'dest-symlink')
         fs.symlinkSync(src, destLink, 'file')
 
-        fs.copySync(src, destLink)
+        try {
+          fs.copySync(src, destLink)
+        } catch (err) {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
 
         const link = fs.readlinkSync(destLink)
         assert.strictEqual(link, src)

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
@@ -39,19 +39,16 @@ describe('+ copySync() - prevent copying into itself', () => {
   afterEach(done => fs.remove(TEST_DIR, done))
 
   describe('> when source is a file', () => {
-    it('should copy the file successfully even when dest parent is a subdir of src', done => {
+    it('should copy the file successfully even when dest parent is a subdir of src', () => {
       const srcFile = path.join(TEST_DIR, 'src', 'srcfile.txt')
       const destFile = path.join(TEST_DIR, 'src', 'dest', 'destfile.txt')
       fs.writeFileSync(srcFile, dat0)
 
-      fs.copy(srcFile, destFile, err => {
-        assert.ifError(err)
+      fs.copySync(srcFile, destFile)
 
-        assert(fs.existsSync(destFile, 'file copied'))
-        const out = fs.readFileSync(destFile, 'utf8')
-        assert.strictEqual(out, dat0, 'file contents matched')
-        done()
-      })
+      assert(fs.existsSync(destFile, 'file copied'))
+      const out = fs.readFileSync(destFile, 'utf8')
+      assert.strictEqual(out, dat0, 'file contents matched')
     })
   })
 
@@ -63,112 +60,113 @@ describe('+ copySync() - prevent copying into itself', () => {
 
   describe('> when source is a directory', () => {
     describe('>> when dest is a directory', () => {
-      it(`of not itself`, done => {
+      it(`of not itself`, () => {
         const dest = path.join(TEST_DIR, src.replace(/^\w:/, ''))
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
-      it(`of itself`, done => {
+      it(`of itself`, () => {
         const dest = path.join(src, 'dest')
-        return testError(src, dest, done)
+        return testError(src, dest)
       })
-      it(`should copy the directory successfully when dest is 'src_dest'`, done => {
+      it(`should copy the directory successfully when dest is 'src_dest'`, () => {
         const dest = path.join(TEST_DIR, 'src_dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
-      it(`should copy the directory successfully when dest is 'src-dest'`, done => {
+      it(`should copy the directory successfully when dest is 'src-dest'`, () => {
         const dest = path.join(TEST_DIR, 'src-dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'dest_src'`, done => {
+      it(`should copy the directory successfully when dest is 'dest_src'`, () => {
         const dest = path.join(TEST_DIR, 'dest_src')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'src_dest/src'`, done => {
+      it(`should copy the directory successfully when dest is 'src_dest/src'`, () => {
         const dest = path.join(TEST_DIR, 'src_dest', 'src')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'src-dest/src'`, done => {
+      it(`should copy the directory successfully when dest is 'src-dest/src'`, () => {
         const dest = path.join(TEST_DIR, 'src-dest', 'src')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'dest_src/src'`, done => {
+      it(`should copy the directory successfully when dest is 'dest_src/src'`, () => {
         const dest = path.join(TEST_DIR, 'dest_src', 'src')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'src_src/dest'`, done => {
+      it(`should copy the directory successfully when dest is 'src_src/dest'`, () => {
         const dest = path.join(TEST_DIR, 'src_src', 'dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'src-src/dest'`, done => {
+      it(`should copy the directory successfully when dest is 'src-src/dest'`, () => {
         const dest = path.join(TEST_DIR, 'src-src', 'dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'srcsrc/dest'`, done => {
+      it(`should copy the directory successfully when dest is 'srcsrc/dest'`, () => {
         const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should copy the directory successfully when dest is 'dest/src'`, done => {
+      it(`should copy the directory successfully when dest is 'dest/src'`, () => {
         const dest = path.join(TEST_DIR, 'dest', 'src')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it('should copy the directory successfully when dest is very nested that all its parents need to be created', done => {
+      it('should copy the directory successfully when dest is very nested that all its parents need to be created', () => {
         const dest = path.join(TEST_DIR, 'dest', 'src', 'foo', 'bar', 'baz', 'qux', 'quux', 'waldo',
           'grault', 'garply', 'fred', 'plugh', 'thud', 'some', 'highly', 'deeply',
           'badly', 'nasty', 'crazy', 'mad', 'nested', 'dest')
-        return testSuccess(src, dest, done)
+        return testSuccess(src, dest)
       })
 
-      it(`should error when dest is 'src/dest'`, done => {
+      it(`should error when dest is 'src/dest'`, () => {
         const dest = path.join(TEST_DIR, 'src', 'dest')
-        return testError(src, dest, done)
+        return testError(src, dest)
       })
 
-      it(`should error when dest is 'src/src_dest'`, done => {
+      it(`should error when dest is 'src/src_dest'`, () => {
         const dest = path.join(TEST_DIR, 'src', 'src_dest')
-        return testError(src, dest, done)
+        return testError(src, dest)
       })
 
-      it(`should error when dest is 'src/dest_src'`, done => {
+      it(`should error when dest is 'src/dest_src'`, () => {
         const dest = path.join(TEST_DIR, 'src', 'dest_src')
-        return testError(src, dest, done)
+        return testError(src, dest)
       })
 
-      it(`should error when dest is 'src/dest/src'`, done => {
+      it(`should error when dest is 'src/dest/src'`, () => {
         const dest = path.join(TEST_DIR, 'src', 'dest', 'src')
-        return testError(src, dest, done)
+        return testError(src, dest)
       })
     })
 
     describe('>> when dest is a symlink', () => {
-      it('should not copy and return when dest points exactly to src', done => {
+      it('should error when dest points exactly to src', () => {
         const destLink = path.join(TEST_DIR, 'dest-symlink')
         fs.symlinkSync(src, destLink, 'dir')
 
         const srclenBefore = klawSync(src).length
         assert(srclenBefore > 2)
 
-        fs.copy(src, destLink, err => {
-          assert.ifError(err)
+        try {
+          fs.copySync(src, destLink)
+        } catch (err) {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
 
-          const srclenAfter = klawSync(src).length
-          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+        const srclenAfter = klawSync(src).length
+        assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
 
-          const link = fs.readlinkSync(destLink)
-          assert.strictEqual(link, src)
-          done()
-        })
+        const link = fs.readlinkSync(destLink)
+        assert.strictEqual(link, src)
       })
 
-      it('should copy the directory successfully when src is a subdir of resolved dest path', done => {
+      it('should copy the directory successfully when src is a subdir of resolved dest path', () => {
         const srcInDest = path.join(TEST_DIR, 'dest', 'some', 'nested', 'src')
         const destLink = path.join(TEST_DIR, 'dest-symlink')
         fs.copySync(src, srcInDest) // put some stuff in srcInDest
@@ -180,64 +178,63 @@ describe('+ copySync() - prevent copying into itself', () => {
         const destlenBefore = klawSync(dest).length
 
         assert(srclen > 2)
-        fs.copy(srcInDest, destLink, err => {
-          assert.ifError(err)
+        fs.copySync(srcInDest, destLink)
 
-          const destlenAfter = klawSync(dest).length
+        const destlenAfter = klawSync(dest).length
 
-          // assert dest length is oldlen + length of stuff copied from src
-          assert.strictEqual(destlenAfter, destlenBefore + srclen, 'dest length should be equal to old length + copied legnth')
+        // assert dest length is oldlen + length of stuff copied from src
+        assert.strictEqual(destlenAfter, destlenBefore + srclen, 'dest length should be equal to old length + copied legnth')
 
-          FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
+        FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
 
-          const o0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
-          const o1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
-          const o2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
-          const o3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
+        const o0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
+        const o1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
+        const o2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
+        const o3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
 
-          assert.strictEqual(o0, dat0, 'files contents matched')
-          assert.strictEqual(o1, dat1, 'files contents matched')
-          assert.strictEqual(o2, dat2, 'files contents matched')
-          assert.strictEqual(o3, dat3, 'files contents matched')
-          done()
-        })
+        assert.strictEqual(o0, dat0, 'files contents matched')
+        assert.strictEqual(o1, dat1, 'files contents matched')
+        assert.strictEqual(o2, dat2, 'files contents matched')
+        assert.strictEqual(o3, dat3, 'files contents matched')
       })
     })
   })
 
   describe('> when source is a symlink', () => {
     describe('>> when dest is a directory', () => {
-      it('should error when resolved src path points to dest', done => {
+      it('should error when resolved src path points to dest', () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
 
         const dest = path.join(TEST_DIR, 'src')
 
-        fs.copy(srcLink, dest, err => {
+        try {
+          fs.copySync(srcLink, dest)
+        } catch (err) {
           assert(err)
-          // assert source not affected
-          const link = fs.readlinkSync(srcLink)
-          assert.strictEqual(link, src)
-          done()
-        })
+        }
+        // assert source not affected
+        const link = fs.readlinkSync(srcLink)
+        assert.strictEqual(link, src)
       })
 
-      it('should error when dest is a subdir of resolved src path', done => {
+      it('should error when dest is a subdir of resolved src path', () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
 
         const dest = path.join(TEST_DIR, 'src', 'some', 'nested', 'dest')
         fs.mkdirsSync(dest)
 
-        fs.copy(srcLink, dest, err => {
+        try {
+          fs.copySync(srcLink, dest)
+        } catch (err) {
           assert(err)
-          const link = fs.readlinkSync(srcLink)
-          assert.strictEqual(link, src)
-          done()
-        })
+        }
+        const link = fs.readlinkSync(srcLink)
+        assert.strictEqual(link, src)
       })
 
-      it('should error when resolved src path is a subdir of dest', done => {
+      it('should error when resolved src path is a subdir of dest', () => {
         const dest = path.join(TEST_DIR, 'dest')
 
         const resolvedSrcPath = path.join(dest, 'contains', 'src')
@@ -247,39 +244,36 @@ describe('+ copySync() - prevent copying into itself', () => {
         // make symlink that points to a subdir in dest
         fs.symlinkSync(resolvedSrcPath, srcLink, 'dir')
 
-        fs.copy(srcLink, dest, err => {
+        try {
+          fs.copySync(srcLink, dest)
+        } catch (err) {
           assert(err)
-          done()
-        })
+        }
       })
 
-      it(`should copy the directory successfully when dest is 'src_src/dest'`, done => {
+      it(`should copy the directory successfully when dest is 'src_src/dest'`, () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
 
         const dest = path.join(TEST_DIR, 'src_src', 'dest')
-        testSuccess(srcLink, dest, () => {
-          const link = fs.readlinkSync(dest)
-          assert.strictEqual(link, src)
-          done()
-        })
+        testSuccess(srcLink, dest)
+        const link = fs.readlinkSync(dest)
+        assert.strictEqual(link, src)
       })
 
-      it(`should copy the directory successfully when dest is 'srcsrc/dest'`, done => {
+      it(`should copy the directory successfully when dest is 'srcsrc/dest'`, () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
 
         const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
-        testSuccess(srcLink, dest, () => {
-          const link = fs.readlinkSync(dest)
-          assert.strictEqual(link, src)
-          done()
-        })
+        testSuccess(srcLink, dest)
+        const link = fs.readlinkSync(dest)
+        assert.strictEqual(link, src)
       })
     })
 
     describe('>> when dest is a symlink', () => {
-      it('should silently return when resolved dest path is exactly the same as resolved src path', done => {
+      it('should silently return when resolved dest path is exactly the same as resolved src path', () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
         const destLink = path.join(TEST_DIR, 'dest-symlink')
@@ -290,23 +284,19 @@ describe('+ copySync() - prevent copying into itself', () => {
         assert(srclenBefore > 2)
         assert(destlenBefore > 2)
 
-        fs.copy(srcLink, destLink, err => {
-          assert.ifError(err)
+        fs.copySync(srcLink, destLink)
+        const srclenAfter = klawSync(srcLink).length
+        assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+        const destlenAfter = klawSync(destLink).length
+        assert.strictEqual(destlenAfter, destlenBefore, 'dest length should not change')
 
-          const srclenAfter = klawSync(srcLink).length
-          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
-          const destlenAfter = klawSync(destLink).length
-          assert.strictEqual(destlenAfter, destlenBefore, 'dest length should not change')
-
-          const srcln = fs.readlinkSync(srcLink)
-          assert.strictEqual(srcln, src)
-          const destln = fs.readlinkSync(destLink)
-          assert.strictEqual(destln, src)
-          done()
-        })
+        const srcln = fs.readlinkSync(srcLink)
+        assert.strictEqual(srcln, src)
+        const destln = fs.readlinkSync(destLink)
+        assert.strictEqual(destln, src)
       })
 
-      it('should error when resolved dest path is a subdir of resolved src path', done => {
+      it('should error when resolved dest path is a subdir of resolved src path', () => {
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         fs.symlinkSync(src, srcLink, 'dir')
 
@@ -316,15 +306,16 @@ describe('+ copySync() - prevent copying into itself', () => {
 
         fs.symlinkSync(resolvedDestPath, destLink, 'dir')
 
-        fs.copy(srcLink, destLink, err => {
-          assert.ifError(err)
-          const destln = fs.readlinkSync(destLink)
-          assert.strictEqual(destln, src)
-          done()
-        })
+        try {
+          fs.copySync(srcLink, destLink)
+        } catch (err) {
+          assert(err)
+        }
+        const destln = fs.readlinkSync(destLink)
+        assert.strictEqual(destln, src)
       })
 
-      it('should error when resolved src path is a subdir of resolved dest path', done => {
+      it('should error when resolved src path is a subdir of resolved dest path', () => {
         const srcInDest = path.join(TEST_DIR, 'dest', 'some', 'nested', 'src')
         const srcLink = path.join(TEST_DIR, 'src-symlink')
         const destLink = path.join(TEST_DIR, 'dest-symlink')
@@ -336,45 +327,45 @@ describe('+ copySync() - prevent copying into itself', () => {
         fs.symlinkSync(srcInDest, srcLink, 'dir')
         fs.symlinkSync(dest, destLink, 'dir')
 
-        fs.copy(srcLink, destLink, err => {
+        try {
+          fs.copySync(srcLink, destLink)
+        } catch (err) {
           assert.strictEqual(err.message, `Cannot overwrite '${dest}' with '${srcInDest}'.`)
-          const destln = fs.readlinkSync(destLink)
-          assert.strictEqual(destln, dest)
-          done()
-        })
+        }
+        const destln = fs.readlinkSync(destLink)
+        assert.strictEqual(destln, dest)
       })
     })
   })
 })
 
-function testSuccess (src, dest, done) {
+function testSuccess (src, dest) {
   const srclen = klawSync(src).length
   assert(srclen > 2)
-  fs.copy(src, dest, err => {
-    assert.ifError(err)
 
-    const destlen = klawSync(dest).length
+  fs.copySync(src, dest)
 
-    assert.strictEqual(destlen, srclen)
+  const destlen = klawSync(dest).length
 
-    FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
+  assert.strictEqual(destlen, srclen)
 
-    const o0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
-    const o1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
-    const o2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
-    const o3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
+  FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
 
-    assert.strictEqual(o0, dat0, 'file contents matched')
-    assert.strictEqual(o1, dat1, 'file contents matched')
-    assert.strictEqual(o2, dat2, 'file contents matched')
-    assert.strictEqual(o3, dat3, 'file contents matched')
-    done()
-  })
+  const o0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
+  const o1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
+  const o2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
+  const o3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
+
+  assert.strictEqual(o0, dat0, 'file contents matched')
+  assert.strictEqual(o1, dat1, 'file contents matched')
+  assert.strictEqual(o2, dat2, 'file contents matched')
+  assert.strictEqual(o3, dat3, 'file contents matched')
 }
 
-function testError (src, dest, done) {
-  fs.copy(src, dest, err => {
+function testError (src, dest) {
+  try {
+    fs.copySync(src, dest)
+  } catch (err) {
     assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
-    done()
-  })
+  }
 }

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -23,42 +23,44 @@ function copySync (src, dest, opts) {
     see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
-  // don't allow src and dest to be the same
-  if (path.resolve(src) === path.resolve(dest)) throw new Error('Source and destination must not be the same.')
+  const resolvedDest = checkPaths(src, dest)
 
   if (opts.filter && !opts.filter(src, dest)) return
 
   const destParent = path.dirname(dest)
   if (!fs.existsSync(destParent)) mkdirpSync(destParent)
-  return startCopy(src, dest, opts)
+  return startCopy(resolvedDest, src, dest, opts)
 }
 
-function startCopy (src, dest, opts) {
+function startCopy (resolvedDest, src, dest, opts) {
+  // resovledDest is only truthy in the first call of startCopy.
+  // when copying directory items, startCopy is called recursively and
+  // resolvedDest is null, so we need to check paths in that case.
+  if (resolvedDest) return resumeCopy(resolvedDest, src, dest, opts)
+  const resolvedDestNested = checkPaths(src, dest)
+  return resumeCopy(resolvedDestNested, src, dest, opts)
+}
+
+function resumeCopy (resolvedDest, src, dest, opts) {
   if (opts.filter && !opts.filter(src, dest)) return
-  return getStats(src, dest, opts)
+  return getStats(resolvedDest, src, dest, opts)
 }
 
-function getStats (src, dest, opts) {
+function getStats (resolvedDest, src, dest, opts) {
   const statSync = opts.dereference ? fs.statSync : fs.lstatSync
   const st = statSync(src)
 
-  if (st.isDirectory()) return onDir(st, src, dest, opts)
+  if (st.isDirectory()) return onDir(st, resolvedDest, src, dest, opts)
   else if (st.isFile() ||
            st.isCharacterDevice() ||
-           st.isBlockDevice()) return onFile(st, src, dest, opts)
-  else if (st.isSymbolicLink()) return onLink(src, dest, opts)
+           st.isBlockDevice()) return onFile(st, resolvedDest, src, dest, opts)
+  else if (st.isSymbolicLink()) return onLink(resolvedDest, src, dest, opts)
 }
 
-function onFile (srcStat, src, dest, opts) {
-  const resolvedPath = checkDest(dest)
-  if (resolvedPath === notExist) {
-    return copyFile(srcStat, src, dest, opts)
-  } else if (resolvedPath === existsReg) {
-    return mayCopyFile(srcStat, src, dest, opts)
-  } else {
-    if (src === resolvedPath) return
-    return mayCopyFile(srcStat, src, dest, opts)
-  }
+function onFile (srcStat, resolvedDest, src, dest, opts) {
+  if (resolvedDest === notExist) return copyFile(srcStat, src, dest, opts)
+  else if (resolvedDest === existsReg) return mayCopyFile(srcStat, src, dest, opts)
+  return mayCopyFile(srcStat, src, dest, opts)
 }
 
 function mayCopyFile (srcStat, src, dest, opts) {
@@ -102,22 +104,19 @@ function copyFileFallback (srcStat, src, dest, opts) {
   fs.closeSync(fdw)
 }
 
-function onDir (srcStat, src, dest, opts) {
-  const resolvedPath = checkDest(dest)
-  if (resolvedPath === notExist) {
+function onDir (srcStat, resolvedDest, src, dest, opts) {
+  if (resolvedDest === notExist) {
     if (isSrcSubdir(src, dest)) {
       throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
     }
     return mkDirAndCopy(srcStat, src, dest, opts)
-  } else if (resolvedPath === existsReg) {
+  } else if (resolvedDest === existsReg) {
     if (isSrcSubdir(src, dest)) {
       throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
     }
     return mayCopyDir(src, dest, opts)
-  } else {
-    if (src === resolvedPath) return
-    return copyDir(src, dest, opts)
   }
+  return copyDir(src, dest, opts)
 }
 
 function mayCopyDir (src, dest, opts) {
@@ -135,41 +134,51 @@ function mkDirAndCopy (srcStat, src, dest, opts) {
 
 function copyDir (src, dest, opts) {
   fs.readdirSync(src).forEach(item => {
-    startCopy(path.join(src, item), path.join(dest, item), opts)
+    startCopy(null, path.join(src, item), path.join(dest, item), opts)
   })
 }
 
-function onLink (src, dest, opts) {
-  let resolvedSrcPath = fs.readlinkSync(src)
+function onLink (resolvedDest, src, dest, opts) {
+  let resolvedSrc = fs.readlinkSync(src)
 
   if (opts.dereference) {
-    resolvedSrcPath = path.resolve(process.cwd(), resolvedSrcPath)
+    resolvedSrc = path.resolve(process.cwd(), resolvedSrc)
   }
 
-  let resolvedDestPath = checkDest(dest)
-  if (resolvedDestPath === notExist || resolvedDestPath === existsReg) {
+  if (resolvedDest === notExist || resolvedDest === existsReg) {
     // if dest already exists, fs throws error anyway,
     // so no need to guard against it here.
-    return fs.symlinkSync(resolvedSrcPath, dest)
+    return fs.symlinkSync(resolvedSrc, dest)
   } else {
     if (opts.dereference) {
-      resolvedDestPath = path.resolve(process.cwd(), resolvedDestPath)
+      resolvedDest = path.resolve(process.cwd(), resolvedDest)
     }
-    if (resolvedDestPath === resolvedSrcPath) return
+    if (pathsAreIdentical(resolvedSrc, resolvedDest)) return
 
     // prevent copy if src is a subdir of dest since unlinking
     // dest in this case would result in removing src contents
     // and therefore a broken symlink would be created.
-    if (fs.statSync(dest).isDirectory() && isSrcSubdir(resolvedDestPath, resolvedSrcPath)) {
-      throw new Error(`Cannot overwrite '${resolvedDestPath}' with '${resolvedSrcPath}'.`)
+    if (fs.statSync(dest).isDirectory() && isSrcSubdir(resolvedDest, resolvedSrc)) {
+      throw new Error(`Cannot overwrite '${resolvedDest}' with '${resolvedSrc}'.`)
     }
-    return copyLink(resolvedSrcPath, dest)
+    return copyLink(resolvedSrc, dest)
   }
 }
 
-function copyLink (resolvedSrcPath, dest) {
+function copyLink (resolvedSrc, dest) {
   fs.unlinkSync(dest)
-  return fs.symlinkSync(resolvedSrcPath, dest)
+  return fs.symlinkSync(resolvedSrc, dest)
+}
+
+// return true if dest is a subdir of src, otherwise false.
+// extract dest base dir and check if that is the same as src basename.
+function isSrcSubdir (src, dest) {
+  const srcArray = path.resolve(src).split(path.sep)
+  const destArray = path.resolve(dest).split(path.sep)
+
+  return srcArray.reduce((acc, current, i) => {
+    return acc && destArray[i] === current
+  }, true)
 }
 
 // check if dest exists and is a symlink.
@@ -188,15 +197,27 @@ function checkDest (dest) {
   return resolvedPath // dest exists and is a symlink
 }
 
-// return true if dest is a subdir of src, otherwise false.
-// extract dest base dir and check if that is the same as src basename.
-function isSrcSubdir (src, dest) {
-  const srcArray = path.resolve(src).split(path.sep)
-  const destArray = path.resolve(dest).split(path.sep)
+function pathsAreIdentical (src, dest) {
+  const os = process.platform
+  const resolvedSrc = path.resolve(src)
+  const resolvedDest = path.resolve(dest)
+  // case-insensitive paths
+  if (os === 'darwin' || os === 'win32') {
+    return resolvedSrc.toLowerCase() === resolvedDest.toLowerCase()
+  }
+  return resolvedSrc === resolvedDest
+}
 
-  return srcArray.reduce((acc, current, i) => {
-    return acc && destArray[i] === current
-  }, true)
+function checkPaths (src, dest) {
+  const resolvedDest = checkDest(dest)
+  if (resolvedDest === notExist || resolvedDest === existsReg) {
+    if (pathsAreIdentical(src, dest)) throw new Error('Source and destination must not be the same.')
+    return resolvedDest
+  } else {
+    // check resolved dest path if dest is a symlink
+    if (pathsAreIdentical(src, resolvedDest)) throw new Error('Source and destination must not be the same.')
+    return resolvedDest
+  }
 }
 
 module.exports = copySync

--- a/lib/copy/__tests__/copy-case-insensitive-paths.test.js
+++ b/lib/copy/__tests__/copy-case-insensitive-paths.test.js
@@ -1,0 +1,115 @@
+'use strict'
+
+const assert = require('assert')
+const os = require('os')
+const path = require('path')
+const fs = require(process.cwd())
+
+/* global beforeEach, afterEach, describe, it */
+
+describe('+ copy() - case insensitive paths', () => {
+  let TEST_DIR = ''
+  let src = ''
+  let dest = ''
+
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'copy-case-insensitive-paths')
+    fs.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(done => fs.remove(TEST_DIR, done))
+
+  describe('> when src is a directory', () => {
+    it('should behave correctly based on the OS', done => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      dest = path.join(TEST_DIR, 'srcDir')
+
+      fs.copy(src, dest, err => {
+        if (os === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        }
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+        }
+        done()
+      })
+    })
+  })
+
+  describe('> when src is a file', () => {
+    it('should behave correctly based on the OS', done => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      dest = path.join(TEST_DIR, 'srcFile')
+
+      fs.copy(src, dest, err => {
+        if (os === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        }
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+        }
+        done()
+      })
+    })
+  })
+
+  describe('> when src is a symlink', () => {
+    it('should behave correctly based on the OS, symlink dir', done => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'dir')
+      dest = path.join(TEST_DIR, 'srcDir')
+
+      fs.copy(src, dest, err => {
+        if (os === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, dest)
+        }
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+        }
+        done()
+      })
+    })
+
+    it('should behave correctly based on the OS, symlink file', done => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'file')
+      dest = path.join(TEST_DIR, 'srcFile')
+
+      fs.copy(src, dest, err => {
+        if (os === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, dest)
+        }
+        if (os === 'darwin' || os === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          assert(fs.existsSync(src))
+          assert(!fs.existsSync(dest))
+        }
+        done()
+      })
+    })
+  })
+})

--- a/lib/copy/__tests__/copy-prevent-copying-identical.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-identical.test.js
@@ -35,9 +35,9 @@ describe('+ copy() - prevent copying identical files and dirs', () => {
   //  src is symlink, dest is regular
   //  src is symlink, dest is symlink
 
-  describe('> when the source is a directory', () => {
+  describe('> when src is a directory', () => {
     describe(`>> when src is regular and dest is a symlink that points to src`, () => {
-      it('should not copy and return', done => {
+      it('should error', done => {
         src = path.join(TEST_DIR, 'src')
         fs.mkdirsSync(src)
         const subdir = path.join(TEST_DIR, 'src', 'subdir')
@@ -50,7 +50,7 @@ describe('+ copy() - prevent copying identical files and dirs', () => {
         const oldlen = klawSync(src).length
 
         fs.copy(src, destLink, err => {
-          assert.ifError(err)
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
 
           const newlen = klawSync(src).length
           assert.strictEqual(newlen, oldlen)
@@ -122,9 +122,9 @@ describe('+ copy() - prevent copying identical files and dirs', () => {
   //  src is symlink, dest is regular
   //  src is symlink, dest is symlink
 
-  describe('> when the source is a file', () => {
+  describe('> when src is a file', () => {
     describe(`>> when src is regular and dest is a symlink that points to src`, () => {
-      it('should not copy and return', done => {
+      it('should error', done => {
         src = path.join(TEST_DIR, 'src', 'somefile.txt')
         fs.ensureFileSync(src)
         fs.writeFileSync(src, 'some data')
@@ -133,7 +133,7 @@ describe('+ copy() - prevent copying identical files and dirs', () => {
         fs.symlinkSync(src, destLink, 'file')
 
         fs.copy(src, destLink, err => {
-          assert.ifError(err)
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
 
           const link = fs.readlinkSync(destLink)
           assert.strictEqual(link, src)

--- a/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
@@ -149,7 +149,7 @@ describe('+ copy() - prevent copying into itself', () => {
     })
 
     describe('>> when dest is a symlink', () => {
-      it('should not copy and return when dest points exactly to src', done => {
+      it('should error when dest points exactly to src', done => {
         const destLink = path.join(TEST_DIR, 'dest-symlink')
         fs.symlinkSync(src, destLink, 'dir')
 
@@ -157,7 +157,7 @@ describe('+ copy() - prevent copying into itself', () => {
         assert(srclenBefore > 2)
 
         fs.copy(src, destLink, err => {
-          assert.ifError(err)
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
 
           const srclenAfter = klawSync(src).length
           assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -54,7 +54,7 @@ describe('fs-extra', () => {
       })
     })
 
-    describe('> when the source is a file', () => {
+    describe('> when src is a file', () => {
       it('should copy the file asynchronously', done => {
         const fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_src')
         const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
@@ -70,7 +70,7 @@ describe('fs-extra', () => {
         })
       })
 
-      it('should return an error if the source file does not exist', done => {
+      it('should return an error if src file does not exist', done => {
         const fileSrc = 'we-simply-assume-this-file-does-not-exist.bin'
         const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
 
@@ -110,8 +110,8 @@ describe('fs-extra', () => {
       })
     })
 
-    describe('> when the source is a directory', () => {
-      describe('> when the source directory does not exist', () => {
+    describe('> when src is a directory', () => {
+      describe('> when src directory does not exist', () => {
         it('should return an error', done => {
           const ts = path.join(TEST_DIR, 'this_dir_does_not_exist')
           const td = path.join(TEST_DIR, 'this_dir_really_does_not_matter')

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -29,62 +29,68 @@ function copy (src, dest, opts, cb) {
     see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
-  // don't allow src and dest to be the same
-  if (path.resolve(src) === path.resolve(dest)) return cb(new Error('Source and destination must not be the same.'))
-
-  if (opts.filter) return handleFilter(checkParentDir, src, dest, opts, cb)
-  return checkParentDir(src, dest, opts, cb)
+  checkPaths(src, dest, (err, resolvedDest) => {
+    if (err) return cb(err)
+    if (opts.filter) return handleFilter(checkParentDir, resolvedDest, src, dest, opts, cb)
+    return checkParentDir(resolvedDest, src, dest, opts, cb)
+  })
 }
 
-function checkParentDir (src, dest, opts, cb) {
+function checkParentDir (resolvedDest, src, dest, opts, cb) {
   const destParent = path.dirname(dest)
   pathExists(destParent, (err, dirExists) => {
     if (err) return cb(err)
-    if (dirExists) return startCopy(src, dest, opts, cb)
+    if (dirExists) return startCopy(resolvedDest, src, dest, opts, cb)
     mkdirp(destParent, err => {
       if (err) return cb(err)
-      return startCopy(src, dest, opts, cb)
+      return startCopy(resolvedDest, src, dest, opts, cb)
     })
   })
 }
 
-function startCopy (src, dest, opts, cb) {
-  if (opts.filter) return handleFilter(getStats, src, dest, opts, cb)
-  return getStats(src, dest, opts, cb)
+function startCopy (resolvedDest, src, dest, opts, cb) {
+  // resovledDest is only truthy in the first call of startCopy.
+  // when copying directory items, startCopy is called recursively and
+  // resolvedDest is null, so we need to check paths in that case.
+  if (resolvedDest) return resumeCopy(resolvedDest, src, dest, opts, cb)
+  return checkPaths(src, dest, (err, resolvedDest) => {
+    if (err) return cb(err)
+    return resumeCopy(resolvedDest, src, dest, opts, cb)
+  })
 }
 
-function handleFilter (onInclude, src, dest, opts, cb) {
+function resumeCopy (resolvedDest, src, dest, opts, cb) {
+  if (opts.filter) return handleFilter(getStats, resolvedDest, src, dest, opts, cb)
+  return getStats(resolvedDest, src, dest, opts, cb)
+}
+
+function handleFilter (onInclude, resolvedDest, src, dest, opts, cb) {
   Promise.resolve(opts.filter(src, dest)).then(include => {
-    if (include) return onInclude(src, dest, opts, cb)
+    if (include) {
+      if (resolvedDest) return onInclude(resolvedDest, src, dest, opts, cb)
+      return onInclude(src, dest, opts, cb)
+    }
     return cb()
   }, error => cb(error))
 }
 
-function getStats (src, dest, opts, cb) {
+function getStats (resolvedDest, src, dest, opts, cb) {
   const stat = opts.dereference ? fs.stat : fs.lstat
   stat(src, (err, st) => {
     if (err) return cb(err)
 
-    if (st.isDirectory()) return onDir(st, src, dest, opts, cb)
+    if (st.isDirectory()) return onDir(st, resolvedDest, src, dest, opts, cb)
     else if (st.isFile() ||
              st.isCharacterDevice() ||
-             st.isBlockDevice()) return onFile(st, src, dest, opts, cb)
-    else if (st.isSymbolicLink()) return onLink(src, dest, opts, cb)
+             st.isBlockDevice()) return onFile(st, resolvedDest, src, dest, opts, cb)
+    else if (st.isSymbolicLink()) return onLink(resolvedDest, src, dest, opts, cb)
   })
 }
 
-function onFile (srcStat, src, dest, opts, cb) {
-  checkDest(dest, (err, resolvedPath) => {
-    if (err) return cb(err)
-    if (resolvedPath === notExist) {
-      return copyFile(srcStat, src, dest, opts, cb)
-    } else if (resolvedPath === existsReg) {
-      return mayCopyFile(srcStat, src, dest, opts, cb)
-    } else {
-      if (src === resolvedPath) return cb()
-      return mayCopyFile(srcStat, src, dest, opts, cb)
-    }
-  })
+function onFile (srcStat, resolvedDest, src, dest, opts, cb) {
+  if (resolvedDest === notExist) return copyFile(srcStat, src, dest, opts, cb)
+  else if (resolvedDest === existsReg) return mayCopyFile(srcStat, src, dest, opts, cb)
+  return mayCopyFile(srcStat, src, dest, opts, cb)
 }
 
 function mayCopyFile (srcStat, src, dest, opts, cb) {
@@ -128,24 +134,19 @@ function setDestModeAndTimestamps (srcStat, dest, opts, cb) {
   })
 }
 
-function onDir (srcStat, src, dest, opts, cb) {
-  checkDest(dest, (err, resolvedPath) => {
-    if (err) return cb(err)
-    if (resolvedPath === notExist) {
-      if (isSrcSubdir(src, dest)) {
-        return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
-      }
-      return mkDirAndCopy(srcStat, src, dest, opts, cb)
-    } else if (resolvedPath === existsReg) {
-      if (isSrcSubdir(src, dest)) {
-        return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
-      }
-      return mayCopyDir(src, dest, opts, cb)
-    } else {
-      if (src === resolvedPath) return cb()
-      return copyDir(src, dest, opts, cb)
+function onDir (srcStat, resolvedDest, src, dest, opts, cb) {
+  if (resolvedDest === notExist) {
+    if (isSrcSubdir(src, dest)) {
+      return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
     }
-  })
+    return mkDirAndCopy(srcStat, src, dest, opts, cb)
+  } else if (resolvedDest === existsReg) {
+    if (isSrcSubdir(src, dest)) {
+      return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
+    }
+    return mayCopyDir(src, dest, opts, cb)
+  }
+  return copyDir(src, dest, opts, cb)
 }
 
 function mayCopyDir (src, dest, opts, cb) {
@@ -178,53 +179,60 @@ function copyDir (src, dest, opts, cb) {
 function copyDirItems (items, src, dest, opts, cb) {
   const item = items.pop()
   if (!item) return cb()
-  startCopy(path.join(src, item), path.join(dest, item), opts, err => {
+  startCopy(null, path.join(src, item), path.join(dest, item), opts, err => {
     if (err) return cb(err)
     return copyDirItems(items, src, dest, opts, cb)
   })
 }
 
-function onLink (src, dest, opts, cb) {
-  fs.readlink(src, (err, resolvedSrcPath) => {
+function onLink (resolvedDest, src, dest, opts, cb) {
+  fs.readlink(src, (err, resolvedSrc) => {
     if (err) return cb(err)
 
     if (opts.dereference) {
-      resolvedSrcPath = path.resolve(process.cwd(), resolvedSrcPath)
+      resolvedSrc = path.resolve(process.cwd(), resolvedSrc)
     }
 
-    checkDest(dest, (err, resolvedDestPath) => {
-      if (err) return cb(err)
-
-      if (resolvedDestPath === notExist || resolvedDestPath === existsReg) {
-        // if dest already exists, fs throws error anyway,
-        // so no need to guard against it here.
-        return fs.symlink(resolvedSrcPath, dest, cb)
-      } else {
-        if (opts.dereference) {
-          resolvedDestPath = path.resolve(process.cwd(), resolvedDestPath)
-        }
-        if (resolvedDestPath === resolvedSrcPath) return cb()
-
-        // prevent copy if src is a subdir of dest since unlinking
-        // dest in this case would result in removing src contents
-        // and therefore a broken symlink would be created.
-        fs.stat(dest, (err, st) => {
-          if (err) return cb(err)
-          if (st.isDirectory() && isSrcSubdir(resolvedDestPath, resolvedSrcPath)) {
-            return cb(new Error(`Cannot overwrite '${resolvedDestPath}' with '${resolvedSrcPath}'.`))
-          }
-          return copyLink(resolvedSrcPath, dest, cb)
-        })
+    if (resolvedDest === notExist || resolvedDest === existsReg) {
+      // if dest already exists, fs throws error anyway,
+      // so no need to guard against it here.
+      return fs.symlink(resolvedSrc, dest, cb)
+    } else {
+      if (opts.dereference) {
+        resolvedDest = path.resolve(process.cwd(), resolvedDest)
       }
-    })
+      if (pathsAreIdentical(resolvedSrc, resolvedDest)) return cb()
+
+      // prevent copy if src is a subdir of dest since unlinking
+      // dest in this case would result in removing src contents
+      // and therefore a broken symlink would be created.
+      fs.stat(dest, (err, st) => {
+        if (err) return cb(err)
+        if (st.isDirectory() && isSrcSubdir(resolvedDest, resolvedSrc)) {
+          return cb(new Error(`Cannot overwrite '${resolvedDest}' with '${resolvedSrc}'.`))
+        }
+        return copyLink(resolvedSrc, dest, cb)
+      })
+    }
   })
 }
 
-function copyLink (resolvedSrcPath, dest, cb) {
+function copyLink (resolvedSrc, dest, cb) {
   fs.unlink(dest, err => {
     if (err) return cb(err)
-    return fs.symlink(resolvedSrcPath, dest, cb)
+    return fs.symlink(resolvedSrc, dest, cb)
   })
+}
+
+// return true if dest is a subdir of src, otherwise false.
+// extract dest base dir and check if that is the same as src basename.
+function isSrcSubdir (src, dest) {
+  const srcArray = path.resolve(src).split(path.sep)
+  const destArray = path.resolve(dest).split(path.sep)
+
+  return srcArray.reduce((acc, current, i) => {
+    return acc && destArray[i] === current
+  }, true)
 }
 
 // check if dest exists and is a symlink.
@@ -242,15 +250,29 @@ function checkDest (dest, cb) {
   })
 }
 
-// return true if dest is a subdir of src, otherwise false.
-// extract dest base dir and check if that is the same as src basename.
-function isSrcSubdir (src, dest) {
-  const srcArray = path.resolve(src).split(path.sep)
-  const destArray = path.resolve(dest).split(path.sep)
+function pathsAreIdentical (src, dest) {
+  const os = process.platform
+  const resolvedSrc = path.resolve(src)
+  const resolvedDest = path.resolve(dest)
+  // case-insensitive paths
+  if (os === 'darwin' || os === 'win32') {
+    return resolvedSrc.toLowerCase() === resolvedDest.toLowerCase()
+  }
+  return resolvedSrc === resolvedDest
+}
 
-  return srcArray.reduce((acc, current, i) => {
-    return acc && destArray[i] === current
-  }, true)
+function checkPaths (src, dest, cb) {
+  checkDest(dest, (err, resolvedDest) => {
+    if (err) return cb(err)
+    if (resolvedDest === notExist || resolvedDest === existsReg) {
+      if (pathsAreIdentical(src, dest)) return cb(new Error('Source and destination must not be the same.'))
+      return cb(null, resolvedDest)
+    } else {
+      // check resolved dest path if dest is a symlink
+      if (pathsAreIdentical(src, resolvedDest)) return cb(new Error('Source and destination must not be the same.'))
+      return cb(null, resolvedDest)
+    }
+  })
 }
 
 module.exports = copy


### PR DESCRIPTION
fix #565.

`copy` and `copySync`:

Check paths stricter before performing copy and also check case-insensitive paths. Added tests as well. Also, found some `copySync` test file was actually calling `copy` :grin: (I forgot to change it to sync version after copy-paste it!) Fixed that one as well :smile: