### PR TITLE
Consistent errors across OSs for ensurefile

### DIFF
--- a/lib/ensure/__tests__/create.test.js
+++ b/lib/ensure/__tests__/create.test.js
@@ -70,7 +70,12 @@ describe('fs-extra', () => {
         fs.writeFileSync(existingFile)
 
         const file = path.join(existingFile, Math.random() + '.txt')
-        assert.throws(() => fse.createFileSync(file), { code: 'ENOTDIR' })
+        try {
+          fse.createFileSync(file)
+          assert.fail()
+        } catch (err) {
+          assert.strictEqual(err.code, 'ENOTDIR')
+        }
       })
     })
   })

--- a/lib/ensure/__tests__/create.test.js
+++ b/lib/ensure/__tests__/create.test.js
@@ -42,6 +42,18 @@ describe('fs-extra', () => {
           done()
         })
       })
+
+      it('should give clear error if node in directory tree is a file', done => {
+        const existingFile = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
+        fse.mkdirsSync(path.dirname(existingFile))
+        fs.writeFileSync(existingFile)
+
+        const file = path.join(existingFile, Math.random() + '.txt')
+        fse.createFile(file, err => {
+          assert.strictEqual(err.code, 'ENOTDIR')
+          done()
+        })
+      })
     })
   })
 

--- a/lib/ensure/__tests__/create.test.js
+++ b/lib/ensure/__tests__/create.test.js
@@ -63,6 +63,15 @@ describe('fs-extra', () => {
         fse.createFileSync(file)
         assert.strictEqual(fs.readFileSync(file, 'utf8'), 'hello world')
       })
+
+      it('should give clear error if node in directory tree is a file', () => {
+        const existingFile = path.join(TEST_DIR, Math.random() + 'ts-e', Math.random() + '.txt')
+        fse.mkdirsSync(path.dirname(existingFile))
+        fs.writeFileSync(existingFile)
+
+        const file = path.join(existingFile, Math.random() + '.txt')
+        assert.throws(() => fse.createFileSync(file), { code: 'ENOTDIR' })
+      })
     })
   })
 })

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -8,9 +8,21 @@ const pathExists = require('../path-exists').pathExists
 
 function createFile (file, callback) {
   function makeFile () {
-    fs.writeFile(file, '', err => {
+    const dir = path.dirname(file)
+
+    fs.stat(dir, (err, stats) => {
       if (err) return callback(err)
-      callback()
+      if (!stats.isDirectory()) {
+        // This is just to cause an internal ENOTDIR error to be thrown
+        fs.readdir(dir, err => {
+          if (err) return callback(err)
+        })
+      } else {
+        fs.writeFile(file, '', err => {
+          if (err) return callback(err)
+          callback()
+        })
+      }
     })
   }
 

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -40,6 +40,11 @@ function createFileSync (file) {
     mkdir.mkdirsSync(dir)
   }
 
+  if (!fs.statSync(dir).isDirectory()) {
+    // This is just to cause an internal ENOTDIR error to be thrown
+    fs.readdirSync(dir)
+  }
+
   fs.writeFileSync(file, '')
 }
 


### PR DESCRIPTION
Resolves #696 

Ensures that if you do something like `ensureFile('/foo/bar.txt/narf.txt')` an `ENOTDIR` error is always returned.

Before this PR `ENOTDIR` is returned for macOS and Linux but Windows returns `ENOENT` which is misleading.