### PR TITLE
Update graceful-fs version

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "graceful-fs": "^4.1.2",
+    "graceful-fs": "^4.1.3",
     "jsonfile": "^4.0.0",
     "universalify": "^0.1.0"
   },


### PR DESCRIPTION
This solves an issue with expo not being able to run properly: https://github.com/expo/expo-cli/issues/141

The change from graceful-fs 4.1.2 to 4.1.3 is this commit:
https://github.com/isaacs/node-graceful-fs/commit/a1587eae7c5dcf74ccf6556ac7d6f704ea794804