### PR TITLE
Add heuristics to stats.ino comparison when bigint is not available

### DIFF
--- a/lib/util/stat.js
+++ b/lib/util/stat.js
@@ -76,7 +76,7 @@ function checkPaths (src, dest, funcName, cb) {
   getStats(src, dest, (err, stats) => {
     if (err) return cb(err)
     const { srcStat, destStat } = stats
-    if (destStat && destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+    if (destStat && areIdentical(srcStat, destStat)) {
       return cb(new Error('Source and destination must not be the same.'))
     }
     if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
@@ -88,7 +88,7 @@ function checkPaths (src, dest, funcName, cb) {
 
 function checkPathsSync (src, dest, funcName) {
   const { srcStat, destStat } = getStatsSync(src, dest)
-  if (destStat && destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+  if (destStat && areIdentical(srcStat, destStat)) {
     throw new Error('Source and destination must not be the same.')
   }
   if (srcStat.isDirectory() && isSrcSubdir(src, dest)) {
@@ -111,7 +111,7 @@ function checkParentPaths (src, srcStat, dest, funcName, cb) {
         if (err.code === 'ENOENT') return cb()
         return cb(err)
       }
-      if (destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+      if (areIdentical(srcStat, destStat)) {
         return cb(new Error(errMsg(src, dest, funcName)))
       }
       return checkParentPaths(src, srcStat, destParent, funcName, cb)
@@ -122,7 +122,7 @@ function checkParentPaths (src, srcStat, dest, funcName, cb) {
         if (err.code === 'ENOENT') return cb()
         return cb(err)
       }
-      if (destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+      if (areIdentical(srcStat, destStat)) {
         return cb(new Error(errMsg(src, dest, funcName)))
       }
       return checkParentPaths(src, srcStat, destParent, funcName, cb)
@@ -145,10 +145,33 @@ function checkParentPathsSync (src, srcStat, dest, funcName) {
     if (err.code === 'ENOENT') return
     throw err
   }
-  if (destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+  if (areIdentical(srcStat, destStat)) {
     throw new Error(errMsg(src, dest, funcName))
   }
   return checkParentPathsSync(src, srcStat, destParent, funcName)
+}
+
+function areIdentical (srcStat, destStat) {
+  if (destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev) {
+    if (nodeSupportsBigInt() || destStat.ino < Number.MAX_SAFE_INTEGER) {
+      // definitive answer
+      return true
+    }
+    // Use additional heuristics if we can't use 'bigint'.
+    // Different 'ino' could be represented the same if they are >= Number.MAX_SAFE_INTEGER
+    // See issue 657
+    if (destStat.size === srcStat.size &&
+        destStat.mode === srcStat.mode &&
+        destStat.nlink === srcStat.nlink &&
+        destStat.atimeMs === srcStat.atimeMs &&
+        destStat.mtimeMs === srcStat.mtimeMs &&
+        destStat.ctimeMs === srcStat.ctimeMs &&
+        destStat.birthtimeMs === srcStat.birthtimeMs) {
+      // heuristic answer
+      return true
+    }
+  }
+  return false
 }
 
 // return true if dest is a subdir of src, otherwise false.


### PR DESCRIPTION
The resolution of https://github.com/jprichardson/node-fs-extra/issues/657 relies on Node >= 10.5, but actually leaves the issue not fixed on previous versions of Node (in particular, for the OP, who reported the issue on Node 8.11.3). The issue particularly problematic and frequent in automated setups, such as running tests that create files in sequence, where it is likely to happen.

This PR minimizes the frequency of this issue by comparing additional `fs.Stats` values when `Bigint` support is not available. Note that the check is still heuristic: different stats prove they are different files*, but while same stats do not prove they are the same, we must err on the side of caution and still treat them as the same file.

(*) **Race condition**: comparing file stats before performing a copy or other operation implicitly introduces a race condition. However the existing implementation already suffered from this, so we presume that this PR does not make the condition much worse (with the exception that unlike `ino` and `vol`, a malicious user could in theory manipulate some of the other `stats`). In practice, this race condition seems extremely hard to abuse, since it requires using a vulnerable system, and a means to change the file stats between the two `stats` calls made by `getStats` and `getStatsSync`.