### PR TITLE
Catch errors thrown by onInclude

### DIFF
--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -54,7 +54,7 @@ function handleFilter (onInclude, destStat, src, dest, opts, cb) {
       return onInclude(src, dest, opts, cb)
     }
     return cb()
-  }, error => cb(error))
+  }).catch(error => cb(error))
 }
 
 function startCopy (destStat, src, dest, opts, cb) {


### PR DESCRIPTION
When using the `.then($1, $2)` function, any errors thrown from `$1` will *not* be delegated to `$2`. Changing to `.then($1).catch($2)` makes sure that even errors from `$1` gets delegated to `$2`.

Found by this proposed standard rule: standard/eslint-config-standard#129