### PR TITLE
Update standard libraries and update code accordingly

### DIFF
--- a/docs/copy.md
+++ b/docs/copy.md
@@ -32,12 +32,12 @@ fs.copy('/tmp/mydir', '/tmp/mynewdir', err => {
 
 // With Promises:
 fs.copy('/tmp/myfile', '/tmp/mynewfile')
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example () {

--- a/docs/emptyDir.md
+++ b/docs/emptyDir.md
@@ -22,12 +22,12 @@ fs.emptyDir('/tmp/some/dir', err => {
 
 // With Promises:
 fs.emptyDir('/tmp/some/dir')
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example () {

--- a/docs/ensureDir.md
+++ b/docs/ensureDir.md
@@ -33,21 +33,21 @@ fs.ensureDir(dir, desiredMode, err => {
 
 // With Promises:
 fs.ensureDir(dir)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With Promises and a mode integer:
 fs.ensureDir(dir, desiredMode)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (directory) {

--- a/docs/ensureFile.md
+++ b/docs/ensureFile.md
@@ -22,12 +22,12 @@ fs.ensureFile(file, err => {
 
 // With Promises:
 fs.ensureFile(file)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (f) {

--- a/docs/ensureLink.md
+++ b/docs/ensureLink.md
@@ -22,12 +22,12 @@ fs.ensureLink(srcpath, dstpath, err => {
 
 // With Promises:
 fs.ensureLink(srcpath, dstpath)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (src, dest) {

--- a/docs/ensureSymlink.md
+++ b/docs/ensureSymlink.md
@@ -23,12 +23,12 @@ fs.ensureSymlink(srcpath, dstpath, err => {
 
 // With Promises:
 fs.ensureSymlink(srcpath, dstpath)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (src, dest) {

--- a/docs/move.md
+++ b/docs/move.md
@@ -25,12 +25,12 @@ fs.move(srcpath, dstpath, err => {
 
 // With Promises:
 fs.move(srcpath, dstpath)
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (src, dest) {

--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -26,13 +26,13 @@ fs.outputFile(file, 'hello!', err => {
 
 // With Promises:
 fs.outputFile(file, 'hello!')
-.then(() => fs.readFile(file, 'utf8'))
-.then(data => {
-  console.log(data) // => hello!
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => fs.readFile(file, 'utf8'))
+  .then(data => {
+    console.log(data) // => hello!
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (f) {

--- a/docs/outputJson-sync.md
+++ b/docs/outputJson-sync.md
@@ -18,7 +18,7 @@ Almost the same as [`writeJsonSync`](writeJson-sync.md), except that if the dire
 const fs = require('fs-extra')
 
 const file = '/tmp/this/path/does/not/exist/file.json'
-fs.outputJsonSync(file, {name: 'JP'})
+fs.outputJsonSync(file, { name: 'JP' })
 
 const data = fs.readJsonSync(file)
 console.log(data.name) // => JP

--- a/docs/outputJson.md
+++ b/docs/outputJson.md
@@ -21,7 +21,7 @@ const fs = require('fs-extra')
 const file = '/tmp/this/path/does/not/exist/file.json'
 
 // With a callback:
-fs.outputJson(file, {name: 'JP'}, err => {
+fs.outputJson(file, { name: 'JP' }, err => {
   console.log(err) // => null
 
   fs.readJson(file, (err, data) => {
@@ -31,19 +31,19 @@ fs.outputJson(file, {name: 'JP'}, err => {
 })
 
 // With Promises:
-fs.outputJson(file, {name: 'JP'})
-.then(() => fs.readJson(file))
-.then(data => {
-  console.log(data.name) // => JP
-})
-.catch(err => {
-  console.error(err)
-})
+fs.outputJson(file, { name: 'JP' })
+  .then(() => fs.readJson(file))
+  .then(data => {
+    console.log(data.name) // => JP
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (f) {
   try {
-    await fs.outputJson(f, {name: 'JP'})
+    await fs.outputJson(f, { name: 'JP' })
 
     const data = await fs.readJson(f)
 

--- a/docs/readJson.md
+++ b/docs/readJson.md
@@ -23,12 +23,12 @@ fs.readJson('./package.json', (err, packageObj) => {
 
 // With Promises:
 fs.readJson('./package.json')
-.then(packageObj => {
-  console.log(packageObj.version) // => 0.1.3
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(packageObj => {
+    console.log(packageObj.version) // => 0.1.3
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example () {
@@ -62,14 +62,14 @@ fs.readJson(file, { throws: false }, (err, obj) => {
   console.log(obj) // => null
 })
 
-// Wtih Promises:
+// With Promises:
 fs.readJson(file, { throws: false })
-.then(obj => {
-  console.log(obj) // => null
-})
-.catch(err => {
-  console.error(err) // Not called
-})
+  .then(obj => {
+    console.log(obj) // => null
+  })
+  .catch(err => {
+    console.error(err) // Not called
+  })
 
 // With async/await:
 async function example (f) {

--- a/docs/remove.md
+++ b/docs/remove.md
@@ -26,12 +26,12 @@ fs.remove('/home/jprichardson', err => {
 
 // With Promises:
 fs.remove('/tmp/myfile')
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example (src, dest) {

--- a/docs/writeJson-sync.md
+++ b/docs/writeJson-sync.md
@@ -17,7 +17,7 @@ Writes an object to a JSON file.
 ```js
 const fs = require('fs-extra')
 
-fs.writeJsonSync('./package.json', {name: 'fs-extra'})
+fs.writeJsonSync('./package.json', { name: 'fs-extra' })
 ```
 ---
 

--- a/docs/writeJson.md
+++ b/docs/writeJson.md
@@ -19,25 +19,25 @@ Writes an object to a JSON file.
 const fs = require('fs-extra')
 
 // With a callback:
-fs.writeJson('./package.json', {name: 'fs-extra'}, err => {
+fs.writeJson('./package.json', { name: 'fs-extra' }, err => {
   if (err) return console.error(err)
 
   console.log('success!')
 })
 
 // With Promises:
-fs.writeJson('./package.json', {name: 'fs-extra'})
-.then(() => {
-  console.log('success!')
-})
-.catch(err => {
-  console.error(err)
-})
+fs.writeJson('./package.json', { name: 'fs-extra' })
+  .then(() => {
+    console.log('success!')
+  })
+  .catch(err => {
+    console.error(err)
+  })
 
 // With async/await:
 async function example () {
   try {
-    await fs.writeJson('./package.json', {name: 'fs-extra'})
+    await fs.writeJson('./package.json', { name: 'fs-extra' })
     console.log('success!')
   } catch (err) {
     console.error(err)

--- a/lib/__tests__/promise.test.js
+++ b/lib/__tests__/promise.test.js
@@ -29,7 +29,7 @@ describe('promise support', () => {
     it('provides fse.promises API', () => {
       const desc = Object.getOwnPropertyDescriptor(fse, 'promises')
       assert.ok(desc)
-      assert.equal(typeof desc.get, 'function')
+      assert.strictEqual(typeof desc.get, 'function')
     })
   }
 })

--- a/lib/copy-sync/__tests__/broken-symlink.test.js
+++ b/lib/copy-sync/__tests__/broken-symlink.test.js
@@ -28,7 +28,7 @@ describe('copy-sync / broken symlink', () => {
   })
 
   it('should throw an error when dereference=true', () => {
-    assert.throws(() => copySync(src, out, {dereference: true}), err => err.code === 'ENOENT')
+    assert.throws(() => copySync(src, out, { dereference: true }), err => err.code === 'ENOENT')
   })
 })
 

--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -136,7 +136,7 @@ describe('+ copySync() / file', () => {
       describe('> when destination file does NOT exist', () => {
         describe('> when overwrite is true', () => {
           it('should copy the file and not throw an error', () => {
-            fs.copySync(src, dest, {overwrite: true})
+            fs.copySync(src, dest, { overwrite: true })
             const destData = fs.readFileSync(dest, 'utf8')
             assert.strictEqual(srcData, destData)
           })
@@ -144,7 +144,7 @@ describe('+ copySync() / file', () => {
 
         describe('> when overwrite is false', () => {
           it('should copy the file and not throw an error', () => {
-            fs.copySync(src, dest, {overwrite: false})
+            fs.copySync(src, dest, { overwrite: false })
             const destData = fs.readFileSync(dest, 'utf8')
             assert.strictEqual(srcData, destData)
           })
@@ -161,7 +161,7 @@ describe('+ copySync() / file', () => {
 
         describe('> when overwrite is true', () => {
           it('should copy the file and not throw an error', () => {
-            fs.copySync(src, dest, {overwrite: true})
+            fs.copySync(src, dest, { overwrite: true })
             destData = fs.readFileSync(dest, 'utf8')
             assert.strictEqual(srcData, destData)
           })
@@ -169,14 +169,14 @@ describe('+ copySync() / file', () => {
 
         describe('> when overwrite is false', () => {
           it('should not throw an error', () => {
-            fs.copySync(src, dest, {overwrite: false})
+            fs.copySync(src, dest, { overwrite: false })
 
             // copy never happened
             const destDataNew = fs.readFileSync(dest, 'utf8')
             assert.strictEqual(destData, destDataNew)
           })
           it('should throw an error when errorOnExist is true', () => {
-            assert.throws(() => fs.copySync(src, dest, {overwrite: false, errorOnExist: true}))
+            assert.throws(() => fs.copySync(src, dest, { overwrite: false, errorOnExist: true }))
 
             // copy never happened
             const destDataNew = fs.readFileSync(dest, 'utf8')
@@ -188,7 +188,7 @@ describe('+ copySync() / file', () => {
           it('should copy the file and not throw an error', () => {
             try {
               fs.chmodSync(dest, parseInt('444', 8))
-              fs.copySync(src, dest, {overwrite: true})
+              fs.copySync(src, dest, { overwrite: true })
               destData = fs.readFileSync(dest, 'utf8')
               assert.strictEqual(srcData, destData)
             } finally {
@@ -212,7 +212,7 @@ describe('+ copySync() / file', () => {
       })
 
       it('is an alias for overwrite', () => {
-        fs.copySync(src, dest, {clobber: false})
+        fs.copySync(src, dest, { clobber: false })
 
         // copy never happened
         const destDataNew = fs.readFileSync(dest, 'utf8')

--- a/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-preserve-time.test.js
@@ -31,8 +31,8 @@ describeIfPractical('copySync() - preserveTimestamps option', () => {
 
   describe('> when preserveTimestamps option is true', () => {
     it('should have the same timestamps on copy', () => {
-      fs.copySync(SRC, DEST, {preserveTimestamps: true})
-      FILES.forEach(testFile({preserveTimestamps: true}))
+      fs.copySync(SRC, DEST, { preserveTimestamps: true })
+      FILES.forEach(testFile({ preserveTimestamps: true }))
     })
   })
 

--- a/lib/copy-sync/__tests__/symlink.test.js
+++ b/lib/copy-sync/__tests__/symlink.test.js
@@ -36,7 +36,7 @@ describe('copy-sync / symlink', () => {
 
   it('copies file contents when dereference=true', () => {
     try {
-      copySync(src, out, {dereference: true})
+      copySync(src, out, { dereference: true })
     } catch (err) {
       assert.ifError(err)
     }

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -9,7 +9,7 @@ const notExist = Symbol('notExist')
 
 function copySync (src, dest, opts) {
   if (typeof opts === 'function') {
-    opts = {filter: opts}
+    opts = { filter: opts }
   }
 
   opts = opts || {}
@@ -173,14 +173,14 @@ function checkStats (src, dest) {
   try {
     destStat = fs.statSync(dest)
   } catch (err) {
-    if (err.code === 'ENOENT') return {srcStat, destStat: notExist}
+    if (err.code === 'ENOENT') return { srcStat, destStat: notExist }
     throw err
   }
-  return {srcStat, destStat}
+  return { srcStat, destStat }
 }
 
 function checkPaths (src, dest) {
-  const {srcStat, destStat} = checkStats(src, dest)
+  const { srcStat, destStat } = checkStats(src, dest)
   if (destStat.ino && destStat.ino === srcStat.ino) {
     throw new Error('Source and destination must not be the same.')
   }

--- a/lib/copy/__tests__/copy-preserve-time.test.js
+++ b/lib/copy/__tests__/copy-preserve-time.test.js
@@ -32,8 +32,8 @@ describeIfPractical('copy() - preserve timestamp', () => {
 
   describe('> when timestamp option is true', () => {
     it('should have the same timestamps on copy', done => {
-      copy(SRC, DEST, {preserveTimestamps: true}, () => {
-        FILES.forEach(testFile({preserveTimestamps: true}))
+      copy(SRC, DEST, { preserveTimestamps: true }, () => {
+        FILES.forEach(testFile({ preserveTimestamps: true }))
         done()
       })
     })

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -38,7 +38,7 @@ describe('fs-extra', () => {
 
       fse.ensureFileSync(src)
       fse.ensureFileSync(dest)
-      fse.copy(src, dest, {overwrite: false, errorOnExist: true}, err => {
+      fse.copy(src, dest, { overwrite: false, errorOnExist: true }, err => {
         assert(err)
         done()
       })
@@ -50,7 +50,7 @@ describe('fs-extra', () => {
 
       fse.ensureFileSync(src)
       fse.ensureFileSync(dest)
-      fse.copy(src, dest, {overwrite: false, errorOnExist: true}, err => {
+      fse.copy(src, dest, { overwrite: false, errorOnExist: true }, err => {
         assert(err)
         done()
       })

--- a/lib/copy/__tests__/ncp/broken-symlink.test.js
+++ b/lib/copy/__tests__/ncp/broken-symlink.test.js
@@ -31,7 +31,7 @@ describe('ncp broken symlink', () => {
   })
 
   it('should return an error when dereference=true', done => {
-    ncp(src, out, {dereference: true}, err => {
+    ncp(src, out, { dereference: true }, err => {
       assert.strictEqual(err.code, 'ENOENT')
       done()
     })

--- a/lib/copy/__tests__/ncp/ncp.test.js
+++ b/lib/copy/__tests__/ncp/ncp.test.js
@@ -72,7 +72,7 @@ describe('ncp', () => {
       })
 
       it('the copy is complete after callback', done => {
-        ncp(src, out, {overwrite: true}, err => {
+        ncp(src, out, { overwrite: true }, err => {
           fs.createReadStream = () => done(new Error('createReadStream after callback'))
 
           assert.ifError(err)
@@ -85,7 +85,7 @@ describe('ncp', () => {
       beforeEach(done => rimraf(out, done))
 
       it('works', cb => {
-        ncp(src, out, {overwrite: false}, err => {
+        ncp(src, out, { overwrite: false }, err => {
           assert.ifError(err)
           cb()
         })
@@ -93,7 +93,7 @@ describe('ncp', () => {
 
       it('should not error if files exist', cb => {
         ncp(src, out, () => {
-          ncp(src, out, {overwrite: false}, err => {
+          ncp(src, out, { overwrite: false }, err => {
             assert.ifError(err)
             cb()
           })

--- a/lib/copy/__tests__/ncp/symlink.test.js
+++ b/lib/copy/__tests__/ncp/symlink.test.js
@@ -35,7 +35,7 @@ describe('ncp / symlink', () => {
   })
 
   it('copies file contents when dereference=true', done => {
-    ncp(src, out, {dereference: true}, err => {
+    ncp(src, out, { dereference: true }, err => {
       assert.ifError(err)
 
       const fileSymlinkPath = path.join(out, 'file-symlink')

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -13,7 +13,7 @@ function copy (src, dest, opts, cb) {
     cb = opts
     opts = {}
   } else if (typeof opts === 'function') {
-    opts = {filter: opts}
+    opts = { filter: opts }
   }
 
   cb = cb || function () {}
@@ -221,10 +221,10 @@ function checkStats (src, dest, cb) {
     if (err) return cb(err)
     fs.stat(dest, (err, destStat) => {
       if (err) {
-        if (err.code === 'ENOENT') return cb(null, {srcStat, destStat: notExist})
+        if (err.code === 'ENOENT') return cb(null, { srcStat, destStat: notExist })
         return cb(err)
       }
-      return cb(null, {srcStat, destStat})
+      return cb(null, { srcStat, destStat })
     })
   })
 }
@@ -232,7 +232,7 @@ function checkStats (src, dest, cb) {
 function checkPaths (src, dest, cb) {
   checkStats(src, dest, (err, stats) => {
     if (err) return cb(err)
-    const {srcStat, destStat} = stats
+    const { srcStat, destStat } = stats
     if (destStat.ino && destStat.ino === srcStat.ino) {
       return cb(new Error('Source and destination must not be the same.'))
     }

--- a/lib/ensure/__tests__/symlink-paths.test.js
+++ b/lib/ensure/__tests__/symlink-paths.test.js
@@ -38,16 +38,16 @@ describe('symlink-type', () => {
   })
 
   const tests = [
-    [['foo.txt', 'symlink.txt'], {toCwd: 'foo.txt', toDst: 'foo.txt'}], // smart && nodestyle
-    [['foo.txt', 'empty-dir/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // smart
-    [['../foo.txt', 'empty-dir/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // nodestyle
-    [['foo.txt', 'dir-bar/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // smart
-    [['../foo.txt', 'dir-bar/symlink.txt'], {toCwd: 'foo.txt', toDst: '../foo.txt'}], // nodestyle
+    [['foo.txt', 'symlink.txt'], { toCwd: 'foo.txt', toDst: 'foo.txt' }], // smart && nodestyle
+    [['foo.txt', 'empty-dir/symlink.txt'], { toCwd: 'foo.txt', toDst: '../foo.txt' }], // smart
+    [['../foo.txt', 'empty-dir/symlink.txt'], { toCwd: 'foo.txt', toDst: '../foo.txt' }], // nodestyle
+    [['foo.txt', 'dir-bar/symlink.txt'], { toCwd: 'foo.txt', toDst: '../foo.txt' }], // smart
+    [['../foo.txt', 'dir-bar/symlink.txt'], { toCwd: 'foo.txt', toDst: '../foo.txt' }], // nodestyle
     // this is to preserve node's symlink capability these arguments say create
     // a link to 'dir-foo/foo.txt' this works because it exists this is unlike
     // the previous example with 'empty-dir' because 'empty-dir/foo.txt' does not exist.
-    [['foo.txt', 'dir-foo/symlink.txt'], {toCwd: 'dir-foo/foo.txt', toDst: 'foo.txt'}], // nodestyle
-    [['foo.txt', 'real-alpha/real-beta/real-gamma/symlink.txt'], {toCwd: 'foo.txt', toDst: '../../../foo.txt'}]
+    [['foo.txt', 'dir-foo/symlink.txt'], { toCwd: 'dir-foo/foo.txt', toDst: 'foo.txt' }], // nodestyle
+    [['foo.txt', 'real-alpha/real-beta/real-gamma/symlink.txt'], { toCwd: 'foo.txt', toDst: '../../../foo.txt' }]
   ]
 
   // formats paths to pass on multiple operating systems

--- a/lib/json/__tests__/output-json-sync.test.js
+++ b/lib/json/__tests__/output-json-sync.test.js
@@ -22,7 +22,7 @@ describe('json', () => {
       const file = path.join(TEST_DIR, 'this-dir', 'does-not', 'exist', 'file.json')
       assert(!fs.existsSync(file))
 
-      const data = {name: 'JP'}
+      const data = { name: 'JP' }
       outputJsonSync(file, data)
 
       assert(fs.existsSync(file))
@@ -37,7 +37,7 @@ describe('json', () => {
         assert(!fs.existsSync(file))
 
         const replacer = (k, v) => v === 'JP' ? 'Jon Paul' : v
-        const data = {name: 'JP'}
+        const data = { name: 'JP' }
 
         outputJsonSync(file, data, { replacer })
         const newData = JSON.parse(fs.readFileSync(file, 'utf8'))

--- a/lib/json/__tests__/output-json.test.js
+++ b/lib/json/__tests__/output-json.test.js
@@ -22,7 +22,7 @@ describe('json', () => {
       const file = path.join(TEST_DIR, 'this-dir', 'prob-does-not', 'exist', 'file.json')
       assert(!fs.existsSync(file))
 
-      const data = {name: 'JP'}
+      const data = { name: 'JP' }
       outputJson(file, data, err => {
         if (err) return done(err)
 
@@ -38,7 +38,7 @@ describe('json', () => {
       const file = path.join(TEST_DIR, 'this-dir', 'prob-does-not', 'exist', 'file.json')
       assert(!fs.existsSync(file))
 
-      const data = {name: 'JP'}
+      const data = { name: 'JP' }
       return outputJson(file, data)
     })
 
@@ -48,7 +48,7 @@ describe('json', () => {
         assert(!fs.existsSync(file))
 
         const replacer = (k, v) => v === 'JP' ? 'Jon Paul' : v
-        const data = {name: 'JP'}
+        const data = { name: 'JP' }
 
         outputJson(file, data, { replacer }, err => {
           assert.ifError(err)

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -101,7 +101,7 @@ describe('moveSync()', () => {
     assert(fs.existsSync(dest))
 
     try {
-      fse.moveSync(src, dest, {overwrite: false})
+      fse.moveSync(src, dest, { overwrite: false })
     } catch (err) {
       assert.ok(err && err.code === 'EEXIST', 'throw EEXIST')
     }
@@ -114,7 +114,7 @@ describe('moveSync()', () => {
     // verify file exists already
     assert(fs.existsSync(dest))
 
-    fse.moveSync(src, dest, {overwrite: true})
+    fse.moveSync(src, dest, { overwrite: true })
 
     const contents = fs.readFileSync(dest, 'utf8')
     const expected = /^sonic the hedgehog\r?\n$/
@@ -135,7 +135,7 @@ describe('moveSync()', () => {
     assert(pathsBefore.indexOf('another-file') >= 0)
     assert(pathsBefore.indexOf('another-folder') >= 0)
 
-    fse.moveSync(src, dest, {overwrite: true})
+    fse.moveSync(src, dest, { overwrite: true })
 
     // verify dest does not have old stuff
     const pathsAfter = fs.readdirSync(dest)
@@ -212,7 +212,7 @@ describe('moveSync()', () => {
 
     setUpMockFs('EXDEV')
 
-    fse.moveSync(src, dest, {overwrite: true})
+    fse.moveSync(src, dest, { overwrite: true })
 
     const contents = fs.readFileSync(dest + '/another-folder/file3', 'utf8')
     const expected = /^knuckles\r?\n$/
@@ -270,7 +270,7 @@ describe('moveSync()', () => {
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.moveSync(src, dest, {clobber: true})
+      fse.moveSync(src, dest, { clobber: true })
 
       const contents = fs.readFileSync(dest, 'utf8')
       const expected = /^sonic the hedgehog\r?\n$/

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -58,7 +58,7 @@ describe('+ move()', () => {
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.move(src, dest, {overwrite: true}, err => {
+      fse.move(src, dest, { overwrite: true }, err => {
         assert.ifError(err)
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
@@ -83,7 +83,7 @@ describe('+ move()', () => {
       assert(paths.indexOf('another-file') >= 0)
       assert(paths.indexOf('another-folder') >= 0)
 
-      fse.move(src, dest, {overwrite: true}, err => {
+      fse.move(src, dest, { overwrite: true }, err => {
         assert.ifError(err)
 
         // verify dest does not have old stuff
@@ -107,7 +107,7 @@ describe('+ move()', () => {
 
       setUpMockFs('EXDEV')
 
-      fse.move(src, dest, {overwrite: true}, err => {
+      fse.move(src, dest, { overwrite: true }, err => {
         assert.ifError(err)
         assert.strictEqual(fs.rename.callCount, 1)
 
@@ -188,7 +188,7 @@ describe('+ move()', () => {
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.move(src, dest, {overwrite: false}, err => {
+      fse.move(src, dest, { overwrite: false }, err => {
         assert.strictEqual(err.message, 'dest already exists.')
         done()
       })
@@ -279,7 +279,7 @@ describe('+ move()', () => {
       // verify file exists already
       assert(fs.existsSync(dest))
 
-      fse.move(src, dest, {clobber: true}, err => {
+      fse.move(src, dest, { clobber: true }, err => {
         assert.ifError(err)
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/

--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -19,7 +19,7 @@ describe('utimes', () => {
     fse.emptyDir(TEST_DIR, done)
     // reset stubs
     gracefulFsStub = {}
-    utimes = proxyquire('../utimes', {'graceful-fs': gracefulFsStub})
+    utimes = proxyquire('../utimes', { 'graceful-fs': gracefulFsStub })
   })
 
   describe('hasMillisResSync()', () => {

--- a/package.json
+++ b/package.json
@@ -52,8 +52,8 @@
     "rimraf": "^2.2.8",
     "secure-random": "^1.1.1",
     "semver": "^5.3.0",
-    "standard": "^11.0.1",
-    "standard-markdown": "^4.0.1"
+    "standard": "^12.0.1",
+    "standard-markdown": "^5.0.1"
   },
   "main": "./lib/index.js",
   "scripts": {


### PR DESCRIPTION
This PR updates the `standard` and `standard-markdown` and updates the code and docs accordingly (in the example code snippets). 

Two types of changes were made:
- Spaces inside `{` and `}` (e.g. `{ key: value }` rather than `{key: value}`
- Extra Indentation when chaining promises over multiple lines (in example code only)

This is a fix for https://github.com/jprichardson/node-fs-extra/issues/631.