### PR TITLE
fix flaky test in remove.test.js

### DIFF
--- a/lib/remove/__tests__/remove.test.js
+++ b/lib/remove/__tests__/remove.test.js
@@ -70,11 +70,12 @@ describe('remove', () => {
       fs.writeFileSync(file, 'hello')
 
       assert(fs.existsSync(file))
-      const existsChecker = setInterval(() => {
+      let existsChecker = setInterval(() => {
         fse.pathExists(file, (err, itDoes) => {
           assert.ifError(err)
-          if (!itDoes) {
+          if (!itDoes && existsChecker) {
             clearInterval(existsChecker)
+            existsChecker = null
             done()
           }
         })


### PR DESCRIPTION
Hi,

The async operations of fse.remove, fse.pathExists, and setInterval may interleave (race) causing the callback of fse.pathExists be called twice with variable itDoes=false. In this case, error `Error: done() called multiple times` is thrown, making the test flaky.