### PR TITLE
Fix removeSync() to eliminate spurious ENOTEMPTY errors on Windows

### DIFF
--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -304,7 +304,7 @@ function rmkidsSync (p, options) {
       try {
         const ret = options.rmdirSync(p, options)
         return ret
-      } catch { }
+      } catch (er) { }
 
     } while (Date.now() - startTime < 500) // give up after 500ms
   } else {

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -297,15 +297,12 @@ function rmkidsSync (p, options) {
     // try really hard to delete stuff on windows, because it has a
     // PROFOUNDLY annoying habit of not closing handles promptly when
     // files are deleted, resulting in spurious ENOTEMPTY errors.
-    const startTime = Date.now();
+    const startTime = Date.now()
     do {
-      console.log(Date.now() - startTime);
-
       try {
         const ret = options.rmdirSync(p, options)
         return ret
       } catch (er) { }
-
     } while (Date.now() - startTime < 500) // give up after 500ms
   } else {
     const ret = options.rmdirSync(p, options)

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -285,12 +285,6 @@ function rmdirSync (p, options, originalEr) {
   }
 }
 
-function getMilliseconds(lastTime) {
-  let [seconds, nanoseconds] = process.hrtime(lastTime);
-  // limit the non-fractional portion to be less than 1^32
-  return (seconds & 0xffffffff) * 1000 + nanoseconds / 1000000;
-}
-
 function rmkidsSync (p, options) {
   assert(p)
   assert(options)
@@ -303,15 +297,16 @@ function rmkidsSync (p, options) {
     // try really hard to delete stuff on windows, because it has a
     // PROFOUNDLY annoying habit of not closing handles promptly when
     // files are deleted, resulting in spurious ENOTEMPTY errors.
-    const startTime = getMilliseconds();
+    const startTime = Date.now();
     do {
+      console.log(Date.now() - startTime);
+
       try {
         const ret = options.rmdirSync(p, options)
         return ret
       } catch { }
 
-      // This comparison uses modular arithmetic since getMilliseconds() can roll over
-    } while (((getMilliseconds() - startTime) & 0xffffffff) < 500) // give up after 500ms
+    } while (Date.now() - startTime < 500) // give up after 500ms
   } else {
     const ret = options.rmdirSync(p, options)
     return ret

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -285,29 +285,37 @@ function rmdirSync (p, options, originalEr) {
   }
 }
 
+function getMilliseconds(lastTime) {
+  let [seconds, nanoseconds] = process.hrtime(lastTime);
+  // limit the non-fractional portion to be less than 1^32
+  return (seconds & 0xffffffff) * 1000 + nanoseconds / 1000000;
+}
+
 function rmkidsSync (p, options) {
   assert(p)
   assert(options)
   options.readdirSync(p).forEach(f => rimrafSync(path.join(p, f), options))
 
-  // We only end up here once we got ENOTEMPTY at least once, and
-  // at this point, we are guaranteed to have removed all the kids.
-  // So, we know that it won't be ENOENT or ENOTDIR or anything else.
-  // try really hard to delete stuff on windows, because it has a
-  // PROFOUNDLY annoying habit of not closing handles promptly when
-  // files are deleted, resulting in spurious ENOTEMPTY errors.
-  const retries = isWindows ? 100 : 1
-  let i = 0
-  do {
-    let threw = true
-    try {
-      const ret = options.rmdirSync(p, options)
-      threw = false
-      return ret
-    } finally {
-      if (++i < retries && threw) continue // eslint-disable-line
-    }
-  } while (true)
+  if (isWindows) {
+    // We only end up here once we got ENOTEMPTY at least once, and
+    // at this point, we are guaranteed to have removed all the kids.
+    // So, we know that it won't be ENOENT or ENOTDIR or anything else.
+    // try really hard to delete stuff on windows, because it has a
+    // PROFOUNDLY annoying habit of not closing handles promptly when
+    // files are deleted, resulting in spurious ENOTEMPTY errors.
+    const startTime = getMilliseconds();
+    do {
+      try {
+        const ret = options.rmdirSync(p, options)
+        return ret
+      } catch { }
+
+      // This comparison uses modular arithmetic since getMilliseconds() can roll over
+    } while (((getMilliseconds() - startTime) & 0xffffffff) < 500) // give up after 500ms
+  } else {
+    const ret = options.rmdirSync(p, options)
+    return ret
+  }
 }
 
 module.exports = rimraf


### PR DESCRIPTION
Lately I've been seeing a lot of errors like this on Windows:

> `ERROR: ENOTEMPTY: directory not empty, rmdir 'C:\some\folder'`

The Windows OS prevents a folder from being removed while file handles are still open.  Certain processes such as virus scanners and compiler environments watch folders for changes.  After a folder is removed, they take a little while to realize this and unregister their handlers.  In my empirical tests, it can occasionally take around 100ms - 200ms.

**fs-extra** already provides some protection against this:

[rimraf.js](https://github.com/jprichardson/node-fs-extra/blob/ab254b1efdefe0b05f73e96fb3f1d17902e03942/lib/remove/rimraf.js#L288)
```js
  // We only end up here once we got ENOTEMPTY at least once, and
  // at this point, we are guaranteed to have removed all the kids.
  // So, we know that it won't be ENOENT or ENOTDIR or anything else.
  // try really hard to delete stuff on windows, because it has a
  // PROFOUNDLY annoying habit of not closing handles promptly when
  // files are deleted, resulting in spurious ENOTEMPTY errors.
  const retries = isWindows ? 100 : 1
  let i = 0
  do {
    let threw = true
    try {
      const ret = options.rmdirSync(p, options)
      threw = false
      return ret
    } finally {
      if (++i < retries && threw) continue // eslint-disable-line
    }
  } while (true)
```

However, this algorithm relies on a retry count to decide when to give up.  If the PC is idle or has very fast hardware, then 100 retries is way too little.  We could increase the limit, but the units are arbitrary.

This PR changes the loop to measure actual time, since that's more representative of the underlying problem.