### PR TITLE
CheckPath Error -> Warn of Inode.

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -182,7 +182,11 @@ function checkStats (src, dest) {
 function checkPaths (src, dest) {
   const {srcStat, destStat} = checkStats(src, dest)
   if (destStat.ino && destStat.ino === srcStat.ino) {
-    throw new Error('Source and destination must not be the same.')
+    console.warn(
+      'Source and destination must not be the same.',
+      'Dest Inode: ' + destStat.ino,
+      'Src Inode: ' + srcStat.ino
+    )
   }
   if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
     throw new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -234,7 +234,11 @@ function checkPaths (src, dest, cb) {
     if (err) return cb(err)
     const {srcStat, destStat} = stats
     if (destStat.ino && destStat.ino === srcStat.ino) {
-      return cb(new Error('Source and destination must not be the same.'))
+      console.warn(
+        'Source and destination must not be the same.',
+        'Dest Inode: ' + destStat.ino,
+        'Src Inode: ' + srcStat.ino
+      )
     }
     if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
       return cb(new Error(`Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`))


### PR DESCRIPTION
Fixes https://github.com/jprichardson/node-fs-extra/issues/657

The inode number is an integer unique to the volume upon which it is stored.
That means, the method checkPaths() disallows me to copy a file from one to another volume.
Also `fs-extra` does not set the big-integer flag of node `fs`. It's only a "default" JavaScript number (max integer is 53-bit). [See the difference here](https://stackblitz.com/edit/js-bigint-comparison?embed=1&file=index.js) On Windows the cap is reached.

No option provided, because checking if Inode is the wrong way. It's not only a big-integer issue. Inodes are only unique to the volume upon which it is stored.

This will fix the issue #657 
I keep it as warning to see it when is happen.
Maybe not the best solution. But with the thrown error, it is not possible to use it.
Example: It's not possible to stable build with Android-Cordova 8.x. Because Cordova switched to `fs-extra` since version 8.x. 

Better solutions are welcome. But keep in mind that the Inode (state.ino of fs) is not really unique global and in current fs-extra implementation. Again:
- The inode number is an integer unique to the volume upon which it is stored.
- `state.ino` of `fs` also supports `big-integer`. Node version 10.4 is required to use this. But currently it's set for `number` (53-bit) only.

The aim is to remove / replace this check. Because it's faulty. (Inode) You'll get errors from `fs` / `os`.
