### PR TITLE
copy*(): refactor copyDirItems() to avoid passing null param

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -33,15 +33,6 @@ function copySync (src, dest, opts) {
 }
 
 function startCopy (resolvedDest, src, dest, opts) {
-  // resovledDest is only truthy in the first call of startCopy.
-  // when copying directory items, startCopy is called recursively and
-  // resolvedDest is null, so we need to check paths in that case.
-  if (resolvedDest) return resumeCopy(resolvedDest, src, dest, opts)
-  const resolvedDestNested = checkPaths(src, dest)
-  return resumeCopy(resolvedDestNested, src, dest, opts)
-}
-
-function resumeCopy (resolvedDest, src, dest, opts) {
   if (opts.filter && !opts.filter(src, dest)) return
   return getStats(resolvedDest, src, dest, opts)
 }
@@ -133,9 +124,14 @@ function mkDirAndCopy (srcStat, src, dest, opts) {
 }
 
 function copyDir (src, dest, opts) {
-  fs.readdirSync(src).forEach(item => {
-    startCopy(null, path.join(src, item), path.join(dest, item), opts)
-  })
+  fs.readdirSync(src).forEach(item => copyDirItem(item, src, dest, opts))
+}
+
+function copyDirItem (item, src, dest, opts) {
+  const srcItem = path.join(src, item)
+  const destItem = path.join(dest, item)
+  const resolvedDest = checkPaths(srcItem, destItem)
+  return startCopy(resolvedDest, srcItem, destItem, opts)
 }
 
 function onLink (resolvedDest, src, dest, opts) {

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -49,17 +49,6 @@ function checkParentDir (resolvedDest, src, dest, opts, cb) {
 }
 
 function startCopy (resolvedDest, src, dest, opts, cb) {
-  // resovledDest is only truthy in the first call of startCopy.
-  // when copying directory items, startCopy is called recursively and
-  // resolvedDest is null, so we need to check paths in that case.
-  if (resolvedDest) return resumeCopy(resolvedDest, src, dest, opts, cb)
-  return checkPaths(src, dest, (err, resolvedDest) => {
-    if (err) return cb(err)
-    return resumeCopy(resolvedDest, src, dest, opts, cb)
-  })
-}
-
-function resumeCopy (resolvedDest, src, dest, opts, cb) {
   if (opts.filter) return handleFilter(getStats, resolvedDest, src, dest, opts, cb)
   return getStats(resolvedDest, src, dest, opts, cb)
 }
@@ -179,9 +168,18 @@ function copyDir (src, dest, opts, cb) {
 function copyDirItems (items, src, dest, opts, cb) {
   const item = items.pop()
   if (!item) return cb()
-  startCopy(null, path.join(src, item), path.join(dest, item), opts, err => {
+  return copyDirItem(items, item, src, dest, opts, cb)
+}
+
+function copyDirItem (items, item, src, dest, opts, cb) {
+  const srcItem = path.join(src, item)
+  const destItem = path.join(dest, item)
+  checkPaths(srcItem, destItem, (err, resolvedDest) => {
     if (err) return cb(err)
-    return copyDirItems(items, src, dest, opts, cb)
+    startCopy(resolvedDest, srcItem, destItem, opts, err => {
+      if (err) return cb(err)
+      return copyDirItems(items, src, dest, opts, cb)
+    })
   })
 }
 


### PR DESCRIPTION
refactored `copy` and `copySync` so that `startCopy` can have a consistent signature and no need to pass a null param. IDK, I figured that'd be easier to read and understand the code then!