### PR TITLE
[BREAKING] move*(): check paths before moving

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -162,6 +162,7 @@ function copyLink (resolvedSrc, dest) {
 }
 
 // return true if dest is a subdir of src, otherwise false.
+// It only checks the path strings.
 function isSrcSubdir (src, dest) {
   const srcArr = path.resolve(src).split(path.sep).filter(i => i)
   const destArr = path.resolve(dest).split(path.sep).filter(i => i)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -215,6 +215,7 @@ function copyLink (resolvedSrc, dest, cb) {
 }
 
 // return true if dest is a subdir of src, otherwise false.
+// It only checks the path strings.
 function isSrcSubdir (src, dest) {
   const srcArr = path.resolve(src).split(path.sep).filter(i => i)
   const destArr = path.resolve(dest).split(path.sep).filter(i => i)

--- a/lib/move-sync/__tests__/move-sync-case-insensitive-paths.test.js
+++ b/lib/move-sync/__tests__/move-sync-case-insensitive-paths.test.js
@@ -1,0 +1,124 @@
+'use strict'
+
+const assert = require('assert')
+const os = require('os')
+const path = require('path')
+const fs = require('../../')
+const platform = os.platform()
+
+/* global beforeEach, afterEach, describe, it */
+
+describe('+ moveSync() - case insensitive paths', () => {
+  let TEST_DIR = ''
+  let src = ''
+  let dest = ''
+
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-sync-case-insensitive-paths')
+    fs.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(() => fs.removeSync(TEST_DIR))
+
+  describe('> when src is a directory', () => {
+    it('should behave correctly based on the OS', () => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      dest = path.join(TEST_DIR, 'srcDir')
+      let errThrown = false
+
+      try {
+        fs.moveSync(src, dest)
+      } catch (err) {
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        }
+      }
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        assert(!errThrown)
+      }
+    })
+  })
+
+  describe('> when src is a file', () => {
+    it('should behave correctly based on the OS', () => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      dest = path.join(TEST_DIR, 'srcFile')
+      let errThrown = false
+
+      try {
+        fs.moveSync(src, dest)
+      } catch (err) {
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        }
+      }
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        assert(!errThrown)
+      }
+    })
+  })
+
+  describe('> when src is a symlink', () => {
+    it('should behave correctly based on the OS, symlink dir', () => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'dir')
+      dest = path.join(TEST_DIR, 'src-Symlink')
+      let errThrown = false
+
+      try {
+        fs.moveSync(srcLink, dest)
+      } catch (err) {
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        }
+      }
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        const destLink = fs.readlinkSync(dest)
+        assert.strictEqual(destLink, src)
+        assert(!errThrown)
+      }
+    })
+
+    it('should behave correctly based on the OS, symlink file', () => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'file')
+      dest = path.join(TEST_DIR, 'src-Symlink')
+      let errThrown = false
+
+      try {
+        fs.moveSync(srcLink, dest)
+      } catch (err) {
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        }
+      }
+      if (platform === 'darwin' || platform === 'win32') assert(errThrown)
+      if (platform === 'linux') {
+        assert(fs.existsSync(dest))
+        assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        const destLink = fs.readlinkSync(dest)
+        assert.strictEqual(destLink, src)
+        assert(!errThrown)
+      }
+    })
+  })
+})

--- a/lib/move-sync/__tests__/move-sync-prevent-moving-into-itself.test.js
+++ b/lib/move-sync/__tests__/move-sync-prevent-moving-into-itself.test.js
@@ -3,11 +3,12 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */
 
+// these files are used for all tests
 const FILES = [
   'file0.txt',
   path.join('dir1', 'file1.txt'),
@@ -21,20 +22,35 @@ const dat2 = 'file2'
 const dat3 = 'file3'
 
 describe('+ moveSync() - prevent moving into itself', () => {
-  let TEST_DIR, src, dest
+  let TEST_DIR, src
 
-  beforeEach(() => {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-sync-prevent-moving-into-itself')
     src = path.join(TEST_DIR, 'src')
-    fs.mkdirsSync(src)
+    fs.mkdirpSync(src)
 
     fs.outputFileSync(path.join(src, FILES[0]), dat0)
     fs.outputFileSync(path.join(src, FILES[1]), dat1)
     fs.outputFileSync(path.join(src, FILES[2]), dat2)
     fs.outputFileSync(path.join(src, FILES[3]), dat3)
+    done()
   })
 
-  afterEach(() => fs.removeSync(TEST_DIR))
+  afterEach(done => fs.remove(TEST_DIR, done))
+
+  describe('> when source is a file', () => {
+    it('should move the file successfully even if dest parent is a subdir of src', () => {
+      const srcFile = path.join(TEST_DIR, 'src', 'srcfile.txt')
+      const destFile = path.join(TEST_DIR, 'src', 'dest', 'destfile.txt')
+      fs.writeFileSync(srcFile, dat0)
+
+      fs.moveSync(srcFile, destFile)
+
+      assert(fs.existsSync(destFile))
+      const out = fs.readFileSync(destFile, 'utf8')
+      assert.strictEqual(out, dat0, 'file contents matched')
+    })
+  })
 
   describe('> when source is a file', () => {
     it(`should move the file successfully even when dest parent is 'src/dest'`, () => {
@@ -64,82 +80,276 @@ describe('+ moveSync() - prevent moving into itself', () => {
   })
 
   describe('> when source is a directory', () => {
-    it(`should move the directory successfully when dest is 'src_dest'`, () => {
-      dest = path.join(TEST_DIR, 'src_dest')
-      return testSuccessDir(src, dest)
+    describe('>> when dest is a directory', () => {
+      it(`of not itself`, () => {
+        const dest = path.join(TEST_DIR, src.replace(/^\w:/, ''))
+        return testSuccessDir(src, dest)
+      })
+      it(`of itself`, () => {
+        const dest = path.join(src, 'dest')
+        return testError(src, dest)
+      })
+      it(`should move the directory successfully when dest is 'src_dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src_dest')
+        return testSuccessDir(src, dest)
+      })
+      it(`should move the directory successfully when dest is 'src-dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src-dest')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'dest_src'`, () => {
+        const dest = path.join(TEST_DIR, 'dest_src')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'src_dest/src'`, () => {
+        const dest = path.join(TEST_DIR, 'src_dest', 'src')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'src-dest/src'`, () => {
+        const dest = path.join(TEST_DIR, 'src-dest', 'src')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'dest_src/src'`, () => {
+        const dest = path.join(TEST_DIR, 'dest_src', 'src')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'src_src/dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src_src', 'dest')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'src-src/dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src-src', 'dest')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'srcsrc/dest'`, () => {
+        const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should move the directory successfully when dest is 'dest/src'`, () => {
+        const dest = path.join(TEST_DIR, 'dest', 'src')
+        return testSuccessDir(src, dest)
+      })
+
+      it('should move the directory successfully when dest is very nested that all its parents need to be created', () => {
+        const dest = path.join(TEST_DIR, 'dest', 'src', 'foo', 'bar', 'baz', 'qux', 'quux', 'waldo',
+          'grault', 'garply', 'fred', 'plugh', 'thud', 'some', 'highly', 'deeply',
+          'badly', 'nasty', 'crazy', 'mad', 'nested', 'dest')
+        return testSuccessDir(src, dest)
+      })
+
+      it(`should error when dest is 'src/dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src', 'dest')
+        return testError(src, dest)
+      })
+
+      it(`should error when dest is 'src/src_dest'`, () => {
+        const dest = path.join(TEST_DIR, 'src', 'src_dest')
+        return testError(src, dest)
+      })
+
+      it(`should error when dest is 'src/dest_src'`, () => {
+        const dest = path.join(TEST_DIR, 'src', 'dest_src')
+        return testError(src, dest)
+      })
+
+      it(`should error when dest is 'src/dest/src'`, () => {
+        const dest = path.join(TEST_DIR, 'src', 'dest', 'src')
+        return testError(src, dest)
+      })
     })
 
-    it(`should move the directory successfully when dest is 'src-dest'`, () => {
-      dest = path.join(TEST_DIR, 'src-dest')
-      return testSuccessDir(src, dest)
+    describe('>> when dest is a symlink', () => {
+      it('should error when dest points exactly to src', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+        let errThrown = false
+        try {
+          fs.moveSync(src, destLink)
+        } catch (err) {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+        }
+      })
+
+      it('should error when dest is a subdirectory of src (bind-mounted directory with subdirectory)', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1')
+        assert(fs.existsSync(dest))
+        let errThrown = false
+        try {
+          fs.moveSync(src, dest)
+        } catch (err) {
+          assert.strictEqual(err.message, `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+        }
+      })
+
+      it('should error when dest is a subdirectory of src (more than one level depth)', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1', 'dir2')
+        assert(fs.existsSync(dest))
+        let errThrown = false
+        try {
+          fs.moveSync(src, dest)
+        } catch (err) {
+          assert.strictEqual(err.message, `Cannot move '${src}' to a subdirectory of itself, '${path.join(destLink, 'dir1')}'.`)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+        }
+      })
+    })
+  })
+
+  describe('> when source is a symlink', () => {
+    describe('>> when dest is a directory', () => {
+      it('should error when resolved src path points to dest', () => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src')
+        let errThrown = false
+        try {
+          fs.moveSync(srcLink, dest)
+        } catch (err) {
+          assert(err)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          // assert source not affected
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, src)
+        }
+      })
+
+      it('should error when dest is a subdir of resolved src path', () => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src', 'some', 'nested', 'dest')
+        fs.mkdirsSync(dest)
+        let errThrown = false
+        try {
+          fs.moveSync(srcLink, dest)
+        } catch (err) {
+          assert(err)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, src)
+        }
+      })
+
+      it('should error when resolved src path is a subdir of dest', () => {
+        const dest = path.join(TEST_DIR, 'dest')
+
+        const resolvedSrcPath = path.join(dest, 'contains', 'src')
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.copySync(src, resolvedSrcPath)
+
+        // make symlink that points to a subdir in dest
+        fs.symlinkSync(resolvedSrcPath, srcLink, 'dir')
+
+        let errThrown = false
+        try {
+          fs.moveSync(srcLink, dest)
+        } catch (err) {
+          assert(err)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+        }
+      })
+
+      it(`should move the directory successfully when dest is 'src_src/dest'`, () => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src_src', 'dest')
+        testSuccessDir(srcLink, dest)
+        const link = fs.readlinkSync(dest)
+        assert.strictEqual(link, src)
+      })
+
+      it(`should move the directory successfully when dest is 'srcsrc/dest'`, () => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
+        testSuccessDir(srcLink, dest)
+        const link = fs.readlinkSync(dest)
+        assert.strictEqual(link, src)
+      })
     })
 
-    it(`should move the directory successfully when dest is 'dest_src'`, () => {
-      dest = path.join(TEST_DIR, 'dest_src')
-      return testSuccessDir(src, dest)
-    })
+    describe('>> when dest is a symlink', () => {
+      it('should error when resolved dest path is exactly the same as resolved src path', () => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
 
-    it(`should move the directory successfully when dest is 'src_dest/src'`, () => {
-      dest = path.join(TEST_DIR, 'src_dest', 'src')
-      return testSuccessDir(src, dest)
-    })
+        const srclenBefore = klawSync(srcLink).length
+        const destlenBefore = klawSync(destLink).length
+        assert(srclenBefore > 2)
+        assert(destlenBefore > 2)
+        let errThrown = false
+        try {
+          fs.moveSync(srcLink, destLink)
+        } catch (err) {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(srcLink).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+          const destlenAfter = klawSync(destLink).length
+          assert.strictEqual(destlenAfter, destlenBefore, 'dest length should not change')
 
-    it(`should move the directory successfully when dest is 'src-dest/src'`, () => {
-      dest = path.join(TEST_DIR, 'src-dest', 'src')
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should move the directory successfully when dest is 'dest_src/src'`, () => {
-      dest = path.join(TEST_DIR, 'dest_src', 'src')
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should move the directory successfully when dest is 'src_src/dest'`, () => {
-      dest = path.join(TEST_DIR, 'src_src', 'dest')
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should move the directory successfully when dest is 'src-src/dest'`, () => {
-      dest = path.join(TEST_DIR, 'src-src', 'dest')
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should move the directory successfully when dest is 'srcsrc/dest'`, () => {
-      dest = path.join(TEST_DIR, 'srcsrc', 'dest')
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should move the directory successfully when dest is 'dest/src'`, () => {
-      dest = path.join(TEST_DIR, 'dest', 'src')
-      return testSuccessDir(src, dest)
-    })
-
-    it('should move the directory successfully when dest is very nested that all its parents need to be created', () => {
-      dest = path.join(TEST_DIR, 'dest', 'src', 'foo', 'bar', 'baz', 'qux', 'quux', 'waldo',
-        'grault', 'garply', 'fred', 'plugh', 'thud', 'some', 'highly', 'deeply',
-        'badly', 'nasty', 'crazy', 'mad', 'nested', 'dest')
-      assert(!fs.existsSync(dest))
-      return testSuccessDir(src, dest)
-    })
-
-    it(`should throw error when dest is 'src/dest'`, () => {
-      dest = path.join(TEST_DIR, 'src', 'dest')
-      return testError(src, dest)
-    })
-
-    it(`should throw error when dest is 'src/src_dest'`, () => {
-      dest = path.join(TEST_DIR, 'src', 'src_dest')
-      return testError(src, dest)
-    })
-
-    it(`should throw error when dest is 'src/dest_src'`, () => {
-      dest = path.join(TEST_DIR, 'src', 'dest_src')
-      return testError(src, dest)
-    })
-
-    it(`should throw error when dest is 'src/dest/src'`, () => {
-      dest = path.join(TEST_DIR, 'src', 'dest', 'src')
-      return testError(src, dest)
+          const srcln = fs.readlinkSync(srcLink)
+          assert.strictEqual(srcln, src)
+          const destln = fs.readlinkSync(destLink)
+          assert.strictEqual(destln, src)
+        }
+      })
     })
   })
 })
@@ -148,42 +358,43 @@ function testSuccessFile (src, destFile) {
   const srcFile = path.join(src, FILES[0])
 
   fs.moveSync(srcFile, destFile)
-
-  const o0 = fs.readFileSync(destFile, 'utf8')
-  assert.strictEqual(o0, dat0, 'file contents matched')
+  const f0 = fs.readFileSync(destFile, 'utf8')
+  assert.strictEqual(f0, dat0, 'file contents matched')
   assert(!fs.existsSync(srcFile))
 }
 
 function testSuccessDir (src, dest) {
   const srclen = klawSync(src).length
-  // assert src has contents
-  assert(srclen > 2)
+
+  assert(srclen > 2) // assert src has contents
 
   fs.moveSync(src, dest)
-
   const destlen = klawSync(dest).length
 
-  // assert src and dest length are the same
   assert.strictEqual(destlen, srclen, 'src and dest length should be equal')
 
-  const o0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
-  const o1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
-  const o2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
-  const o3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
+  const f0 = fs.readFileSync(path.join(dest, FILES[0]), 'utf8')
+  const f1 = fs.readFileSync(path.join(dest, FILES[1]), 'utf8')
+  const f2 = fs.readFileSync(path.join(dest, FILES[2]), 'utf8')
+  const f3 = fs.readFileSync(path.join(dest, FILES[3]), 'utf8')
 
-  assert.strictEqual(o0, dat0, 'file contents matched')
-  assert.strictEqual(o1, dat1, 'file contents matched')
-  assert.strictEqual(o2, dat2, 'file contents matched')
-  assert.strictEqual(o3, dat3, 'file contents matched')
+  assert.strictEqual(f0, dat0, 'file contents matched')
+  assert.strictEqual(f1, dat1, 'file contents matched')
+  assert.strictEqual(f2, dat2, 'file contents matched')
+  assert.strictEqual(f3, dat3, 'file contents matched')
   assert(!fs.existsSync(src))
 }
 
 function testError (src, dest) {
+  let errThrown = false
   try {
     fs.moveSync(src, dest)
   } catch (err) {
     assert.strictEqual(err.message, `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
     assert(fs.existsSync(src))
     assert(!fs.existsSync(dest))
+    errThrown = true
+  } finally {
+    assert(errThrown)
   }
 }

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -46,7 +46,15 @@ describe('moveSync()', () => {
     const src = `${TEST_DIR}/a-file`
     const dest = `${TEST_DIR}/a-file`
 
-    fse.moveSync(src, dest)
+    let errThrown = false
+    try {
+      fse.moveSync(src, dest)
+    } catch (err) {
+      assert.strictEqual(err.message, 'Source and destination must not be the same.')
+      errThrown = true
+    } finally {
+      assert(errThrown)
+    }
 
     // assert src not affected
     const contents = fs.readFileSync(src, 'utf8')

--- a/lib/move-sync/index.js
+++ b/lib/move-sync/index.js
@@ -9,12 +9,10 @@ const mkdirpSync = require('../mkdirs').mkdirpSync
 function moveSync (src, dest, opts) {
   opts = opts || {}
   const overwrite = opts.overwrite || opts.clobber || false
-  src = path.resolve(src)
-  dest = path.resolve(dest)
-  if (src === dest) return fs.accessSync(src)
 
-  const st = fs.statSync(src)
-  if (st.isDirectory() && isSrcSubdir(src, dest)) throw new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
+  const srcStat = checkPaths(src, dest)
+  checkParentStats(src, srcStat, dest)
+
   mkdirpSync(path.dirname(dest))
   return doRename(src, dest, overwrite)
 }
@@ -47,10 +45,55 @@ function moveAcrossDevice (src, dest, overwrite) {
   return removeSync(src)
 }
 
+// return true if dest is a subdir of src, otherwise false.
+// It only checks the path strings.
 function isSrcSubdir (src, dest) {
-  const srcArr = src.split(path.sep)
-  const destArr = dest.split(path.sep)
-  return srcArr.reduce((acc, curr, i) => acc && destArr[i] === curr, true)
+  const srcArr = path.resolve(src).split(path.sep).filter(i => i)
+  const destArr = path.resolve(dest).split(path.sep).filter(i => i)
+  return srcArr.reduce((acc, cur, i) => acc && destArr[i] === cur, true)
+}
+
+function checkStats (src, dest) {
+  const srcStat = fs.statSync(src)
+  let destStat
+  try {
+    destStat = fs.statSync(dest)
+  } catch (err) {
+    if (err.code === 'ENOENT') return {srcStat}
+    throw err
+  }
+  return {srcStat, destStat}
+}
+
+// recursively check if dest parent is a subdirectory of src.
+// It works for all file types including symlinks since it
+// checks the src and dest inodes. It starts from the deepest
+// parent and stops once it reaches the src parent or the root path.
+function checkParentStats (src, srcStat, dest) {
+  const destParent = path.dirname(dest)
+  if (destParent && (destParent === path.dirname(src) || destParent === path.parse(destParent).root)) return
+  let destStat
+  try {
+    destStat = fs.statSync(destParent)
+  } catch (err) {
+    if (err.code === 'ENOENT') return
+    throw err
+  }
+  if (destStat.ino && destStat.ino === srcStat.ino) {
+    throw new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
+  }
+  return checkParentStats(src, srcStat, destParent)
+}
+
+function checkPaths (src, dest) {
+  const {srcStat, destStat} = checkStats(src, dest)
+  if (destStat && destStat.ino && destStat.ino === srcStat.ino) {
+    throw new Error('Source and destination must not be the same.')
+  }
+  if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
+    throw new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
+  }
+  return srcStat
 }
 
 module.exports = { moveSync }

--- a/lib/move/__tests__/move-case-insensitive-paths.test.js
+++ b/lib/move/__tests__/move-case-insensitive-paths.test.js
@@ -1,0 +1,108 @@
+'use strict'
+
+const assert = require('assert')
+const os = require('os')
+const path = require('path')
+const fs = require('../../')
+const platform = os.platform()
+
+/* global beforeEach, afterEach, describe, it */
+
+describe('+ move() - case insensitive paths', () => {
+  let TEST_DIR = ''
+  let src = ''
+  let dest = ''
+
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-case-insensitive-paths')
+    fs.emptyDir(TEST_DIR, done)
+  })
+
+  afterEach(done => fs.remove(TEST_DIR, done))
+
+  describe('> when src is a directory', () => {
+    it('should behave correctly based on the OS', done => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      dest = path.join(TEST_DIR, 'srcDir')
+
+      fs.move(src, dest, err => {
+        if (platform === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+        }
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
+        done()
+      })
+    })
+  })
+
+  describe('> when src is a file', () => {
+    it('should behave correctly based on the OS', done => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      dest = path.join(TEST_DIR, 'srcFile')
+
+      fs.move(src, dest, err => {
+        if (platform === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+        }
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
+        done()
+      })
+    })
+  })
+
+  describe('> when src is a symlink', () => {
+    it('should behave correctly based on the OS, symlink dir', done => {
+      src = path.join(TEST_DIR, 'srcdir')
+      fs.outputFileSync(path.join(src, 'subdir', 'file.txt'), 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'dir')
+      dest = path.join(TEST_DIR, 'src-Symlink')
+
+      fs.move(srcLink, dest, err => {
+        if (platform === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(path.join(dest, 'subdir', 'file.txt'), 'utf8'), 'some data')
+          const destLink = fs.readlinkSync(dest)
+          assert.strictEqual(destLink, src)
+        }
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
+        done()
+      })
+    })
+
+    it('should behave correctly based on the OS, symlink file', done => {
+      src = path.join(TEST_DIR, 'srcfile')
+      fs.outputFileSync(src, 'some data')
+      const srcLink = path.join(TEST_DIR, 'src-symlink')
+      fs.symlinkSync(src, srcLink, 'file')
+      dest = path.join(TEST_DIR, 'src-Symlink')
+
+      fs.move(srcLink, dest, err => {
+        if (platform === 'linux') {
+          assert.ifError(err)
+          assert(fs.existsSync(dest))
+          assert.strictEqual(fs.readFileSync(dest, 'utf8'), 'some data')
+          const destLink = fs.readlinkSync(dest)
+          assert.strictEqual(destLink, src)
+        }
+        if (platform === 'darwin' || platform === 'win32') {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+        }
+        done()
+      })
+    })
+  })
+})

--- a/lib/move/__tests__/move-prevent-moving-into-itself.test.js
+++ b/lib/move/__tests__/move-prevent-moving-into-itself.test.js
@@ -3,11 +3,12 @@
 const assert = require('assert')
 const os = require('os')
 const path = require('path')
-const fs = require(process.cwd())
+const fs = require('../../')
 const klawSync = require('klaw-sync')
 
 /* global beforeEach, afterEach, describe, it */
 
+// these files are used for all tests
 const FILES = [
   'file0.txt',
   path.join('dir1', 'file1.txt'),
@@ -21,9 +22,9 @@ const dat2 = 'file2'
 const dat3 = 'file3'
 
 describe('+ move() - prevent moving into itself', () => {
-  let TEST_DIR, src, dest
+  let TEST_DIR, src
 
-  beforeEach(() => {
+  beforeEach(done => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-prevent-moving-into-itself')
     src = path.join(TEST_DIR, 'src')
     fs.mkdirpSync(src)
@@ -32,9 +33,27 @@ describe('+ move() - prevent moving into itself', () => {
     fs.outputFileSync(path.join(src, FILES[1]), dat1)
     fs.outputFileSync(path.join(src, FILES[2]), dat2)
     fs.outputFileSync(path.join(src, FILES[3]), dat3)
+    done()
   })
 
-  afterEach(() => fs.removeSync(TEST_DIR))
+  afterEach(done => fs.remove(TEST_DIR, done))
+
+  describe('> when source is a file', () => {
+    it('should move the file successfully even if dest parent is a subdir of src', done => {
+      const srcFile = path.join(TEST_DIR, 'src', 'srcfile.txt')
+      const destFile = path.join(TEST_DIR, 'src', 'dest', 'destfile.txt')
+      fs.writeFileSync(srcFile, dat0)
+
+      fs.move(srcFile, destFile, err => {
+        assert.ifError(err)
+
+        assert(fs.existsSync(destFile))
+        const out = fs.readFileSync(destFile, 'utf8')
+        assert.strictEqual(out, dat0, 'file contents matched')
+        done()
+      })
+    })
+  })
 
   describe('> when source is a file', () => {
     it(`should move the file successfully even when dest parent is 'src/dest'`, done => {
@@ -64,82 +83,256 @@ describe('+ move() - prevent moving into itself', () => {
   })
 
   describe('> when source is a directory', () => {
-    it(`should move the directory successfully when dest is 'src_dest'`, done => {
-      dest = path.join(TEST_DIR, 'src_dest')
-      return testSuccessDir(src, dest, done)
+    describe('>> when dest is a directory', () => {
+      it(`of not itself`, done => {
+        const dest = path.join(TEST_DIR, src.replace(/^\w:/, ''))
+        return testSuccessDir(src, dest, done)
+      })
+      it(`of itself`, done => {
+        const dest = path.join(src, 'dest')
+        return testError(src, dest, done)
+      })
+      it(`should move the directory successfully when dest is 'src_dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src_dest')
+        return testSuccessDir(src, dest, done)
+      })
+      it(`should move the directory successfully when dest is 'src-dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src-dest')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'dest_src'`, done => {
+        const dest = path.join(TEST_DIR, 'dest_src')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'src_dest/src'`, done => {
+        const dest = path.join(TEST_DIR, 'src_dest', 'src')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'src-dest/src'`, done => {
+        const dest = path.join(TEST_DIR, 'src-dest', 'src')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'dest_src/src'`, done => {
+        const dest = path.join(TEST_DIR, 'dest_src', 'src')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'src_src/dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src_src', 'dest')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'src-src/dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src-src', 'dest')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'srcsrc/dest'`, done => {
+        const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should move the directory successfully when dest is 'dest/src'`, done => {
+        const dest = path.join(TEST_DIR, 'dest', 'src')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it('should move the directory successfully when dest is very nested that all its parents need to be created', done => {
+        const dest = path.join(TEST_DIR, 'dest', 'src', 'foo', 'bar', 'baz', 'qux', 'quux', 'waldo',
+          'grault', 'garply', 'fred', 'plugh', 'thud', 'some', 'highly', 'deeply',
+          'badly', 'nasty', 'crazy', 'mad', 'nested', 'dest')
+        return testSuccessDir(src, dest, done)
+      })
+
+      it(`should error when dest is 'src/dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src', 'dest')
+        return testError(src, dest, done)
+      })
+
+      it(`should error when dest is 'src/src_dest'`, done => {
+        const dest = path.join(TEST_DIR, 'src', 'src_dest')
+        return testError(src, dest, done)
+      })
+
+      it(`should error when dest is 'src/dest_src'`, done => {
+        const dest = path.join(TEST_DIR, 'src', 'dest_src')
+        return testError(src, dest, done)
+      })
+
+      it(`should error when dest is 'src/dest/src'`, done => {
+        const dest = path.join(TEST_DIR, 'src', 'dest', 'src')
+        return testError(src, dest, done)
+      })
     })
 
-    it(`should move the directory successfully when dest is 'src-dest'`, done => {
-      dest = path.join(TEST_DIR, 'src-dest')
-      return testSuccessDir(src, dest, done)
+    describe('>> when dest is a symlink', () => {
+      it('should error when dest points exactly to src', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        fs.move(src, destLink, err => {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when dest is a subdirectory of src (bind-mounted directory with subdirectory)', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1')
+        assert(fs.existsSync(dest))
+        fs.move(src, dest, err => {
+          assert.strictEqual(err.message, `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`)
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when dest is a subdirectory of src (more than one level depth)', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        const dest = path.join(destLink, 'dir1', 'dir2')
+        assert(fs.existsSync(dest))
+        fs.move(src, dest, err => {
+          assert.strictEqual(err.message, `Cannot move '${src}' to a subdirectory of itself, '${path.join(destLink, 'dir1')}'.`)
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+    })
+  })
+
+  describe('> when source is a symlink', () => {
+    describe('>> when dest is a directory', () => {
+      it('should error when resolved src path points to dest', done => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src')
+
+        fs.move(srcLink, dest, err => {
+          assert(err)
+          // assert source not affected
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when dest is a subdir of resolved src path', done => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src', 'some', 'nested', 'dest')
+        fs.mkdirsSync(dest)
+
+        fs.move(srcLink, dest, err => {
+          assert(err)
+          const link = fs.readlinkSync(srcLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it('should error when resolved src path is a subdir of dest', done => {
+        const dest = path.join(TEST_DIR, 'dest')
+
+        const resolvedSrcPath = path.join(dest, 'contains', 'src')
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.copySync(src, resolvedSrcPath)
+
+        // make symlink that points to a subdir in dest
+        fs.symlinkSync(resolvedSrcPath, srcLink, 'dir')
+
+        fs.move(srcLink, dest, err => {
+          assert(err)
+          done()
+        })
+      })
+
+      it(`should move the directory successfully when dest is 'src_src/dest'`, done => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'src_src', 'dest')
+        testSuccessDir(srcLink, dest, () => {
+          const link = fs.readlinkSync(dest)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
+      it(`should move the directory successfully when dest is 'srcsrc/dest'`, done => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+
+        const dest = path.join(TEST_DIR, 'srcsrc', 'dest')
+        testSuccessDir(srcLink, dest, () => {
+          const link = fs.readlinkSync(dest)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
     })
 
-    it(`should move the directory successfully when dest is 'dest_src'`, done => {
-      dest = path.join(TEST_DIR, 'dest_src')
-      return testSuccessDir(src, dest, done)
-    })
+    describe('>> when dest is a symlink', () => {
+      it('should error when resolved dest path is exactly the same as resolved src path', done => {
+        const srcLink = path.join(TEST_DIR, 'src-symlink')
+        fs.symlinkSync(src, srcLink, 'dir')
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
 
-    it(`should move the directory successfully when dest is 'src_dest/src'`, done => {
-      dest = path.join(TEST_DIR, 'src_dest', 'src')
-      return testSuccessDir(src, dest, done)
-    })
+        const srclenBefore = klawSync(srcLink).length
+        const destlenBefore = klawSync(destLink).length
+        assert(srclenBefore > 2)
+        assert(destlenBefore > 2)
 
-    it(`should move the directory successfully when dest is 'src-dest/src'`, done => {
-      dest = path.join(TEST_DIR, 'src-dest', 'src')
-      return testSuccessDir(src, dest, done)
-    })
+        fs.move(srcLink, destLink, err => {
+          assert.strictEqual(err.message, 'Source and destination must not be the same.')
 
-    it(`should move the directory successfully when dest is 'dest_src/src'`, done => {
-      dest = path.join(TEST_DIR, 'dest_src', 'src')
-      return testSuccessDir(src, dest, done)
-    })
+          const srclenAfter = klawSync(srcLink).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+          const destlenAfter = klawSync(destLink).length
+          assert.strictEqual(destlenAfter, destlenBefore, 'dest length should not change')
 
-    it(`should move the directory successfully when dest is 'src_src/dest'`, done => {
-      dest = path.join(TEST_DIR, 'src_src', 'dest')
-      return testSuccessDir(src, dest, done)
-    })
-
-    it(`should move the directory successfully when dest is 'src-src/dest'`, done => {
-      dest = path.join(TEST_DIR, 'src-src', 'dest')
-      return testSuccessDir(src, dest, done)
-    })
-
-    it(`should move the directory successfully when dest is 'srcsrc/dest'`, done => {
-      dest = path.join(TEST_DIR, 'srcsrc', 'dest')
-      return testSuccessDir(src, dest, done)
-    })
-
-    it(`should move the directory successfully when dest is 'dest/src'`, done => {
-      dest = path.join(TEST_DIR, 'dest', 'src')
-      return testSuccessDir(src, dest, done)
-    })
-
-    it('should move the directory successfully when dest is very nested that all its parents need to be created', done => {
-      dest = path.join(TEST_DIR, 'dest', 'src', 'foo', 'bar', 'baz', 'qux', 'quux', 'waldo',
-        'grault', 'garply', 'fred', 'plugh', 'thud', 'some', 'highly', 'deeply',
-        'badly', 'nasty', 'crazy', 'mad', 'nested', 'dest')
-      assert(!fs.existsSync(dest))
-      return testSuccessDir(src, dest, done)
-    })
-
-    it(`should return error when dest is 'src/dest'`, done => {
-      dest = path.join(TEST_DIR, 'src', 'dest')
-      return testError(src, dest, done)
-    })
-
-    it(`should return error when dest is 'src/src_dest'`, done => {
-      dest = path.join(TEST_DIR, 'src', 'src_dest')
-      return testError(src, dest, done)
-    })
-
-    it(`should return error when dest is 'src/dest_src'`, done => {
-      dest = path.join(TEST_DIR, 'src', 'dest_src')
-      return testError(src, dest, done)
-    })
-
-    it(`should return error when dest is 'src/dest/src'`, done => {
-      dest = path.join(TEST_DIR, 'src', 'dest', 'src')
-      return testError(src, dest, done)
+          const srcln = fs.readlinkSync(srcLink)
+          assert.strictEqual(srcln, src)
+          const destln = fs.readlinkSync(destLink)
+          assert.strictEqual(destln, src)
+          done()
+        })
+      })
     })
   })
 })

--- a/lib/move/__tests__/move-prevent-moving-into-itself.test.js
+++ b/lib/move/__tests__/move-prevent-moving-into-itself.test.js
@@ -24,7 +24,7 @@ const dat3 = 'file3'
 describe('+ move() - prevent moving into itself', () => {
   let TEST_DIR, src
 
-  beforeEach(done => {
+  beforeEach(() => {
     TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-prevent-moving-into-itself')
     src = path.join(TEST_DIR, 'src')
     fs.mkdirpSync(src)
@@ -33,10 +33,9 @@ describe('+ move() - prevent moving into itself', () => {
     fs.outputFileSync(path.join(src, FILES[1]), dat1)
     fs.outputFileSync(path.join(src, FILES[2]), dat2)
     fs.outputFileSync(path.join(src, FILES[3]), dat3)
-    done()
   })
 
-  afterEach(done => fs.remove(TEST_DIR, done))
+  afterEach(() => fs.removeSync(TEST_DIR))
 
   describe('> when source is a file', () => {
     it('should move the file successfully even if dest parent is a subdir of src', done => {

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -2,7 +2,7 @@
 
 const fs = require('graceful-fs')
 const os = require('os')
-const fse = require(process.cwd())
+const fse = require('../../')
 const path = require('path')
 const assert = require('assert')
 
@@ -143,7 +143,7 @@ describe('+ move()', () => {
       const dest = src
 
       fse.move(src, dest, err => {
-        assert.ifError(err)
+        assert.strictEqual(err.message, 'Source and destination must not be the same.')
         done()
       })
     })
@@ -163,7 +163,7 @@ describe('+ move()', () => {
       const dest = src
 
       fse.move(src, dest, err => {
-        assert.ifError(err)
+        assert.strictEqual(err.message, 'Source and destination must not be the same.')
         done()
       })
     })

--- a/lib/move/index.js
+++ b/lib/move/index.js
@@ -16,20 +16,14 @@ function move (src, dest, opts, cb) {
 
   const overwrite = opts.overwrite || opts.clobber || false
 
-  src = path.resolve(src)
-  dest = path.resolve(dest)
-
-  if (src === dest) return fs.access(src, cb)
-
-  fs.stat(src, (err, st) => {
+  checkPaths(src, dest, (err, srcStat) => {
     if (err) return cb(err)
-
-    if (st.isDirectory() && isSrcSubdir(src, dest)) {
-      return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
-    }
-    mkdirp(path.dirname(dest), err => {
+    checkParentStats(src, srcStat, dest, err => {
       if (err) return cb(err)
-      return doRename(src, dest, overwrite, cb)
+      mkdirp(path.dirname(dest), err => {
+        if (err) return cb(err)
+        return doRename(src, dest, overwrite, cb)
+      })
     })
   })
 }
@@ -68,15 +62,58 @@ function moveAcrossDevice (src, dest, overwrite, cb) {
   })
 }
 
+// return true if dest is a subdir of src, otherwise false.
+// It only checks the path strings.
 function isSrcSubdir (src, dest) {
-  const srcArray = src.split(path.sep)
-  const destArray = dest.split(path.sep)
-
-  return srcArray.reduce((acc, current, i) => {
-    return acc && destArray[i] === current
-  }, true)
+  const srcArr = path.resolve(src).split(path.sep).filter(i => i)
+  const destArr = path.resolve(dest).split(path.sep).filter(i => i)
+  return srcArr.reduce((acc, cur, i) => acc && destArr[i] === cur, true)
 }
 
-module.exports = {
-  move: u(move)
+function checkStats (src, dest, cb) {
+  fs.stat(src, (err, srcStat) => {
+    if (err) return cb(err)
+    fs.stat(dest, (err, destStat) => {
+      if (err) {
+        if (err.code === 'ENOENT') return cb(null, {srcStat})
+        return cb(err)
+      }
+      return cb(null, {srcStat, destStat})
+    })
+  })
 }
+
+// recursively check if dest parent is a subdirectory of src.
+// It works for all file types including symlinks since it
+// checks the src and dest inodes. It starts from the deepest
+// parent and stops once it reaches the src parent or the root path.
+function checkParentStats (src, srcStat, dest, cb) {
+  const destParent = path.dirname(dest)
+  if (destParent && (destParent === path.dirname(src) || destParent === path.parse(destParent).root)) return cb()
+  fs.stat(destParent, (err, destStat) => {
+    if (err) {
+      if (err.code === 'ENOENT') return cb()
+      return cb(err)
+    }
+    if (destStat.ino && destStat.ino === srcStat.ino) {
+      return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
+    }
+    return checkParentStats(src, srcStat, destParent, cb)
+  })
+}
+
+function checkPaths (src, dest, cb) {
+  checkStats(src, dest, (err, stats) => {
+    if (err) return cb(err)
+    const {srcStat, destStat} = stats
+    if (destStat && destStat.ino && destStat.ino === srcStat.ino) {
+      return cb(new Error('Source and destination must not be the same.'))
+    }
+    if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
+      return cb(new Error(`Cannot move '${src}' to a subdirectory of itself, '${dest}'.`))
+    }
+    return cb(null, srcStat)
+  })
+}
+
+module.exports = { move: u(move) }


### PR DESCRIPTION
fix #614 and #608.

Added the same _paths checking_ that we use in `copy*()` to `move*()`. This will avoid unexpected behavior and improve reliability of the function!