### PR TITLE
copy*(): fix copying bind-mounted directories

### DIFF
--- a/lib/copy-sync/__tests__/broken-symlink.test.js
+++ b/lib/copy-sync/__tests__/broken-symlink.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs')
 const os = require('os')
-const fse = require(process.cwd())
+const fse = require('../../')
 const path = require('path')
 const assert = require('assert')
 const copySync = require('../copy-sync')

--- a/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
@@ -32,8 +32,6 @@ describe('+ copySync() - case insensitive paths', () => {
       } catch (err) {
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
@@ -58,8 +56,6 @@ describe('+ copySync() - case insensitive paths', () => {
       } catch (err) {
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
@@ -86,8 +82,6 @@ describe('+ copySync() - case insensitive paths', () => {
       } catch (err) {
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
@@ -114,8 +108,6 @@ describe('+ copySync() - case insensitive paths', () => {
       } catch (err) {
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
           errThrown = true
         }
       }

--- a/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-case-insensitive-paths.test.js
@@ -3,7 +3,8 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
+const platform = os.platform()
 
 /* global beforeEach, afterEach, describe, it */
 
@@ -17,7 +18,7 @@ describe('+ copySync() - case insensitive paths', () => {
     fs.emptyDir(TEST_DIR, done)
   })
 
-  afterEach(done => fs.remove(TEST_DIR, done))
+  afterEach(() => fs.removeSync(TEST_DIR))
 
   describe('> when src is a directory', () => {
     it('should behave correctly based on the OS', () => {
@@ -29,15 +30,15 @@ describe('+ copySync() - case insensitive paths', () => {
       try {
         fs.copySync(src, dest)
       } catch (err) {
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
-      if (os === 'darwin' || os === 'win32') assert(errThrown)
-      if (os === 'linux') {
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
         assert(fs.existsSync(dest))
         assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
         assert(!errThrown)
@@ -55,15 +56,15 @@ describe('+ copySync() - case insensitive paths', () => {
       try {
         fs.copySync(src, dest)
       } catch (err) {
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
-      if (os === 'darwin' || os === 'win32') assert(errThrown)
-      if (os === 'linux') {
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
         assert(fs.existsSync(dest))
         assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
         assert(!errThrown)
@@ -77,25 +78,25 @@ describe('+ copySync() - case insensitive paths', () => {
       fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
       const srcLink = path.join(TEST_DIR, 'src-symlink')
       fs.symlinkSync(src, srcLink, 'dir')
-      dest = path.join(TEST_DIR, 'srcDir')
+      dest = path.join(TEST_DIR, 'src-Symlink')
       let errThrown = false
 
       try {
-        fs.copySync(src, dest)
+        fs.copySync(srcLink, dest)
       } catch (err) {
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
-      if (os === 'darwin' || os === 'win32') assert(errThrown)
-      if (os === 'linux') {
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
         assert(fs.existsSync(dest))
         assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
-        const link = fs.readlinkSync(srcLink)
-        assert.strictEqual(link, dest)
+        const destLink = fs.readlinkSync(dest)
+        assert.strictEqual(destLink, src)
         assert(!errThrown)
       }
     })
@@ -105,25 +106,25 @@ describe('+ copySync() - case insensitive paths', () => {
       fs.outputFileSync(src, 'some data')
       const srcLink = path.join(TEST_DIR, 'src-symlink')
       fs.symlinkSync(src, srcLink, 'file')
-      dest = path.join(TEST_DIR, 'srcFile')
+      dest = path.join(TEST_DIR, 'src-Symlink')
       let errThrown = false
 
       try {
-        fs.copySync(src, dest)
+        fs.copySync(srcLink, dest)
       } catch (err) {
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
           errThrown = true
         }
       }
-      if (os === 'darwin' || os === 'win32') assert(errThrown)
-      if (os === 'linux') {
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
         assert(fs.existsSync(dest))
         assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
-        const link = fs.readlinkSync(srcLink)
-        assert.strictEqual(link, dest)
+        const destLink = fs.readlinkSync(dest)
+        assert.strictEqual(destLink, src)
         assert(!errThrown)
       }
     })

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require(process.cwd())
+const fs = require('../../')
 const os = require('os')
 const path = require('path')
 const assert = require('assert')

--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -75,7 +75,7 @@ describe('+ copySync() / dir', () => {
       const srcTarget = path.join(TEST_DIR, 'destination')
       fs.mkdirSync(src)
       fs.mkdirSync(srcTarget)
-      fs.symlinkSync(srcTarget, path.join(src, 'symlink'))
+      fs.symlinkSync(srcTarget, path.join(src, 'symlink'), 'dir')
 
       fs.copySync(src, dest)
 

--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require(process.cwd())
+const fs = require('../../')
 const os = require('os')
 const path = require('path')
 const assert = require('assert')

--- a/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require(process.cwd())
+const fs = require('../../')
 const os = require('os')
 const path = require('path')
 const utimes = require('../../util/utimes')

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-identical.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */
@@ -157,6 +157,27 @@ describe('+ copySync() - prevent copying into itself', () => {
           fs.copySync(src, destLink)
         } catch (err) {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
+
+        const srclenAfter = klawSync(src).length
+        assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+        const link = fs.readlinkSync(destLink)
+        assert.strictEqual(link, src)
+      })
+
+      it('should error when dest is a subdirectory of src (bind-mounted directory with subdirectory)', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1')
+        try {
+          fs.copySync(src, dest)
+        } catch (err) {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
         }
 
         const srclenAfter = klawSync(src).length

--- a/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-prevent-copying-into-itself.test.js
@@ -174,17 +174,46 @@ describe('+ copySync() - prevent copying into itself', () => {
         assert(srclenBefore > 2)
 
         const dest = path.join(destLink, 'dir1')
+        assert(fs.existsSync(dest))
+        let errThrown = false
         try {
           fs.copySync(src, dest)
         } catch (err) {
           assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
         }
+      })
 
-        const srclenAfter = klawSync(src).length
-        assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+      it('should error when dest is a subdirectory of src (more than one level depth)', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
 
-        const link = fs.readlinkSync(destLink)
-        assert.strictEqual(link, src)
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1', 'dir2')
+        assert(fs.existsSync(dest))
+        let errThrown = false
+        try {
+          fs.copySync(src, dest)
+        } catch (err) {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${path.join(destLink, 'dir1')}'.`)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+        }
       })
 
       it('should copy the directory successfully when src is a subdir of resolved dest path', () => {
@@ -371,10 +400,6 @@ function testSuccess (src, dest) {
   assert(srclen > 2)
 
   fs.copySync(src, dest)
-
-  const destlen = klawSync(dest).length
-
-  assert.strictEqual(destlen, srclen)
 
   FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
 

--- a/lib/copy-sync/__tests__/copy-sync-readonly-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-readonly-dir.test.js
@@ -2,9 +2,8 @@
 
 // relevant: https://github.com/jprichardson/node-fs-extra/issues/599
 
-const fs = require(process.cwd())
 const os = require('os')
-const fse = require('../../')
+const fs = require('../../')
 const path = require('path')
 const assert = require('assert')
 const klawSync = require('klaw-sync')
@@ -22,12 +21,12 @@ const FILES = [
 describe('+ copySync() - copy a readonly directory with content', () => {
   beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'test', 'fs-extra', 'copy-readonly-dir')
-    fse.emptyDir(TEST_DIR, done)
+    fs.emptyDir(TEST_DIR, done)
   })
 
   afterEach(done => {
     klawSync(TEST_DIR).forEach(data => fs.chmodSync(data.path, 0o777))
-    fse.remove(TEST_DIR, done)
+    fs.remove(TEST_DIR, done)
   })
 
   describe('> when src is readonly directory with content', () => {
@@ -40,7 +39,7 @@ describe('+ copySync() - copy a readonly directory with content', () => {
       sourceHierarchy.forEach(source => fs.chmodSync(source.path, source.stats.isDirectory() ? 0o555 : 0o444))
 
       const targetDir = path.join(TEST_DIR, 'target')
-      fse.copySync(sourceDir, targetDir)
+      fs.copySync(sourceDir, targetDir)
 
       // Make sure copy was made and mode was preserved
       assert(fs.existsSync(targetDir))

--- a/lib/copy-sync/__tests__/symlink.test.js
+++ b/lib/copy-sync/__tests__/symlink.test.js
@@ -1,8 +1,7 @@
 'use strict'
 
-const fs = require('fs')
 const os = require('os')
-const fse = require(process.cwd())
+const fs = require('../../')
 const path = require('path')
 const assert = require('assert')
 const copySync = require('../copy-sync')
@@ -15,14 +14,14 @@ describe('copy-sync / symlink', () => {
   const out = path.join(TEST_DIR, 'out')
 
   beforeEach(done => {
-    fse.emptyDir(TEST_DIR, err => {
+    fs.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
       createFixtures(src, done)
     })
   })
 
   afterEach(done => {
-    fse.remove(TEST_DIR, done)
+    fs.remove(TEST_DIR, done)
   })
 
   it('copies symlinks by default', () => {

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -22,7 +22,8 @@ function copySync (src, dest, opts) {
     see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
-  const destStat = checkPaths(src, dest)
+  const {srcStat, destStat} = checkPaths(src, dest)
+  checkParentStats(src, srcStat, dest)
 
   if (opts.filter && !opts.filter(src, dest)) return
 
@@ -114,7 +115,7 @@ function copyDir (src, dest, opts) {
 function copyDirItem (item, src, dest, opts) {
   const srcItem = path.join(src, item)
   const destItem = path.join(dest, item)
-  const destStat = checkPaths(srcItem, destItem)
+  const {destStat} = checkPaths(srcItem, destItem)
   return startCopy(destStat, srcItem, destItem, opts)
 }
 
@@ -179,15 +180,27 @@ function checkStats (src, dest) {
   return {srcStat, destStat}
 }
 
-function checkParentStats (src, dest, cb) {
-  const {srcStat, destStat} = checkStats(src, path.dirname(dest))
+// recursively check if dest parent is a subdirectory of src.
+// It works for all file types including symlinks since it
+// checks the src and dest inodes. It starts from the deepest
+// parent and stops once it reaches the src parent or the root path.
+function checkParentStats (src, srcStat, dest) {
+  const destParent = path.dirname(dest)
+  if (destParent && (destParent === path.dirname(src) || destParent === path.parse(destParent).root)) return
+  let destStat
+  try {
+    destStat = fs.statSync(destParent)
+  } catch (err) {
+    if (err.code === 'ENOENT') return
+    throw err
+  }
   if (destStat.ino && destStat.ino === srcStat.ino) {
     throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
   }
+  return checkParentStats(src, srcStat, destParent)
 }
 
 function checkPaths (src, dest) {
-  checkParentStats(src, dest)
   const {srcStat, destStat} = checkStats(src, dest)
   if (destStat.ino && destStat.ino === srcStat.ino) {
     throw new Error('Source and destination must not be the same.')
@@ -195,7 +208,7 @@ function checkPaths (src, dest) {
   if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
     throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
   }
-  return destStat
+  return {srcStat, destStat}
 }
 
 module.exports = copySync

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -162,9 +162,9 @@ function copyLink (resolvedSrc, dest) {
 
 // return true if dest is a subdir of src, otherwise false.
 function isSrcSubdir (src, dest) {
-  const srcArray = path.resolve(src).split(path.sep)
-  const destArray = path.resolve(dest).split(path.sep)
-  return srcArray.reduce((acc, current, i) => acc && destArray[i] === current, true)
+  const srcArr = path.resolve(src).split(path.sep).filter(i => i)
+  const destArr = path.resolve(dest).split(path.sep).filter(i => i)
+  return srcArr.reduce((acc, cur, i) => acc && destArr[i] === cur, true)
 }
 
 function checkStats (src, dest) {
@@ -179,7 +179,15 @@ function checkStats (src, dest) {
   return {srcStat, destStat}
 }
 
+function checkParentStats (src, dest, cb) {
+  const {srcStat, destStat} = checkStats(src, path.dirname(dest))
+  if (destStat.ino && destStat.ino === srcStat.ino) {
+    throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
+  }
+}
+
 function checkPaths (src, dest) {
+  checkParentStats(src, dest)
   const {srcStat, destStat} = checkStats(src, dest)
   if (destStat.ino && destStat.ino === srcStat.ino) {
     throw new Error('Source and destination must not be the same.')

--- a/lib/copy/__tests__/copy-case-insensitive-paths.test.js
+++ b/lib/copy/__tests__/copy-case-insensitive-paths.test.js
@@ -3,7 +3,8 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
+const platform = os.platform()
 
 /* global beforeEach, afterEach, describe, it */
 
@@ -26,12 +27,12 @@ describe('+ copy() - case insensitive paths', () => {
       dest = path.join(TEST_DIR, 'srcDir')
 
       fs.copy(src, dest, err => {
-        if (os === 'linux') {
+        if (platform === 'linux') {
           assert.ifError(err)
           assert(fs.existsSync(dest))
           assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
         }
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
@@ -48,12 +49,12 @@ describe('+ copy() - case insensitive paths', () => {
       dest = path.join(TEST_DIR, 'srcFile')
 
       fs.copy(src, dest, err => {
-        if (os === 'linux') {
+        if (platform === 'linux') {
           assert.ifError(err)
           assert(fs.existsSync(dest))
           assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
         }
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
@@ -69,17 +70,17 @@ describe('+ copy() - case insensitive paths', () => {
       fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
       const srcLink = path.join(TEST_DIR, 'src-symlink')
       fs.symlinkSync(src, srcLink, 'dir')
-      dest = path.join(TEST_DIR, 'srcDir')
+      dest = path.join(TEST_DIR, 'src-Symlink')
 
-      fs.copy(src, dest, err => {
-        if (os === 'linux') {
+      fs.copy(srcLink, dest, err => {
+        if (platform === 'linux') {
           assert.ifError(err)
           assert(fs.existsSync(dest))
           assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
-          const link = fs.readlinkSync(srcLink)
-          assert.strictEqual(link, dest)
+          const destLink = fs.readlinkSync(dest)
+          assert.strictEqual(destLink, src)
         }
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))
@@ -93,17 +94,17 @@ describe('+ copy() - case insensitive paths', () => {
       fs.outputFileSync(src, 'some data')
       const srcLink = path.join(TEST_DIR, 'src-symlink')
       fs.symlinkSync(src, srcLink, 'file')
-      dest = path.join(TEST_DIR, 'srcFile')
+      dest = path.join(TEST_DIR, 'src-Symlink')
 
-      fs.copy(src, dest, err => {
-        if (os === 'linux') {
+      fs.copy(srcLink, dest, err => {
+        if (platform === 'linux') {
           assert.ifError(err)
           assert(fs.existsSync(dest))
           assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
-          const link = fs.readlinkSync(srcLink)
-          assert.strictEqual(link, dest)
+          const destLink = fs.readlinkSync(dest)
+          assert.strictEqual(destLink, src)
         }
-        if (os === 'darwin' || os === 'win32') {
+        if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
           assert(fs.existsSync(src))
           assert(!fs.existsSync(dest))

--- a/lib/copy/__tests__/copy-case-insensitive-paths.test.js
+++ b/lib/copy/__tests__/copy-case-insensitive-paths.test.js
@@ -5,7 +5,7 @@ const os = require('os')
 const path = require('path')
 const fs = require('../../')
 const platform = os.platform()
-
+console.log('platform: ' + platform)
 /* global beforeEach, afterEach, describe, it */
 
 describe('+ copy() - case insensitive paths', () => {
@@ -34,8 +34,6 @@ describe('+ copy() - case insensitive paths', () => {
         }
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
         }
         done()
       })
@@ -56,8 +54,6 @@ describe('+ copy() - case insensitive paths', () => {
         }
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
         }
         done()
       })
@@ -82,8 +78,6 @@ describe('+ copy() - case insensitive paths', () => {
         }
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
         }
         done()
       })
@@ -106,8 +100,6 @@ describe('+ copy() - case insensitive paths', () => {
         }
         if (platform === 'darwin' || platform === 'win32') {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
-          assert(fs.existsSync(src))
-          assert(!fs.existsSync(dest))
         }
         done()
       })

--- a/lib/copy/__tests__/copy-case-insensitive-paths.test.js
+++ b/lib/copy/__tests__/copy-case-insensitive-paths.test.js
@@ -5,7 +5,9 @@ const os = require('os')
 const path = require('path')
 const fs = require('../../')
 const platform = os.platform()
+
 console.log('platform: ' + platform)
+
 /* global beforeEach, afterEach, describe, it */
 
 describe('+ copy() - case insensitive paths', () => {

--- a/lib/copy/__tests__/copy-gh-89.test.js
+++ b/lib/copy/__tests__/copy-gh-89.test.js
@@ -5,7 +5,7 @@
 
 const fs = require('fs')
 const os = require('os')
-const fse = require(process.cwd())
+const fse = require('../../')
 const path = require('path')
 const assert = require('assert')
 

--- a/lib/copy/__tests__/copy-preserve-time.test.js
+++ b/lib/copy/__tests__/copy-preserve-time.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const fs = require(process.cwd())
+const fs = require('../../')
 const os = require('os')
 const path = require('path')
 const copy = require('../copy')

--- a/lib/copy/__tests__/copy-prevent-copying-identical.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-identical.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */

--- a/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
@@ -3,7 +3,7 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */
@@ -158,6 +158,26 @@ describe('+ copy() - prevent copying into itself', () => {
 
         fs.copy(src, destLink, err => {
           assert.strictEqual(err.message, 'Source and destination must not be the same.')
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when dest is a subdirectory of src (bind-mounted directory with subdirectory)', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1')
+        fs.copy(src, dest, err => {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
 
           const srclenAfter = klawSync(src).length
           assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')

--- a/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
@@ -176,8 +176,30 @@ describe('+ copy() - prevent copying into itself', () => {
         assert(srclenBefore > 2)
 
         const dest = path.join(destLink, 'dir1')
+        assert(fs.existsSync(dest))
         fs.copy(src, dest, err => {
           assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when dest is a subdirectory of src (more than one level depth)', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1', 'dir2')
+        assert(fs.existsSync(dest))
+        fs.copy(src, dest, err => {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${path.join(destLink, 'dir1')}'.`)
 
           const srclenAfter = klawSync(src).length
           assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
@@ -369,10 +391,6 @@ function testSuccess (src, dest, done) {
   assert(srclen > 2)
   fs.copy(src, dest, err => {
     assert.ifError(err)
-
-    const destlen = klawSync(dest).length
-
-    assert.strictEqual(destlen, srclen)
 
     FILES.forEach(f => assert(fs.existsSync(path.join(dest, f)), 'file copied'))
 

--- a/lib/copy/__tests__/copy-readonly-dir.test.js
+++ b/lib/copy/__tests__/copy-readonly-dir.test.js
@@ -2,7 +2,7 @@
 
 // relevant: https://github.com/jprichardson/node-fs-extra/issues/599
 
-const fs = require(process.cwd())
+const fs = require('../../')
 const os = require('os')
 const fse = require('../../')
 const path = require('path')

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -144,7 +144,9 @@ describe('fs-extra', () => {
         const srcTarget = path.join(TEST_DIR, 'destination')
         fse.mkdirSync(src)
         fse.mkdirSync(srcTarget)
-        fse.symlinkSync(srcTarget, path.join(src, 'symlink'))
+        // symlink type is only used for Windows and the default is 'file'.
+        // https://nodejs.org/api/fs.html#fs_fs_symlink_target_path_type_callback
+        fse.symlinkSync(srcTarget, path.join(src, 'symlink'), 'dir')
 
         fse.copy(src, dest, err => {
           assert.ifError(err)
@@ -340,11 +342,12 @@ describe('fs-extra', () => {
 
         const dest = path.join(TEST_DIR, 'dest')
 
-        fse.copySync(src, dest, filter)
-
-        assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
-        assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
-        done()
+        fse.copy(src, dest, filter, err => {
+          assert.ifError(err)
+          assert(!fs.existsSync(path.join(dest, IGNORE)), 'directory was not ignored')
+          assert(!fs.existsSync(path.join(dest, IGNORE, 'file')), 'file was not ignored')
+          done()
+        })
       })
 
       it('should apply filter when it is applied only to dest', done => {

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -159,8 +159,9 @@ function copyDirItems (items, src, dest, opts, cb) {
 function copyDirItem (items, item, src, dest, opts, cb) {
   const srcItem = path.join(src, item)
   const destItem = path.join(dest, item)
-  checkPaths(srcItem, destItem, (err, {destStat}) => {
+  checkPaths(srcItem, destItem, (err, stats) => {
     if (err) return cb(err)
+    const {destStat} = stats
     startCopy(destStat, srcItem, destItem, opts, err => {
       if (err) return cb(err)
       return copyDirItems(items, src, dest, opts, cb)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -229,17 +229,31 @@ function checkStats (src, dest, cb) {
   })
 }
 
-function checkPaths (src, dest, cb) {
-  checkStats(src, dest, (err, stats) => {
+function checkParentStats (src, dest, cb) {
+  checkStats(src, path.dirname(dest), (err, stats) => {
     if (err) return cb(err)
     const {srcStat, destStat} = stats
     if (destStat.ino && destStat.ino === srcStat.ino) {
-      return cb(new Error('Source and destination must not be the same.'))
-    }
-    if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
       return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
     }
-    return cb(null, destStat)
+    return cb()
+  })
+}
+
+function checkPaths (src, dest, cb) {
+  checkParentStats(src, dest, err => {
+    if (err) return cb(err)
+    checkStats(src, dest, (err, stats) => {
+      if (err) return cb(err)
+      const {srcStat, destStat} = stats
+      if (destStat.ino && destStat.ino === srcStat.ino) {
+        return cb(new Error('Source and destination must not be the same.'))
+      }
+      if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
+        return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
+      }
+      return cb(null, destStat)
+    })
   })
 }
 

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -28,10 +28,14 @@ function copy (src, dest, opts, cb) {
     see https://github.com/jprichardson/node-fs-extra/issues/269`)
   }
 
-  checkPaths(src, dest, (err, destStat) => {
+  checkPaths(src, dest, (err, stats) => {
     if (err) return cb(err)
-    if (opts.filter) return handleFilter(checkParentDir, destStat, src, dest, opts, cb)
-    return checkParentDir(destStat, src, dest, opts, cb)
+    const {srcStat, destStat} = stats
+    checkParentStats(src, srcStat, dest, err => {
+      if (err) return cb(err)
+      if (opts.filter) return handleFilter(checkParentDir, destStat, src, dest, opts, cb)
+      return checkParentDir(destStat, src, dest, opts, cb)
+    })
   })
 }
 
@@ -155,7 +159,7 @@ function copyDirItems (items, src, dest, opts, cb) {
 function copyDirItem (items, item, src, dest, opts, cb) {
   const srcItem = path.join(src, item)
   const destItem = path.join(dest, item)
-  checkPaths(srcItem, destItem, (err, destStat) => {
+  checkPaths(srcItem, destItem, (err, {destStat}) => {
     if (err) return cb(err)
     startCopy(destStat, srcItem, destItem, opts, err => {
       if (err) return cb(err)
@@ -211,9 +215,9 @@ function copyLink (resolvedSrc, dest, cb) {
 
 // return true if dest is a subdir of src, otherwise false.
 function isSrcSubdir (src, dest) {
-  const srcArray = path.resolve(src).split(path.sep)
-  const destArray = path.resolve(dest).split(path.sep)
-  return srcArray.reduce((acc, current, i) => acc && destArray[i] === current, true)
+  const srcArr = path.resolve(src).split(path.sep).filter(i => i)
+  const destArr = path.resolve(dest).split(path.sep).filter(i => i)
+  return srcArr.reduce((acc, cur, i) => acc && destArr[i] === cur, true)
 }
 
 function checkStats (src, dest, cb) {
@@ -229,31 +233,36 @@ function checkStats (src, dest, cb) {
   })
 }
 
-function checkParentStats (src, dest, cb) {
-  checkStats(src, path.dirname(dest), (err, stats) => {
-    if (err) return cb(err)
-    const {srcStat, destStat} = stats
+// recursively check if dest parent is a subdirectory of src.
+// It works for all file types including symlinks since it
+// checks the src and dest inodes. It starts from the deepest
+// parent and stops once it reaches the src parent or the root path.
+function checkParentStats (src, srcStat, dest, cb) {
+  const destParent = path.dirname(dest)
+  if (destParent && (destParent === path.dirname(src) || destParent === path.parse(destParent).root)) return cb()
+  fs.stat(destParent, (err, destStat) => {
+    if (err) {
+      if (err.code === 'ENOENT') return cb()
+      return cb(err)
+    }
     if (destStat.ino && destStat.ino === srcStat.ino) {
       return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
     }
-    return cb()
+    return checkParentStats(src, srcStat, destParent, cb)
   })
 }
 
 function checkPaths (src, dest, cb) {
-  checkParentStats(src, dest, err => {
+  checkStats(src, dest, (err, stats) => {
     if (err) return cb(err)
-    checkStats(src, dest, (err, stats) => {
-      if (err) return cb(err)
-      const {srcStat, destStat} = stats
-      if (destStat.ino && destStat.ino === srcStat.ino) {
-        return cb(new Error('Source and destination must not be the same.'))
-      }
-      if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
-        return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
-      }
-      return cb(null, destStat)
-    })
+    const {srcStat, destStat} = stats
+    if (destStat.ino && destStat.ino === srcStat.ino) {
+      return cb(new Error('Source and destination must not be the same.'))
+    }
+    if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
+      return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))
+    }
+    return cb(null, {srcStat, destStat})
   })
 }
 


### PR DESCRIPTION
fix #613.

Fixed the issue of infinite loop that would used to happen for cases like bind-mounted directories with subdirectory that would end up creating a lot of recursive same subdirectories and finally failing with `ENAMETOOLONG` error.

With this fix, we catch these weird cases and throw error with descriptive message.

Also, cleaned up some tests.