### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ I got tired of including `mkdirp`, `rimraf`, and `ncp` in most of my projects.
 Installation
 ------------
 
-    npm install --save fs-extra
+    npm install fs-extra
 
 
 


### PR DESCRIPTION
"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358