### PR TITLE
fix docs to be consistent with node docs

### DIFF
--- a/docs/copy-sync.md
+++ b/docs/copy-sync.md
@@ -1,4 +1,4 @@
-# copySync(src, dest, [options])
+# copySync(src, dest[, options])
 
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 

--- a/docs/copy.md
+++ b/docs/copy.md
@@ -1,4 +1,4 @@
-# copy(src, dest, [options, callback])
+# copy(src, dest[, options][, callback])
 
 Copy a file or directory. The directory can have contents. Like `cp -r`.
 

--- a/docs/emptyDir.md
+++ b/docs/emptyDir.md
@@ -1,4 +1,4 @@
-# emptyDir(dir, [callback])
+# emptyDir(dir[, callback])
 
 Ensures that a directory is empty. Deletes directory contents if the directory is not empty. If the directory does not exist, it is created. The directory itself is not deleted.
 

--- a/docs/ensureDir.md
+++ b/docs/ensureDir.md
@@ -1,4 +1,4 @@
-# ensureDir(dir, [callback])
+# ensureDir(dir[, callback])
 
 Ensures that the directory exists. If the directory structure does not exist, it is created. Like `mkdir -p`.
 

--- a/docs/ensureFile.md
+++ b/docs/ensureFile.md
@@ -1,4 +1,4 @@
-# ensureFile(file, [callback])
+# ensureFile(file[, callback])
 
 Ensures that the file exists. If the file that is requested to be created is in directories that do not exist, these directories are created. If the file already exists, it is **NOT MODIFIED**.
 

--- a/docs/ensureLink.md
+++ b/docs/ensureLink.md
@@ -1,4 +1,4 @@
-# ensureLink(srcpath, dstpath, [callback])
+# ensureLink(srcpath, dstpath[, callback])
 
 Ensures that the link exists. If the directory structure does not exist, it is created.
 

--- a/docs/ensureSymlink-sync.md
+++ b/docs/ensureSymlink-sync.md
@@ -1,4 +1,4 @@
-# ensureSymlinkSync(srcpath, dstpath, [type])
+# ensureSymlinkSync(srcpath, dstpath[, type])
 
 Ensures that the symlink exists. If the directory structure does not exist, it is created.
 

--- a/docs/ensureSymlink.md
+++ b/docs/ensureSymlink.md
@@ -1,4 +1,4 @@
-# ensureSymlink(srcpath, dstpath, [type, callback])
+# ensureSymlink(srcpath, dstpath[, type][, callback])
 
 Ensures that the symlink exists. If the directory structure does not exist, it is created.
 

--- a/docs/move-sync.md
+++ b/docs/move-sync.md
@@ -1,4 +1,4 @@
-# moveSync(src, dest, [options])
+# moveSync(src, dest[, options])
 
 Moves a file or directory, even across devices.
 

--- a/docs/move.md
+++ b/docs/move.md
@@ -1,4 +1,4 @@
-# move(src, dest, [options, callback])
+# move(src, dest[, options][, callback])
 
 Moves a file or directory, even across devices.
 

--- a/docs/outputFile-sync.md
+++ b/docs/outputFile-sync.md
@@ -1,4 +1,4 @@
-# outputFileSync(file, data, [options])
+# outputFileSync(file, data[, options])
 
 Almost the same as `writeFileSync` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed). `options` are what you'd pass to [`fs.writeFileSync()`](https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options).
 

--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -1,4 +1,4 @@
-# outputFile(file, data, [options, callback])
+# outputFile(file, data[, options][, callback])
 
 Almost the same as `writeFile` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed). `options` are what you'd pass to [`fs.writeFile()`](https://nodejs.org/api/fs.html#fs_fs_writefile_file_data_options_callback).
 

--- a/docs/outputJson-sync.md
+++ b/docs/outputJson-sync.md
@@ -1,4 +1,4 @@
-# outputJsonSync(file, object, [options])
+# outputJsonSync(file, object[, options])
 
 Almost the same as [`writeJsonSync`](writeJson-sync.md), except that if the directory does not exist, it's created.
 

--- a/docs/outputJson.md
+++ b/docs/outputJson.md
@@ -1,4 +1,4 @@
-# outputJson(file, object, [options, callback])
+# outputJson(file, object[, options][, callback])
 
 Almost the same as [`writeJson`](writeJson.md), except that if the directory does not exist, it's created.
 

--- a/docs/readJson-sync.md
+++ b/docs/readJson-sync.md
@@ -1,4 +1,4 @@
-# readJsonSync(file, [options])
+# readJsonSync(file[, options])
 
 Reads a JSON file and then parses it into an object. `options` are the same
 that you'd pass to [`jsonFile.readFileSync`](https://github.com/jprichardson/node-jsonfile#readfilesyncfilename-options).

--- a/docs/readJson.md
+++ b/docs/readJson.md
@@ -1,4 +1,4 @@
-# readJson(file, [options, callback])
+# readJson(file[, options][, callback])
 
 Reads a JSON file and then parses it into an object. `options` are the same
 that you'd pass to [`jsonFile.readFile`](https://github.com/jprichardson/node-jsonfile#readfilefilename-options-callback).

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -1,4 +1,4 @@
-# remove(path, [callback])
+# remove(path[, callback])
 
 Removes a file or directory. The directory can have contents. Like `rm -rf`.
 

--- a/docs/writeJson-sync.md
+++ b/docs/writeJson-sync.md
@@ -1,4 +1,4 @@
-# writeJsonSync(file, object, [options])
+# writeJsonSync(file, object[, options])
 
 Writes an object to a JSON file.
 

--- a/docs/writeJson.md
+++ b/docs/writeJson.md
@@ -1,4 +1,4 @@
-# writeJson(file, object, [options, callback])
+# writeJson(file, object[, options][, callback])
 
 Writes an object to a JSON file.
 


### PR DESCRIPTION
Node's docs uses the pattern of `,` after `[` for optional parameters. For instance, please take a look at [this one](https://nodejs.org/api/fs.html#fs_fs_appendfilesync_path_data_options). So, figured why not following the same pattern!