### PR TITLE
fix a flaky test in ncp.test.js

### DIFF
--- a/lib/copy/__tests__/ncp/ncp.test.js
+++ b/lib/copy/__tests__/ncp/ncp.test.js
@@ -44,10 +44,8 @@ describe('ncp', () => {
             for (const fileName in files) {
               const curFile = files[fileName]
               if (curFile instanceof Object) {
-                return filter(curFile)
-              }
-
-              if (fileName.substr(fileName.length - 1) === 'a') {
+                filter(curFile)
+              } else if (fileName.substr(fileName.length - 1) === 'a') {
                 delete files[fileName]
               }
             }


### PR DESCRIPTION
Hi, 

Function `readDirFiles` may due to some race return object `srcFiles` with different structures. In particular, if property `sub` (an object) comes before `a` (string), function `filter` fails to remove `a` as it returns after the recursive call. This case makes the test flaky. 

Error:
```
      Uncaught AssertionError [ERR_ASSERTION]: Input A expected to strictly deep-equal input B:
+ expected - actual ... Lines skipped

  {
-   a: 'Hello world\n',
    b: 'Hello ncp\n',
...
    }
  }
      + expected - actual

       {
      -  "a": "Hello world\n"
         "b": "Hello ncp\n"
         "c": ""
         "d": ""
         "e": ""
      
      at readDirFiles (lib/copy/__tests__/ncp/ncp.test.js:58:20)

```