### PR TITLE
Add "promise" to keywords on npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "create",
     "text",
     "output",
-    "move"
+    "move",
+    "promise"
   ],
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
fs-extra is probably the most popular promise-supporting fs library on npm, but if you [search npmjs.com for "fs promise"](https://www.npmjs.com/search?q=fs+promise), it doesn’t even show up. This change should hopefully fix that :-).