### PR TITLE
Upgrade 'standard'

### DIFF
--- a/lib/ensure/symlink-paths.js
+++ b/lib/ensure/symlink-paths.js
@@ -34,8 +34,8 @@ function symlinkPaths (srcpath, dstpath, callback) {
         return callback(err)
       }
       return callback(null, {
-        'toCwd': srcpath,
-        'toDst': srcpath
+        toCwd: srcpath,
+        toDst: srcpath
       })
     })
   } else {
@@ -45,8 +45,8 @@ function symlinkPaths (srcpath, dstpath, callback) {
       if (err) return callback(err)
       if (exists) {
         return callback(null, {
-          'toCwd': relativeToDst,
-          'toDst': srcpath
+          toCwd: relativeToDst,
+          toDst: srcpath
         })
       } else {
         return fs.lstat(srcpath, (err) => {
@@ -55,8 +55,8 @@ function symlinkPaths (srcpath, dstpath, callback) {
             return callback(err)
           }
           return callback(null, {
-            'toCwd': srcpath,
-            'toDst': path.relative(dstdir, srcpath)
+            toCwd: srcpath,
+            toDst: path.relative(dstdir, srcpath)
           })
         })
       }
@@ -70,8 +70,8 @@ function symlinkPathsSync (srcpath, dstpath) {
     exists = fs.existsSync(srcpath)
     if (!exists) throw new Error('absolute srcpath does not exist')
     return {
-      'toCwd': srcpath,
-      'toDst': srcpath
+      toCwd: srcpath,
+      toDst: srcpath
     }
   } else {
     const dstdir = path.dirname(dstpath)
@@ -79,15 +79,15 @@ function symlinkPathsSync (srcpath, dstpath) {
     exists = fs.existsSync(relativeToDst)
     if (exists) {
       return {
-        'toCwd': relativeToDst,
-        'toDst': srcpath
+        toCwd: relativeToDst,
+        toDst: srcpath
       }
     } else {
       exists = fs.existsSync(srcpath)
       if (!exists) throw new Error('relative srcpath does not exist')
       return {
-        'toCwd': srcpath,
-        'toDst': path.relative(dstdir, srcpath)
+        toCwd: srcpath,
+        toDst: path.relative(dstdir, srcpath)
       }
     }
   }

--- a/lib/mkdirs/__tests__/clobber.test.js
+++ b/lib/mkdirs/__tests__/clobber.test.js
@@ -19,7 +19,7 @@ describe('mkdirp / clobber', () => {
     fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      const ps = [ TEST_DIR ]
+      const ps = [TEST_DIR]
 
       for (let i = 0; i < 15; i++) {
         const dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)

--- a/lib/mkdirs/__tests__/race.test.js
+++ b/lib/mkdirs/__tests__/race.test.js
@@ -21,7 +21,7 @@ describe('mkdirp / race', () => {
     fse.emptyDir(TEST_DIR, err => {
       assert.ifError(err)
 
-      const ps = [ TEST_DIR ]
+      const ps = [TEST_DIR]
 
       for (let i = 0; i < 15; i++) {
         const dir = Math.floor(Math.random() * Math.pow(16, 4)).toString(16)

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "proxyquire": "^2.0.1",
     "read-dir-files": "^0.1.1",
     "semver": "^5.3.0",
-    "standard": "^12.0.1"
+    "standard": "^13.0.0"
   },
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
I have fixed the following error.

```
  node-fs-extra/lib/ensure/symlink-paths.js:37:9: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:38:9: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/ensure/symlink-paths.js:48:11: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:49:11: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/ensure/symlink-paths.js:58:13: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:59:13: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/ensure/symlink-paths.js:73:7: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:74:7: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/ensure/symlink-paths.js:82:9: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:83:9: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/ensure/symlink-paths.js:89:9: Unnecessarily quoted property 'toCwd' found.
  node-fs-extra/lib/ensure/symlink-paths.js:90:9: Unnecessarily quoted property 'toDst' found.
  node-fs-extra/lib/mkdirs/__tests__/clobber.test.js:22:18: There should be no space after '['.
  node-fs-extra/lib/mkdirs/__tests__/clobber.test.js:22:29: There should be no space before ']'.
  node-fs-extra/lib/mkdirs/__tests__/race.test.js:24:18: There should be no space after '['.
  node-fs-extra/lib/mkdirs/__tests__/race.test.js:24:29: There should be no space before ']'.
```