### PR TITLE
Fix fs.promises ExperimentalWarning on Node 10.1.0

### DIFF
--- a/lib/__tests__/promise.test.js
+++ b/lib/__tests__/promise.test.js
@@ -2,6 +2,8 @@
 
 /* eslint-env mocha */
 
+const assert = require('assert')
+const fs = require('fs')
 const fse = require('..')
 
 const methods = [
@@ -22,4 +24,12 @@ describe('promise support', () => {
       fse[method]().catch(() => done())
     })
   })
+
+  if (Object.getOwnPropertyDescriptor(fs, 'promises')) {
+    it('provides fse.promises API', () => {
+      const desc = Object.getOwnPropertyDescriptor(fse, 'promises')
+      assert.ok(desc)
+      assert.equal(typeof desc.get, 'function')
+    })
+  }
 })

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -46,6 +46,11 @@ const api = [
 
 // Export all keys:
 Object.keys(fs).forEach(key => {
+  if (key === 'promises') {
+    // fs.promises is a getter property that triggers ExperimentalWarning
+    // Don't re-export it here, the getter is defined in "lib/index.js"
+    return
+  }
   exports[key] = fs[key]
 })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -17,3 +17,12 @@ module.exports = Object.assign(
   require('./path-exists'),
   require('./remove')
 )
+
+// Export fs.promises as a getter property so that we don't trigger
+// ExperimentalWarning before fs.promises is actually accessed.
+const fs = require('fs')
+if (Object.getOwnPropertyDescriptor(fs, 'promises')) {
+  Object.defineProperty(module.exports, 'promises', {
+    get () { return fs.promises }
+  })
+}


### PR DESCRIPTION
Fixes #577

When fs-extra is loaded on Node.js 10.1.0, an experimental warning is printed:

```
(node:7885) ExperimentalWarning: The fs.promises API is experimental
```

This pull request fixes the problem by defining `fs.promises` as a getter property.

@RyanZim @jprichardson  could you please take a look?