### PR TITLE
use strict assert

### DIFF
--- a/lib/copy-sync/__tests__/broken-symlink.test.js
+++ b/lib/copy-sync/__tests__/broken-symlink.test.js
@@ -25,7 +25,7 @@ describe('copy-sync / broken symlink', () => {
 
   it('should copy broken symlinks by default', () => {
     assert.doesNotThrow(() => copySync(src, out))
-    assert.equal(fs.readlinkSync(path.join(out, 'broken-symlink')), path.join(src, 'does-not-exist'))
+    assert.strictEqual(fs.readlinkSync(path.join(out, 'broken-symlink')), path.join(src, 'does-not-exist'))
   })
 
   it('should throw an error when dereference=true', () => {

--- a/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
@@ -52,7 +52,7 @@ describeIfPractical('copySync() - preserveTimestamps option', () => {
           assert.strictEqual(toStat.atime.getTime(), utimes.timeRemoveMillis(fromStat.atime.getTime()))
         }
       } else {
-        assert.notEqual(toStat.mtime.getTime(), fromStat.mtime.getTime())
+        assert.notStrictEqual(toStat.mtime.getTime(), fromStat.mtime.getTime())
         // the access time might actually be the same, so check only modification time
       }
     }

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
@@ -26,7 +26,7 @@ describe('+ copySync() - prevent copying identical files and dirs', () => {
     try {
       fs.copySync(fileSrc, fileDest)
     } catch (err) {
-      assert.equal(err.message, 'Source and destination must not be the same.')
+      assert.strictEqual(err.message, 'Source and destination must not be the same.')
     }
   })
 

--- a/lib/copy-sync/__tests__/symlink.test.js
+++ b/lib/copy-sync/__tests__/symlink.test.js
@@ -30,8 +30,8 @@ describe('copy-sync / symlink', () => {
       copySync(src, out)
     })
 
-    assert.equal(fs.readlinkSync(path.join(out, 'file-symlink')), path.join(src, 'foo'))
-    assert.equal(fs.readlinkSync(path.join(out, 'dir-symlink')), path.join(src, 'dir'))
+    assert.strictEqual(fs.readlinkSync(path.join(out, 'file-symlink')), path.join(src, 'foo'))
+    assert.strictEqual(fs.readlinkSync(path.join(out, 'dir-symlink')), path.join(src, 'dir'))
   })
 
   it('copies file contents when dereference=true', () => {
@@ -43,11 +43,11 @@ describe('copy-sync / symlink', () => {
 
     const fileSymlinkPath = path.join(out, 'file-symlink')
     assert.ok(fs.lstatSync(fileSymlinkPath).isFile())
-    assert.equal(fs.readFileSync(fileSymlinkPath), 'foo contents')
+    assert.strictEqual(fs.readFileSync(fileSymlinkPath, 'utf8'), 'foo contents')
 
     const dirSymlinkPath = path.join(out, 'dir-symlink')
     assert.ok(fs.lstatSync(dirSymlinkPath).isDirectory())
-    assert.deepEqual(fs.readdirSync(dirSymlinkPath), ['bar'])
+    assert.deepStrictEqual(fs.readdirSync(dirSymlinkPath), ['bar'])
   })
 })
 

--- a/lib/copy/__tests__/copy-preserve-time.test.js
+++ b/lib/copy/__tests__/copy-preserve-time.test.js
@@ -55,7 +55,7 @@ describeIfPractical('copy() - preserve timestamp', () => {
           assert.strictEqual(toStat.atime.getTime(), utimes.timeRemoveMillis(fromStat.atime.getTime()))
         }
       } else {
-        assert.notEqual(toStat.mtime.getTime(), fromStat.mtime.getTime())
+        assert.notStrictEqual(toStat.mtime.getTime(), fromStat.mtime.getTime())
         // the access time might actually be the same, so check only modification time
       }
     }

--- a/lib/copy/__tests__/copy-prevent-copying-identical.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-identical.test.js
@@ -25,7 +25,7 @@ describe('+ copy() - prevent copying identical files and dirs', () => {
     const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
 
     fs.copy(fileSrc, fileDest, err => {
-      assert.equal(err.message, 'Source and destination must not be the same.')
+      assert.strictEqual(err.message, 'Source and destination must not be the same.')
       done()
     })
   })

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -25,7 +25,7 @@ describe('fs-extra', () => {
       const fileSrc = path.join(TEST_DIR, 'TEST_fs-extra_copy')
       const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
       fse.copy(fileSrc, fileDest, err => {
-        assert.equal(err.message, 'Source and destination must not be the same.')
+        assert.strictEqual(err.message, 'Source and destination must not be the same.')
         done()
       })
     })

--- a/lib/copy/__tests__/ncp/broken-symlink.test.js
+++ b/lib/copy/__tests__/ncp/broken-symlink.test.js
@@ -26,14 +26,14 @@ describe('ncp broken symlink', () => {
   it('should copy broken symlinks by default', done => {
     ncp(src, out, err => {
       if (err) return done(err)
-      assert.equal(fs.readlinkSync(path.join(out, 'broken-symlink')), path.join(src, 'does-not-exist'))
+      assert.strictEqual(fs.readlinkSync(path.join(out, 'broken-symlink')), path.join(src, 'does-not-exist'))
       done()
     })
   })
 
   it('should return an error when dereference=true', done => {
     ncp(src, out, {dereference: true}, err => {
-      assert.equal(err.code, 'ENOENT')
+      assert.strictEqual(err.code, 'ENOENT')
       done()
     })
   })

--- a/lib/copy/__tests__/ncp/ncp-error-perm.test.js
+++ b/lib/copy/__tests__/ncp/ncp-error-perm.test.js
@@ -43,7 +43,7 @@ describe('ncp / error / dest-permission', () => {
 
     ncp(src, subdest, err => {
       assert(err)
-      assert.equal(err.code, 'EACCES')
+      assert.strictEqual(err.code, 'EACCES')
       done()
     })
   })

--- a/lib/copy/__tests__/ncp/ncp.test.js
+++ b/lib/copy/__tests__/ncp/ncp.test.js
@@ -24,7 +24,7 @@ describe('ncp', () => {
         readDirFiles(src, 'utf8', (srcErr, srcFiles) => {
           readDirFiles(out, 'utf8', (outErr, outFiles) => {
             assert.ifError(srcErr)
-            assert.deepEqual(srcFiles, outFiles)
+            assert.deepStrictEqual(srcFiles, outFiles)
             cb()
           })
         })
@@ -55,7 +55,7 @@ describe('ncp', () => {
           filter(srcFiles)
           readDirFiles(out, 'utf8', (outErr, outFiles) => {
             assert.ifError(outErr)
-            assert.deepEqual(srcFiles, outFiles)
+            assert.deepStrictEqual(srcFiles, outFiles)
             cb()
           })
         })
@@ -133,7 +133,7 @@ describe('ncp', () => {
       it('file descriptors are passed correctly', cb => {
         ncp(src, out, {
           transform: (read, write, file) => {
-            assert.notEqual(file.name, undefined)
+            assert.notStrictEqual(file.name, undefined)
             assert.strictEqual(typeof file.mode, 'number')
             read.pipe(write)
           }
@@ -158,7 +158,7 @@ describe('ncp', () => {
         readDirFiles(src, 'utf8', (srcErr, srcFiles) => {
           readDirFiles(out, 'utf8', (outErr, outFiles) => {
             assert.ifError(srcErr)
-            assert.deepEqual(srcFiles, outFiles)
+            assert.deepStrictEqual(srcFiles, outFiles)
             callback()
           })
         })
@@ -181,7 +181,7 @@ describe('ncp', () => {
             }, 100)
           } else {
             // console.log('Total callback count is', totalCallbacks)
-            assert.equal(totalCallbacks, expected)
+            assert.strictEqual(totalCallbacks, expected)
             done()
           }
         }

--- a/lib/copy/__tests__/ncp/symlink.test.js
+++ b/lib/copy/__tests__/ncp/symlink.test.js
@@ -27,8 +27,8 @@ describe('ncp / symlink', () => {
     ncp(src, out, err => {
       assert.ifError(err)
 
-      assert.equal(fs.readlinkSync(path.join(out, 'file-symlink')), path.join(src, 'foo'))
-      assert.equal(fs.readlinkSync(path.join(out, 'dir-symlink')), path.join(src, 'dir'))
+      assert.strictEqual(fs.readlinkSync(path.join(out, 'file-symlink')), path.join(src, 'foo'))
+      assert.strictEqual(fs.readlinkSync(path.join(out, 'dir-symlink')), path.join(src, 'dir'))
 
       done()
     })
@@ -40,11 +40,11 @@ describe('ncp / symlink', () => {
 
       const fileSymlinkPath = path.join(out, 'file-symlink')
       assert.ok(fs.lstatSync(fileSymlinkPath).isFile())
-      assert.equal(fs.readFileSync(fileSymlinkPath), 'foo contents')
+      assert.strictEqual(fs.readFileSync(fileSymlinkPath, 'utf8'), 'foo contents')
 
       const dirSymlinkPath = path.join(out, 'dir-symlink')
       assert.ok(fs.lstatSync(dirSymlinkPath).isDirectory())
-      assert.deepEqual(fs.readdirSync(dirSymlinkPath), ['bar'])
+      assert.deepStrictEqual(fs.readdirSync(dirSymlinkPath), ['bar'])
 
       done()
     })

--- a/lib/empty/__tests__/empty-dir-sync.test.js
+++ b/lib/empty/__tests__/empty-dir-sync.test.js
@@ -24,22 +24,22 @@ describe('+ emptyDir()', () => {
   describe('> when directory exists and contains items', () => {
     it('should delete all of the items', () => {
       // verify nothing
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file'))
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file-2'))
       fse.ensureDirSync(path.join(TEST_DIR, 'some-dir'))
-      assert.equal(fs.readdirSync(TEST_DIR).length, 3)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 3)
 
       fse.emptyDirSync(TEST_DIR)
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
     })
   })
 
   describe('> when directory exists and contains no items', () => {
     it('should do nothing', () => {
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
       fse.emptyDirSync(TEST_DIR)
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
     })
   })
 
@@ -48,7 +48,7 @@ describe('+ emptyDir()', () => {
       fse.removeSync(TEST_DIR)
       assert(!fs.existsSync(TEST_DIR))
       fse.emptyDirSync(TEST_DIR)
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
     })
   })
 })

--- a/lib/empty/__tests__/empty-dir.test.js
+++ b/lib/empty/__tests__/empty-dir.test.js
@@ -24,15 +24,15 @@ describe('+ emptyDir()', () => {
   describe('> when directory exists and contains items', () => {
     it('should delete all of the items', done => {
       // verify nothing
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file'))
       fse.ensureFileSync(path.join(TEST_DIR, 'some-file-2'))
       fse.ensureDirSync(path.join(TEST_DIR, 'some-dir'))
-      assert.equal(fs.readdirSync(TEST_DIR).length, 3)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 3)
 
       fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
-        assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+        assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
         done()
       })
     })
@@ -40,10 +40,10 @@ describe('+ emptyDir()', () => {
 
   describe('> when directory exists and contains no items', () => {
     it('should do nothing', done => {
-      assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+      assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
       fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
-        assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+        assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
         done()
       })
     })
@@ -55,7 +55,7 @@ describe('+ emptyDir()', () => {
       assert(!fs.existsSync(TEST_DIR))
       fse.emptyDir(TEST_DIR, err => {
         assert.ifError(err)
-        assert.equal(fs.readdirSync(TEST_DIR).length, 0)
+        assert.strictEqual(fs.readdirSync(TEST_DIR).length, 0)
         done()
       })
     })

--- a/lib/ensure/__tests__/create.test.js
+++ b/lib/ensure/__tests__/create.test.js
@@ -38,7 +38,7 @@ describe('fs-extra', () => {
         fs.writeFileSync(file, 'hello world')
         fse.createFile(file, err => {
           assert.ifError(err)
-          assert.equal(fs.readFileSync(file, 'utf8'), 'hello world')
+          assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello world')
           done()
         })
       })
@@ -61,7 +61,7 @@ describe('fs-extra', () => {
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
         fse.createFileSync(file)
-        assert.equal(fs.readFileSync(file, 'utf8'), 'hello world')
+        assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello world')
       })
     })
   })

--- a/lib/ensure/__tests__/ensure.test.js
+++ b/lib/ensure/__tests__/ensure.test.js
@@ -53,7 +53,7 @@ describe('fs-extra', () => {
 
         fse.ensureFile(p, err => {
           assert(err)
-          assert.equal(err.code, 'EISDIR')
+          assert.strictEqual(err.code, 'EISDIR')
           done()
         })
       })
@@ -91,7 +91,7 @@ describe('fs-extra', () => {
           try {
             fse.ensureFileSync(p)
           } catch (e) {
-            assert.equal(e.code, 'EISDIR')
+            assert.strictEqual(e.code, 'EISDIR')
             throw e
           }
         })

--- a/lib/ensure/__tests__/link.test.js
+++ b/lib/ensure/__tests__/link.test.js
@@ -79,8 +79,8 @@ describe('fse-ensure-link', () => {
         const dstContent = fs.readFileSync(dstpath, 'utf8')
         const dstDirContents = fs.readdirSync(dstDir)
 
-        assert.equal(isSymlink, true)
-        assert.equal(srcContent, dstContent)
+        assert.strictEqual(isSymlink, true)
+        assert.strictEqual(srcContent, dstContent)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         return done()
       }
@@ -96,10 +96,10 @@ describe('fse-ensure-link', () => {
     it(`should return error when creating link file using src ${srcpath} and dst ${dstpath}`, done => {
       const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
       const callback = err => {
-        assert.equal(err instanceof Error, true)
+        assert.strictEqual(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
         const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-        assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+        assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
       args.push(callback)
@@ -116,7 +116,7 @@ describe('fse-ensure-link', () => {
       const callback = err => {
         if (err) return done(err)
         const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
-        assert.equal(destinationContentBefore, destinationContentAfter)
+        assert.strictEqual(destinationContentBefore, destinationContentAfter)
         return done()
       }
       args.push(callback)
@@ -136,8 +136,8 @@ describe('fse-ensure-link', () => {
       const isSymlink = fs.lstatSync(dstpath).isFile()
       const dstContent = fs.readFileSync(dstpath, 'utf8')
       const dstDirContents = fs.readdirSync(dstDir)
-      assert.equal(isSymlink, true)
-      assert.equal(srcContent, dstContent)
+      assert.strictEqual(isSymlink, true)
+      assert.strictEqual(srcContent, dstContent)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
     })
   }
@@ -155,9 +155,9 @@ describe('fse-ensure-link', () => {
       } catch (e) {
         err = e
       }
-      assert.equal(err instanceof Error, true)
+      assert.strictEqual(err instanceof Error, true)
       const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-      assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+      assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
@@ -169,7 +169,7 @@ describe('fse-ensure-link', () => {
       const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
       fn(...args)
       const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
-      assert.equal(destinationContentBefore, destinationContentAfter)
+      assert.strictEqual(destinationContentBefore, destinationContentAfter)
     })
   }
 
@@ -213,8 +213,8 @@ describe('fse-ensure-link', () => {
             const dstContent = fs.readFileSync(dstpath, 'utf8')
             const dstDirContents = fs.readdirSync(dstDir)
 
-            assert.equal(isSymlink, true)
-            assert.equal(srcContent, dstContent)
+            assert.strictEqual(isSymlink, true)
+            assert.strictEqual(srcContent, dstContent)
             assert(dstDirContents.indexOf(dstBasename) >= 0)
           })
       })

--- a/lib/ensure/__tests__/symlink-paths.test.js
+++ b/lib/ensure/__tests__/symlink-paths.test.js
@@ -67,7 +67,7 @@ describe('symlink-type', () => {
       it(`should return '${JSON.stringify(expectedRelativePaths)}' when src '${args[0]}' and dst is '${args[1]}'`, done => {
         const callback = (err, relativePaths) => {
           if (err) done(err)
-          assert.deepEqual(relativePaths, expectedRelativePaths)
+          assert.deepStrictEqual(relativePaths, expectedRelativePaths)
           done()
         }
         args.push(callback)
@@ -82,7 +82,7 @@ describe('symlink-type', () => {
       const expectedRelativePaths = test[1]
       it(`should return '${JSON.stringify(expectedRelativePaths)}' when src '${args[0]}' and dst is '${args[1]}'`, () => {
         const relativePaths = symlinkPathsSync(...args)
-        assert.deepEqual(relativePaths, expectedRelativePaths)
+        assert.deepStrictEqual(relativePaths, expectedRelativePaths)
       })
     })
   })

--- a/lib/ensure/__tests__/symlink-type.test.js
+++ b/lib/ensure/__tests__/symlink-type.test.js
@@ -98,7 +98,7 @@ describe('symlink-type', () => {
       it(`should return '${expectedType}' when src '${args[0]}'`, done => {
         const callback = (err, type) => {
           if (err) done(err)
-          assert.equal(type, expectedType)
+          assert.strictEqual(type, expectedType)
           done()
         }
         args.push(callback)
@@ -113,7 +113,7 @@ describe('symlink-type', () => {
       const expectedType = test[1]
       it(`should return '${expectedType}' when src '${args[0]}'`, () => {
         const type = symlinkTypeSync(...args)
-        assert.equal(type, expectedType)
+        assert.strictEqual(type, expectedType)
       })
     })
   })

--- a/lib/ensure/__tests__/symlink.test.js
+++ b/lib/ensure/__tests__/symlink.test.js
@@ -91,8 +91,8 @@ describe('fse-ensure-symlink', () => {
         const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
         const dstContent = fs.readFileSync(dstpath, 'utf8')
         const dstDirContents = fs.readdirSync(dstDir)
-        assert.equal(isSymlink, true)
-        assert.equal(srcContent, dstContent)
+        assert.strictEqual(isSymlink, true)
+        assert.strictEqual(srcContent, dstContent)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         return done()
       }
@@ -111,7 +111,7 @@ describe('fse-ensure-symlink', () => {
         const dstBasename = path.basename(dstpath)
         const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
         const dstDirContents = fs.readdirSync(dstDir)
-        assert.equal(isSymlink, true)
+        assert.strictEqual(isSymlink, true)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         assert.throws(() => fs.readFileSync(dstpath, 'utf8'), Error)
         return done()
@@ -127,10 +127,10 @@ describe('fse-ensure-symlink', () => {
     it(`should return error when creating symlink file using src ${srcpath} and dst ${dstpath}`, done => {
       const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
       const callback = err => {
-        assert.equal(err instanceof Error, true)
+        assert.strictEqual(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
         const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-        assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+        assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
       args.push(callback)
@@ -146,7 +146,7 @@ describe('fse-ensure-symlink', () => {
       const callback = err => {
         if (err) return done(err)
         const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
-        assert.equal(destinationContentBefore, destinationContentAfter)
+        assert.strictEqual(destinationContentBefore, destinationContentAfter)
         return done()
       }
       args.push(callback)
@@ -167,8 +167,8 @@ describe('fse-ensure-symlink', () => {
         const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
         const dstContents = fs.readdirSync(dstpath)
         const dstDirContents = fs.readdirSync(dstDir)
-        assert.equal(isSymlink, true)
-        assert.deepEqual(srcContents, dstContents)
+        assert.strictEqual(isSymlink, true)
+        assert.deepStrictEqual(srcContents, dstContents)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         return done()
       }
@@ -187,7 +187,7 @@ describe('fse-ensure-symlink', () => {
         const dstBasename = path.basename(dstpath)
         const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
         const dstDirContents = fs.readdirSync(dstDir)
-        assert.equal(isSymlink, true)
+        assert.strictEqual(isSymlink, true)
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         assert.throws(() => fs.readdirSync(dstpath), Error)
         return done()
@@ -203,10 +203,10 @@ describe('fse-ensure-symlink', () => {
     it(`should return error when creating symlink dir using src ${srcpath} and dst ${dstpath}`, done => {
       const dstdirExistsBefore = fs.existsSync(path.dirname(dstpath))
       const callback = err => {
-        assert.equal(err instanceof Error, true)
+        assert.strictEqual(err instanceof Error, true)
         // ensure that directories aren't created if there's an error
         const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-        assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+        assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
       args.push(callback)
@@ -222,7 +222,7 @@ describe('fse-ensure-symlink', () => {
       const callback = err => {
         if (err) return done(err)
         const destinationContentAfter = fs.readdirSync(dstpath)
-        assert.deepEqual(destinationContentBefore, destinationContentAfter)
+        assert.deepStrictEqual(destinationContentBefore, destinationContentAfter)
         return done()
       }
       args.push(callback)
@@ -242,8 +242,8 @@ describe('fse-ensure-symlink', () => {
       const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
       const dstContent = fs.readFileSync(dstpath, 'utf8')
       const dstDirContents = fs.readdirSync(dstDir)
-      assert.equal(isSymlink, true)
-      assert.equal(srcContent, dstContent)
+      assert.strictEqual(isSymlink, true)
+      assert.strictEqual(srcContent, dstContent)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
     })
   }
@@ -257,7 +257,7 @@ describe('fse-ensure-symlink', () => {
       const dstBasename = path.basename(dstpath)
       const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
       const dstDirContents = fs.readdirSync(dstDir)
-      assert.equal(isSymlink, true)
+      assert.strictEqual(isSymlink, true)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
       assert.throws(() => fs.readFileSync(dstpath, 'utf8'), Error)
     })
@@ -274,9 +274,9 @@ describe('fse-ensure-symlink', () => {
       } catch (e) {
         err = e
       }
-      assert.equal(err instanceof Error, true)
+      assert.strictEqual(err instanceof Error, true)
       const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-      assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+      assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
@@ -287,7 +287,7 @@ describe('fse-ensure-symlink', () => {
       const destinationContentBefore = fs.readFileSync(dstpath, 'utf8')
       fn(...args)
       const destinationContentAfter = fs.readFileSync(dstpath, 'utf8')
-      assert.equal(destinationContentBefore, destinationContentAfter)
+      assert.strictEqual(destinationContentBefore, destinationContentAfter)
     })
   }
 
@@ -303,8 +303,8 @@ describe('fse-ensure-symlink', () => {
       const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
       const dstContents = fs.readdirSync(dstpath)
       const dstDirContents = fs.readdirSync(dstDir)
-      assert.equal(isSymlink, true)
-      assert.deepEqual(srcContents, dstContents)
+      assert.strictEqual(isSymlink, true)
+      assert.deepStrictEqual(srcContents, dstContents)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
     })
   }
@@ -318,7 +318,7 @@ describe('fse-ensure-symlink', () => {
       const dstBasename = path.basename(dstpath)
       const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
       const dstDirContents = fs.readdirSync(dstDir)
-      assert.equal(isSymlink, true)
+      assert.strictEqual(isSymlink, true)
       assert(dstDirContents.indexOf(dstBasename) >= 0)
       assert.throws(() => fs.readdirSync(dstpath), Error)
     })
@@ -335,9 +335,9 @@ describe('fse-ensure-symlink', () => {
       } catch (e) {
         err = e
       }
-      assert.equal(err instanceof Error, true)
+      assert.strictEqual(err instanceof Error, true)
       const dstdirExistsAfter = fs.existsSync(path.dirname(dstpath))
-      assert.equal(dstdirExistsBefore, dstdirExistsAfter)
+      assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
     })
   }
 
@@ -348,7 +348,7 @@ describe('fse-ensure-symlink', () => {
       const destinationContentBefore = fs.readdirSync(dstpath)
       fn(...args)
       const destinationContentAfter = fs.readdirSync(dstpath)
-      assert.deepEqual(destinationContentBefore, destinationContentAfter)
+      assert.deepStrictEqual(destinationContentBefore, destinationContentAfter)
     })
   }
 
@@ -402,8 +402,8 @@ describe('fse-ensure-symlink', () => {
             const isSymlink = fs.lstatSync(dstpath).isSymbolicLink()
             const dstContent = fs.readFileSync(dstpath, 'utf8')
             const dstDirContents = fs.readdirSync(dstDir)
-            assert.equal(isSymlink, true)
-            assert.equal(srcContent, dstContent)
+            assert.strictEqual(isSymlink, true)
+            assert.strictEqual(srcContent, dstContent)
             assert(dstDirContents.indexOf(dstBasename) >= 0)
           })
       })

--- a/lib/fs/__tests__/copyFile.test.js
+++ b/lib/fs/__tests__/copyFile.test.js
@@ -26,7 +26,7 @@ if (typeof fs.copyFile === 'function') {
       fse.writeFileSync(src, 'hello')
       return fse.copyFile(src, dest).then(() => {
         const data = fse.readFileSync(dest, 'utf8')
-        assert.equal(data, 'hello')
+        assert.strictEqual(data, 'hello')
       })
     })
   })

--- a/lib/fs/__tests__/fs-integration.test.js
+++ b/lib/fs/__tests__/fs-integration.test.js
@@ -22,13 +22,13 @@ describe('native fs', () => {
     const file = path.join(TEST_DIR, 'write.txt')
     fse.writeFileSync(file, 'hello')
     const data = fse.readFileSync(file, 'utf8')
-    assert.equal(data, 'hello')
+    assert.strictEqual(data, 'hello')
   })
 
   it('should have native fs constants', () => {
     // Node.js v0.12 / IO.js
     if ('F_OK' in fs) {
-      assert.equal(fse.F_OK, fs.F_OK)
+      assert.strictEqual(fse.F_OK, fs.F_OK)
     }
   })
 })

--- a/lib/fs/__tests__/multi-param.test.js
+++ b/lib/fs/__tests__/multi-param.test.js
@@ -35,7 +35,7 @@ describe('fs.read()', () => {
         .then(results => {
           const bytesRead = results.bytesRead
           const buffer = results.buffer
-          assert.equal(bytesRead, SIZE, 'bytesRead is correct')
+          assert.strictEqual(bytesRead, SIZE, 'bytesRead is correct')
           assert(buffer.equals(TEST_DATA), 'data is correct')
         })
     })
@@ -45,7 +45,7 @@ describe('fs.read()', () => {
         .then(results => {
           const bytesRead = results.bytesRead
           const buffer = results.buffer
-          assert.equal(bytesRead, SIZE, 'bytesRead is correct')
+          assert.strictEqual(bytesRead, SIZE, 'bytesRead is correct')
           assert(buffer.equals(TEST_DATA), 'data is correct')
         })
     })
@@ -55,7 +55,7 @@ describe('fs.read()', () => {
     it('works', done => {
       fs.read(TEST_FD, Buffer.alloc(SIZE), 0, SIZE, 0, (err, bytesRead, buffer) => {
         assert.ifError(err)
-        assert.equal(bytesRead, SIZE, 'bytesRead is correct')
+        assert.strictEqual(bytesRead, SIZE, 'bytesRead is correct')
         assert(buffer.equals(TEST_DATA), 'data is correct')
         done()
       })
@@ -64,7 +64,7 @@ describe('fs.read()', () => {
     it('works when position is null', done => {
       fs.read(TEST_FD, Buffer.alloc(SIZE), 0, SIZE, null, (err, bytesRead, buffer) => {
         assert.ifError(err)
-        assert.equal(bytesRead, SIZE, 'bytesRead is correct')
+        assert.strictEqual(bytesRead, SIZE, 'bytesRead is correct')
         assert(buffer.equals(TEST_DATA), 'data is correct')
         done()
       })
@@ -95,7 +95,7 @@ describe('fs.write()', () => {
         .then(results => {
           const bytesWritten = results.bytesWritten
           const buffer = results.buffer
-          assert.equal(bytesWritten, SIZE, 'bytesWritten is correct')
+          assert.strictEqual(bytesWritten, SIZE, 'bytesWritten is correct')
           assert(buffer.equals(TEST_DATA), 'data is correct')
         })
     })
@@ -105,7 +105,7 @@ describe('fs.write()', () => {
         .then(results => {
           const bytesWritten = results.bytesWritten
           const buffer = results.buffer
-          assert.equal(bytesWritten, SIZE, 'bytesWritten is correct')
+          assert.strictEqual(bytesWritten, SIZE, 'bytesWritten is correct')
           assert(buffer.equals(TEST_DATA), 'data is correct')
         })
     })
@@ -116,8 +116,8 @@ describe('fs.write()', () => {
         .then(results => {
           const bytesWritten = results.bytesWritten
           const buffer = results.buffer
-          assert.equal(bytesWritten, message.length, 'bytesWritten is correct')
-          assert.equal(buffer, message, 'data is correct')
+          assert.strictEqual(bytesWritten, message.length, 'bytesWritten is correct')
+          assert.strictEqual(buffer, message, 'data is correct')
         })
     })
   })
@@ -126,7 +126,7 @@ describe('fs.write()', () => {
     it('works', done => {
       fs.write(TEST_FD, TEST_DATA, 0, SIZE, 0, (err, bytesWritten, buffer) => {
         assert.ifError(err)
-        assert.equal(bytesWritten, SIZE, 'bytesWritten is correct')
+        assert.strictEqual(bytesWritten, SIZE, 'bytesWritten is correct')
         assert(buffer.equals(TEST_DATA), 'data is correct')
         done()
       })
@@ -135,7 +135,7 @@ describe('fs.write()', () => {
     onNode7it('works when minimal arguments are passed', done => {
       fs.write(TEST_FD, TEST_DATA, (err, bytesWritten, buffer) => {
         assert.ifError(err)
-        assert.equal(bytesWritten, SIZE, 'bytesWritten is correct')
+        assert.strictEqual(bytesWritten, SIZE, 'bytesWritten is correct')
         assert(buffer.equals(TEST_DATA), 'data is correct')
         done()
       })
@@ -145,8 +145,8 @@ describe('fs.write()', () => {
       const message = 'Hello World!'
       return fs.write(TEST_FD, message, (err, bytesWritten, buffer) => {
         assert.ifError(err)
-        assert.equal(bytesWritten, message.length, 'bytesWritten is correct')
-        assert.equal(buffer, message, 'data is correct')
+        assert.strictEqual(bytesWritten, message.length, 'bytesWritten is correct')
+        assert.strictEqual(buffer, message, 'data is correct')
         done()
       })
     })

--- a/lib/fs/__tests__/mz.test.js
+++ b/lib/fs/__tests__/mz.test.js
@@ -9,14 +9,14 @@ const fs = require('../..')
 describe('fs', () => {
   it('.stat()', done => {
     fs.stat(__filename).then(stats => {
-      assert.equal(typeof stats.size, 'number')
+      assert.strictEqual(typeof stats.size, 'number')
       done()
     }).catch(done)
   })
 
   it('.statSync()', () => {
     const stats = fs.statSync(__filename)
-    assert.equal(typeof stats.size, 'number')
+    assert.strictEqual(typeof stats.size, 'number')
   })
 
   it('.exists()', done => {
@@ -35,7 +35,7 @@ describe('fs', () => {
     it('.stat()', done => {
       fs.stat(__filename, (err, stats) => {
         assert(!err)
-        assert.equal(typeof stats.size, 'number')
+        assert.strictEqual(typeof stats.size, 'number')
         done()
       })
     })

--- a/lib/json/__tests__/output-json-sync.test.js
+++ b/lib/json/__tests__/output-json-sync.test.js
@@ -28,7 +28,7 @@ describe('json', () => {
       assert(fs.existsSync(file))
       const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
-      assert.equal(data.name, newData.name)
+      assert.strictEqual(data.name, newData.name)
     })
 
     describe('> when an option is passed, like JSON replacer', () => {
@@ -42,7 +42,7 @@ describe('json', () => {
         outputJsonSync(file, data, { replacer })
         const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
-        assert.equal(newData.name, 'Jon Paul')
+        assert.strictEqual(newData.name, 'Jon Paul')
       })
     })
   })

--- a/lib/json/__tests__/output-json.test.js
+++ b/lib/json/__tests__/output-json.test.js
@@ -29,7 +29,7 @@ describe('json', () => {
         assert(fs.existsSync(file))
         const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
 
-        assert.equal(data.name, newData.name)
+        assert.strictEqual(data.name, newData.name)
         done()
       })
     })
@@ -53,7 +53,7 @@ describe('json', () => {
         outputJson(file, data, { replacer }, err => {
           assert.ifError(err)
           const newData = JSON.parse(fs.readFileSync(file, 'utf8'))
-          assert.equal(newData.name, 'Jon Paul')
+          assert.strictEqual(newData.name, 'Jon Paul')
           done()
         })
       })

--- a/lib/mkdirs/__tests__/chmod.test.js
+++ b/lib/mkdirs/__tests__/chmod.test.js
@@ -43,9 +43,9 @@ describe('mkdirp / chmod', () => {
         assert.ok(stat && stat.isDirectory(), 'should be directory')
 
         if (os.platform().indexOf('win') === 0) {
-          assert.equal(stat && stat.mode & o777, o666, 'windows shit')
+          assert.strictEqual(stat && stat.mode & o777, o666, 'windows shit')
         } else {
-          assert.equal(stat && stat.mode & o777, mode, 'should be 0744')
+          assert.strictEqual(stat && stat.mode & o777, mode, 'should be 0744')
         }
 
         done()

--- a/lib/mkdirs/__tests__/clobber.test.js
+++ b/lib/mkdirs/__tests__/clobber.test.js
@@ -45,9 +45,9 @@ describe('mkdirp / clobber', () => {
     fse.mkdirp(file, o755, err => {
       assert.ok(err)
       if (os.platform().indexOf('win') === 0) {
-        assert.equal(err.code, 'EEXIST')
+        assert.strictEqual(err.code, 'EEXIST')
       } else {
-        assert.equal(err.code, 'ENOTDIR')
+        assert.strictEqual(err.code, 'ENOTDIR')
       }
       done()
     })

--- a/lib/mkdirs/__tests__/mkdirp.test.js
+++ b/lib/mkdirs/__tests__/mkdirp.test.js
@@ -38,9 +38,9 @@ describe('mkdirp / mkdirp', () => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.equal(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & o777, o666)
           } else {
-            assert.equal(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & o777, o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/perm.test.js
+++ b/lib/mkdirs/__tests__/perm.test.js
@@ -34,9 +34,9 @@ describe('mkdirp / perm', () => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.equal(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & o777, o666)
           } else {
-            assert.equal(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & o777, o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/perm_sync.test.js
+++ b/lib/mkdirs/__tests__/perm_sync.test.js
@@ -33,9 +33,9 @@ describe('mkdirp / perm_sync', () => {
         assert.ifError(err)
 
         if (os.platform().indexOf('win') === 0) {
-          assert.equal(stat.mode & o777, o666)
+          assert.strictEqual(stat.mode & o777, o666)
         } else {
-          assert.equal(stat.mode & o777, o755)
+          assert.strictEqual(stat.mode & o777, o755)
         }
 
         assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/race.test.js
+++ b/lib/mkdirs/__tests__/race.test.js
@@ -51,9 +51,9 @@ describe('mkdirp / race', () => {
             assert.ifError(err)
 
             if (os.platform().indexOf('win') === 0) {
-              assert.equal(stat.mode & o777, o666)
+              assert.strictEqual(stat.mode & o777, o666)
             } else {
-              assert.equal(stat.mode & o777, o755)
+              assert.strictEqual(stat.mode & o777, o755)
             }
 
             assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/rel.test.js
+++ b/lib/mkdirs/__tests__/rel.test.js
@@ -50,9 +50,9 @@ describe('mkdirp / relative', () => {
           process.chdir(CWD)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.equal(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & o777, o666)
           } else {
-            assert.equal(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & o777, o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/return.test.js
+++ b/lib/mkdirs/__tests__/return.test.js
@@ -30,10 +30,10 @@ describe('mkdirp / return value', () => {
     // already exist, since every other test makes things in there.
     fse.mkdirp(file, (err, made) => {
       assert.ifError(err)
-      assert.equal(made, dir + x)
+      assert.strictEqual(made, dir + x)
       fse.mkdirp(file, (err, made) => {
         assert.ifError(err)
-        assert.equal(made, null)
+        assert.strictEqual(made, null)
         done()
       })
     })

--- a/lib/mkdirs/__tests__/return_sync.test.js
+++ b/lib/mkdirs/__tests__/return_sync.test.js
@@ -30,10 +30,10 @@ describe('mkdirp / return value', () => {
     // already exist, since every other test makes things in there.
     // Note that this will throw on failure, which will fail the test.
     let made = fse.mkdirpSync(file)
-    assert.equal(made, dir + x)
+    assert.strictEqual(made, dir + x)
 
     // making the same file again should have no effect.
     made = fse.mkdirpSync(file)
-    assert.equal(made, null)
+    assert.strictEqual(made, null)
   })
 })

--- a/lib/mkdirs/__tests__/sync.test.js
+++ b/lib/mkdirs/__tests__/sync.test.js
@@ -47,9 +47,9 @@ describe('mkdirp / sync', () => {
         assert.ifError(err)
         // http://stackoverflow.com/questions/592448/c-how-to-set-file-permissions-cross-platform
         if (os.platform().indexOf('win') === 0) {
-          assert.equal(stat.mode & o777, o666)
+          assert.strictEqual(stat.mode & o777, o666)
         } else {
-          assert.equal(stat.mode & o777, o755)
+          assert.strictEqual(stat.mode & o777, o755)
         }
 
         assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/umask.test.js
+++ b/lib/mkdirs/__tests__/umask.test.js
@@ -47,7 +47,7 @@ describe('mkdirp', () => {
             assert.ok(ex, 'file created')
             fs.stat(_rndDir, (err, stat) => {
               assert.ifError(err)
-              assert.equal(stat.mode & o777, o777 & (~process.umask()))
+              assert.strictEqual(stat.mode & o777, o777 & (~process.umask()))
               assert.ok(stat.isDirectory(), 'target not a directory')
               done()
             })
@@ -71,7 +71,7 @@ describe('mkdirp', () => {
           assert.ok(ex, 'file created')
           fs.stat(_rndDir, (err, stat) => {
             assert.ifError(err)
-            assert.equal(stat.mode & o777, (o777 & (~process.umask())))
+            assert.strictEqual(stat.mode & o777, (o777 & (~process.umask())))
             assert.ok(stat.isDirectory(), 'target not a directory')
             done()
           })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -302,7 +302,7 @@ describe('+ move()', () => {
 
       fse.move(SRC_DIR, DEST_DIR, err => {
         assert(fs.existsSync(SRC_DIR))
-        assert.equal(err.message, `Cannot move '${SRC_DIR}' to a subdirectory of itself, '${DEST_DIR}'.`)
+        assert.strictEqual(err.message, `Cannot move '${SRC_DIR}' to a subdirectory of itself, '${DEST_DIR}'.`)
         done()
       })
     })

--- a/lib/output/__tests__/output.test.js
+++ b/lib/output/__tests__/output.test.js
@@ -26,7 +26,7 @@ describe('output', () => {
         fse.outputFile(file, 'hi jp', err => {
           assert.ifError(err)
           assert(fs.existsSync(file))
-          assert.equal(fs.readFileSync(file, 'utf8'), 'hi jp')
+          assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hi jp')
           done()
         })
       })
@@ -44,7 +44,7 @@ describe('output', () => {
         fs.writeFileSync(file, 'hello world')
         fse.outputFile(file, 'hello jp', err => {
           if (err) return done(err)
-          assert.equal(fs.readFileSync(file, 'utf8'), 'hello jp')
+          assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello jp')
           done()
         })
       })
@@ -58,7 +58,7 @@ describe('output', () => {
         assert(!fs.existsSync(file))
         fse.outputFileSync(file, 'hello man')
         assert(fs.existsSync(file))
-        assert.equal(fs.readFileSync(file, 'utf8'), 'hello man')
+        assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello man')
       })
     })
 
@@ -68,7 +68,7 @@ describe('output', () => {
         fse.mkdirsSync(path.dirname(file))
         fs.writeFileSync(file, 'hello world')
         fse.outputFileSync(file, 'hello man')
-        assert.equal(fs.readFileSync(file, 'utf8'), 'hello man')
+        assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello man')
       })
     })
   })

--- a/lib/remove/__tests__/remove-dir.test.js
+++ b/lib/remove/__tests__/remove-dir.test.js
@@ -19,7 +19,7 @@ describe('remove / async / dir', () => {
   describe('> when dir does not exist', () => {
     it('should not throw an error', done => {
       const someDir = path.join(TEST_DIR, 'some-dir/')
-      assert.equal(fs.existsSync(someDir), false)
+      assert.strictEqual(fs.existsSync(someDir), false)
       fse.remove(someDir, err => {
         assert.ifError(err)
         done()

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -33,10 +33,10 @@ function rimraf (p, options, cb) {
   }
 
   assert(p, 'rimraf: missing path')
-  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
-  assert.equal(typeof cb, 'function', 'rimraf: callback function required')
+  assert.strictEqual(typeof p, 'string', 'rimraf: path should be a string')
+  assert.strictEqual(typeof cb, 'function', 'rimraf: callback function required')
   assert(options, 'rimraf: invalid options argument provided')
-  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+  assert.strictEqual(typeof options, 'object', 'rimraf: options should be object')
 
   defaults(options)
 
@@ -229,9 +229,9 @@ function rimrafSync (p, options) {
   defaults(options)
 
   assert(p, 'rimraf: missing path')
-  assert.equal(typeof p, 'string', 'rimraf: path should be a string')
+  assert.strictEqual(typeof p, 'string', 'rimraf: path should be a string')
   assert(options, 'rimraf: missing options')
-  assert.equal(typeof options, 'object', 'rimraf: options should be object')
+  assert.strictEqual(typeof options, 'object', 'rimraf: options should be object')
 
   try {
     st = options.lstatSync(p)

--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -25,17 +25,17 @@ describe('utimes', () => {
   describe('hasMillisResSync()', () => {
     it('should return a boolean indicating whether it has support', () => {
       const res = utimes.hasMillisResSync()
-      assert.equal(typeof res, 'boolean')
+      assert.strictEqual(typeof res, 'boolean')
 
       // HFS => false
-      if (process.platform === 'darwin') assert.equal(res, false)
+      if (process.platform === 'darwin') assert.strictEqual(res, false)
 
       // does anyone use FAT anymore?
-      // if (process.platform === 'win32') assert.equal(res, true)
+      // if (process.platform === 'win32') assert.strictEqual(res, true)
       // fails on appveyor... could appveyor be using FAT?
 
       // this would fail if ext2/ext3
-      if (process.platform === 'linux') assert.equal(res, true)
+      if (process.platform === 'linux') assert.strictEqual(res, true)
     })
   })
 
@@ -60,18 +60,18 @@ describe('utimes', () => {
       const awhileAgo = new Date(1334990868773)
       const awhileAgoNoMillis = new Date(1334990868000)
 
-      assert.notDeepEqual(stats.mtime, awhileAgo)
-      assert.notDeepEqual(stats.atime, awhileAgo)
+      assert.notDeepStrictEqual(stats.mtime, awhileAgo)
+      assert.notDeepStrictEqual(stats.atime, awhileAgo)
 
       utimes.utimesMillis(tmpFile, awhileAgo, awhileAgo, err => {
         assert.ifError(err)
         stats = fs.statSync(tmpFile)
         if (utimes.hasMillisResSync()) {
-          assert.deepEqual(stats.mtime, awhileAgo)
-          assert.deepEqual(stats.atime, awhileAgo)
+          assert.deepStrictEqual(stats.mtime, awhileAgo)
+          assert.deepStrictEqual(stats.atime, awhileAgo)
         } else {
-          assert.deepEqual(stats.mtime, awhileAgoNoMillis)
-          assert.deepEqual(stats.atime, awhileAgoNoMillis)
+          assert.deepStrictEqual(stats.mtime, awhileAgoNoMillis)
+          assert.deepStrictEqual(stats.atime, awhileAgoNoMillis)
         }
         done()
       })
@@ -87,7 +87,7 @@ describe('utimes', () => {
 
       let closeCalled = false
       gracefulFsStub.close = (fd, callback) => {
-        assert.equal(fd, fakeFd)
+        assert.strictEqual(fd, fakeFd)
         closeCalled = true
         if (callback) process.nextTick(callback)
       }
@@ -101,7 +101,7 @@ describe('utimes', () => {
       }
 
       utimes.utimesMillis('ignored', 'ignored', 'ignored', err => {
-        assert.equal(err, testError)
+        assert.strictEqual(err, testError)
         assert(closeCalled)
         done()
       })


### PR DESCRIPTION
So,

`const assert = require('assert')` is [deprecated](https://nodejs.org/api/assert.html).

Instead, it is recommended to use `strict` mode:

`const assert = require('assert').strict`.

But, `strict` property is added in `v9.9.0`. Since we still support node >=v6, as a current solution, just changed all of the following deprecated functions to their `strict` functions:

- `assert.equal` -> `assert.strictEqual`
- `assert.notEqual` -> `assert.notStrictEqual`
- `assert.deepEqual` -> `assert.deepStrictEqual`
- `assert.notDeepEqual` -> `assert.notDeepStrictEqual`