### PR TITLE
Chore: add supported engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "fs-extra",
   "version": "6.0.1",
   "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as mkdir -p, cp -r, and rm -rf.",
+  "engines": {
+    "node": ">=6 <7 || >=8"
+  },
   "homepage": "https://github.com/jprichardson/node-fs-extra",
   "repository": {
     "type": "git",


### PR DESCRIPTION
These engines settings should support Node v6 and v8+

(ref: #579)