### PR TITLE
Drop old Node support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ os:
   - linux
   - osx
 node_js:
-  - 6
-  - 8
-  - 9
   - 10
   - 11
   - 12
+  - 13
 env: TEST_SUITE=unit
 matrix:
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,8 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "6"
-    - nodejs_version: "8"
     - nodejs_version: "10"
+    - nodejs_version: "12"
 
 # Install scripts. (runs after repo cloning)
 install:

--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -57,7 +57,7 @@ describe('+ copySync() / file', () => {
       const fileDest = path.join(TEST_DIR, 'TEST_fs-extra_copy')
       fs.writeFileSync(fileSrc, crypto.randomBytes(SIZE))
 
-      fs.chmodSync(fileSrc, parseInt('750', 8))
+      fs.chmodSync(fileSrc, 0o750)
       fs.copySync(fileSrc, fileDest)
 
       const statSrc = fs.statSync(fileSrc)
@@ -187,7 +187,7 @@ describe('+ copySync() / file', () => {
         describe('> when overwrite is true and dest is readonly', () => {
           it('should copy the file and not throw an error', () => {
             try {
-              fs.chmodSync(dest, parseInt('444', 8))
+              fs.chmodSync(dest, 0o444)
               fs.copySync(src, dest, { overwrite: true })
               destData = fs.readFileSync(dest, 'utf8')
               assert.strictEqual(srcData, destData)

--- a/lib/copy-sync/__tests__/copy-sync-preserve-timestamp.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-preserve-timestamp.test.js
@@ -5,16 +5,12 @@ const os = require('os')
 const path = require('path')
 const utimes = require('../../util/utimes')
 const assert = require('assert')
-const semver = require('semver')
-const nodeVersion = process.version
-const nodeVersionMajor = semver.major(nodeVersion)
 
 /* global beforeEach, afterEach, describe, it */
 
 if (process.arch === 'ia32') console.warn('32 bit arch; skipping copySync timestamp tests')
-if (nodeVersionMajor < 8) console.warn(`old node version (v${nodeVersion}); skipping copySync timestamp tests`)
 
-const describeIfPractical = (process.arch === 'ia32' || nodeVersionMajor < 8) ? describe.skip : describe
+const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 
 describeIfPractical('copySync() - preserveTimestamps option', () => {
   let TEST_DIR, SRC, DEST, FILES

--- a/lib/copy/__tests__/copy-permissions.test.js
+++ b/lib/copy/__tests__/copy-permissions.test.js
@@ -32,13 +32,13 @@ describe('copy', () => {
 
     try {
       gidWheel = process.getgid() // userid.gid('wheel')
-    } catch (err) {
+    } catch {
       gidWheel = process.getgid()
     }
 
     try {
       gidStaff = process.getgid() // userid.gid('staff')
-    } catch (err) {
+    } catch {
       gidStaff = process.getgid()
     }
 

--- a/lib/copy/__tests__/copy-permissions.test.js
+++ b/lib/copy/__tests__/copy-permissions.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global beforeEach, describe, it */
 
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-const o444 = parseInt('444', 8)
-
 describe('copy', () => {
   let TEST_DIR
 
@@ -27,8 +23,8 @@ describe('copy', () => {
     // var userid = require('userid')
 
     // http://man7.org/linux/man-pages/man2/stat.2.html
-    const S_IFREG = parseInt('0100000', 8) // regular file
-    const S_IFDIR = parseInt('0040000', 8) // directory
+    const S_IFREG = 0o100000 // regular file
+    const S_IFDIR = 0o40000 // directory
 
     // these are Mac specific I think (at least staff), should find Linux equivalent
     let gidWheel
@@ -54,31 +50,31 @@ describe('copy', () => {
 
     const f1 = path.join(srcDir, 'f1.txt')
     fs.writeFileSync(f1, '')
-    fs.chmodSync(f1, o666)
+    fs.chmodSync(f1, 0o666)
     fs.chownSync(f1, process.getuid(), gidWheel)
     const f1stats = fs.lstatSync(f1)
-    assert.strictEqual(f1stats.mode - S_IFREG, o666)
+    assert.strictEqual(f1stats.mode - S_IFREG, 0o666)
 
     const d1 = path.join(srcDir, 'somedir')
     fs.mkdirSync(d1)
-    fs.chmodSync(d1, o777)
+    fs.chmodSync(d1, 0o777)
     fs.chownSync(d1, process.getuid(), gidStaff)
     const d1stats = fs.lstatSync(d1)
-    assert.strictEqual(d1stats.mode - S_IFDIR, o777)
+    assert.strictEqual(d1stats.mode - S_IFDIR, 0o777)
 
     const f2 = path.join(d1, 'f2.bin')
     fs.writeFileSync(f2, '')
-    fs.chmodSync(f2, o777)
+    fs.chmodSync(f2, 0o777)
     fs.chownSync(f2, process.getuid(), gidStaff)
     const f2stats = fs.lstatSync(f2)
-    assert.strictEqual(f2stats.mode - S_IFREG, o777)
+    assert.strictEqual(f2stats.mode - S_IFREG, 0o777)
 
     const d2 = path.join(srcDir, 'crazydir')
     fs.mkdirSync(d2)
-    fs.chmodSync(d2, o444)
+    fs.chmodSync(d2, 0o444)
     fs.chownSync(d2, process.getuid(), gidWheel)
     const d2stats = fs.lstatSync(d2)
-    assert.strictEqual(d2stats.mode - S_IFDIR, o444)
+    assert.strictEqual(d2stats.mode - S_IFDIR, 0o444)
 
     const destDir = path.join(permDir, 'dest')
     fse.copy(srcDir, destDir, err => {

--- a/lib/copy/__tests__/copy-preserve-timestamp.test.js
+++ b/lib/copy/__tests__/copy-preserve-timestamp.test.js
@@ -6,16 +6,12 @@ const path = require('path')
 const copy = require('../copy')
 const utimes = require('../../util/utimes')
 const assert = require('assert')
-const semver = require('semver')
-const nodeVersion = process.version
-const nodeVersionMajor = semver.major(nodeVersion)
 
 /* global beforeEach, afterEach, describe, it */
 
 if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
-if (nodeVersionMajor < 8) console.warn(`old node version (v${nodeVersion}); skipping copy timestamp tests`)
 
-const describeIfPractical = (process.arch === 'ia32' || nodeVersionMajor < 8) ? describe.skip : describe
+const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 
 describeIfPractical('copy() - preserve timestamp', () => {
   let TEST_DIR, SRC, DEST, FILES

--- a/lib/copy/__tests__/ncp/ncp-error-perm.test.js
+++ b/lib/copy/__tests__/ncp/ncp-error-perm.test.js
@@ -37,7 +37,7 @@ describe('ncp / error / dest-permission', () => {
     fse.outputFileSync(someFile, 'hello')
 
     fse.mkdirsSync(dest)
-    fs.chmodSync(dest, parseInt('444', 8))
+    fs.chmodSync(dest, 0o444)
 
     const subdest = path.join(dest, 'another-dir')
 

--- a/lib/empty/index.js
+++ b/lib/empty/index.js
@@ -30,7 +30,7 @@ function emptyDirSync (dir) {
   let items
   try {
     items = fs.readdirSync(dir)
-  } catch (err) {
+  } catch {
     return mkdir.mkdirsSync(dir)
   }
 

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -44,7 +44,7 @@ function createFileSync (file) {
   let stats
   try {
     stats = fs.statSync(file)
-  } catch (e) {}
+  } catch {}
   if (stats && stats.isFile()) return
 
   const dir = path.dirname(file)

--- a/lib/ensure/symlink-type.js
+++ b/lib/ensure/symlink-type.js
@@ -19,7 +19,7 @@ function symlinkTypeSync (srcpath, type) {
   if (type) return type
   try {
     stats = fs.lstatSync(srcpath)
-  } catch (e) {
+  } catch {
     return 'file'
   }
   return (stats && stats.isDirectory()) ? 'dir' : 'file'

--- a/lib/fs/__tests__/copyFile.test.js
+++ b/lib/fs/__tests__/copyFile.test.js
@@ -1,33 +1,29 @@
 'use strict'
 
 const os = require('os')
-const fs = require('fs')
 const fse = require('../..')
 const path = require('path')
 const assert = require('assert')
 
 /* eslint-env mocha */
 
-// Only availible in Node 8.5+
-if (typeof fs.copyFile === 'function') {
-  describe('fs.copyFile', () => {
-    let TEST_DIR
+describe('fs.copyFile', () => {
+  let TEST_DIR
 
-    beforeEach(done => {
-      TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'fs-copyfile')
-      fse.emptyDir(TEST_DIR, done)
-    })
+  beforeEach(done => {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'fs-copyfile')
+    fse.emptyDir(TEST_DIR, done)
+  })
 
-    afterEach(done => fse.remove(TEST_DIR, done))
+  afterEach(done => fse.remove(TEST_DIR, done))
 
-    it('supports promises', () => {
-      const src = path.join(TEST_DIR, 'init.txt')
-      const dest = path.join(TEST_DIR, 'copy.txt')
-      fse.writeFileSync(src, 'hello')
-      return fse.copyFile(src, dest).then(() => {
-        const data = fse.readFileSync(dest, 'utf8')
-        assert.strictEqual(data, 'hello')
-      })
+  it('supports promises', () => {
+    const src = path.join(TEST_DIR, 'init.txt')
+    const dest = path.join(TEST_DIR, 'copy.txt')
+    fse.writeFileSync(src, 'hello')
+    return fse.copyFile(src, dest).then(() => {
+      const data = fse.readFileSync(dest, 'utf8')
+      assert.strictEqual(data, 'hello')
     })
   })
-}
+})

--- a/lib/fs/__tests__/fs-integration.test.js
+++ b/lib/fs/__tests__/fs-integration.test.js
@@ -26,9 +26,7 @@ describe('native fs', () => {
   })
 
   it('should have native fs constants', () => {
-    // Node.js v0.12 / IO.js
-    if ('F_OK' in fs) {
-      assert.strictEqual(fse.F_OK, fs.F_OK)
-    }
+    assert.strictEqual(fse.constants.F_OK, fs.constants.F_OK)
+    assert.strictEqual(fse.F_OK, fs.F_OK) // soft deprecated usage, but still available
   })
 })

--- a/lib/fs/__tests__/multi-param.test.js
+++ b/lib/fs/__tests__/multi-param.test.js
@@ -9,8 +9,6 @@ const fs = require('../..')
 
 const SIZE = 1000
 
-// Used for tests on Node 7.2.0+ only
-const onNode7it = semver.gte(process.version, '7.2.0') ? it : it.skip
 // Used for tests on Node 12.9.0+ only
 const describeNode12 = semver.gte(process.version, '12.9.0') ? describe : describe.skip
 
@@ -102,7 +100,7 @@ describe('fs.write()', () => {
         })
     })
 
-    onNode7it('returns an object when minimal arguments are passed', () => {
+    it('returns an object when minimal arguments are passed', () => {
       return fs.write(TEST_FD, TEST_DATA)
         .then(results => {
           const bytesWritten = results.bytesWritten
@@ -134,7 +132,7 @@ describe('fs.write()', () => {
       })
     })
 
-    onNode7it('works when minimal arguments are passed', done => {
+    it('works when minimal arguments are passed', done => {
       fs.write(TEST_FD, TEST_DATA, (err, bytesWritten, buffer) => {
         assert.ifError(err)
         assert.strictEqual(bytesWritten, SIZE, 'bytesWritten is correct')

--- a/lib/fs/__tests__/realpath.test.js
+++ b/lib/fs/__tests__/realpath.test.js
@@ -1,33 +1,29 @@
 'use strict'
 
-const fs = require('fs')
 const fse = require('../..')
 const assert = require('assert')
 
 /* eslint-env mocha */
 
-// fs.realpath.native only available in Node v9.2+
-if (typeof fs.realpath.native === 'function') {
-  describe('realpath.native', () => {
-    it('works with callbacks', () => {
-      fse.realpath.native(__dirname, (err, path) => {
-        assert.ifError(err)
-        assert.strictEqual(path, __dirname)
-      })
-    })
-
-    it('works with promises', (done) => {
-      fse.realpath.native(__dirname)
-        .then(path => {
-          assert.strictEqual(path, __dirname)
-          done()
-        })
-        .catch(done)
-    })
-
-    it('works with sync version', () => {
-      const path = fse.realpathSync.native(__dirname)
+describe('realpath.native', () => {
+  it('works with callbacks', () => {
+    fse.realpath.native(__dirname, (err, path) => {
+      assert.ifError(err)
       assert.strictEqual(path, __dirname)
     })
   })
-}
+
+  it('works with promises', (done) => {
+    fse.realpath.native(__dirname)
+      .then(path => {
+        assert.strictEqual(path, __dirname)
+        done()
+      })
+      .catch(done)
+  })
+
+  it('works with sync version', () => {
+    const path = fse.realpathSync.native(__dirname)
+    assert.strictEqual(path, __dirname)
+  })
+})

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -41,8 +41,6 @@ const api = [
 ].filter(key => {
   // Some commands are not available on some systems. Ex:
   // fs.opendir was added in Node.js v12.12.0
-  // fs.copyFile was added in Node.js v8.5.0
-  // fs.mkdtemp was added in Node.js v5.10.0
   // fs.lchown is not available on at least some Linux
   return typeof fs[key] === 'function'
 })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,22 +1,21 @@
 'use strict'
 
-module.exports = Object.assign(
-  {},
+module.exports = {
   // Export promiseified graceful-fs:
-  require('./fs'),
+  ...require('./fs'),
   // Export extra methods:
-  require('./copy-sync'),
-  require('./copy'),
-  require('./empty'),
-  require('./ensure'),
-  require('./json'),
-  require('./mkdirs'),
-  require('./move-sync'),
-  require('./move'),
-  require('./output'),
-  require('./path-exists'),
-  require('./remove')
-)
+  ...require('./copy-sync'),
+  ...require('./copy'),
+  ...require('./empty'),
+  ...require('./ensure'),
+  ...require('./json'),
+  ...require('./mkdirs'),
+  ...require('./move-sync'),
+  ...require('./move'),
+  ...require('./output'),
+  ...require('./path-exists'),
+  ...require('./remove')
+}
 
 // Export fs.promises as a getter property so that we don't trigger
 // ExperimentalWarning before fs.promises is actually accessed.

--- a/lib/mkdirs/__tests__/chmod.test.js
+++ b/lib/mkdirs/__tests__/chmod.test.js
@@ -8,11 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o744 = parseInt('744', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / chmod', () => {
   let TEST_DIR
   let TEST_SUBDIR
@@ -35,7 +30,7 @@ describe('mkdirp / chmod', () => {
   afterEach(done => fse.remove(TEST_DIR, done))
 
   it('chmod-pre', done => {
-    const mode = o744
+    const mode = 0o744
     fse.mkdirp(TEST_SUBDIR, mode, err => {
       assert.ifError(err, 'should not error')
       fs.stat(TEST_SUBDIR, (err, stat) => {
@@ -43,9 +38,9 @@ describe('mkdirp / chmod', () => {
         assert.ok(stat && stat.isDirectory(), 'should be directory')
 
         if (os.platform().indexOf('win') === 0) {
-          assert.strictEqual(stat && stat.mode & o777, o666, 'windows shit')
+          assert.strictEqual(stat && stat.mode & 0o777, 0o666, 'windows shit')
         } else {
-          assert.strictEqual(stat && stat.mode & o777, mode, 'should be 0744')
+          assert.strictEqual(stat && stat.mode & 0o777, mode, 'should be 0744')
         }
 
         done()
@@ -54,7 +49,7 @@ describe('mkdirp / chmod', () => {
   })
 
   it('chmod', done => {
-    const mode = o755
+    const mode = 0o755
     fse.mkdirp(TEST_SUBDIR, mode, err => {
       assert.ifError(err, 'should not error')
       fs.stat(TEST_SUBDIR, (err, stat) => {

--- a/lib/mkdirs/__tests__/clobber.test.js
+++ b/lib/mkdirs/__tests__/clobber.test.js
@@ -8,8 +8,6 @@ const assert = require('assert')
 
 /* global before, describe, it */
 
-const o755 = parseInt('755', 8)
-
 describe('mkdirp / clobber', () => {
   let TEST_DIR
   let file
@@ -42,7 +40,7 @@ describe('mkdirp / clobber', () => {
   })
 
   it('should clobber', done => {
-    fse.mkdirp(file, o755, err => {
+    fse.mkdirp(file, 0o755, err => {
       assert.ok(err)
       if (os.platform().indexOf('win') === 0) {
         assert.strictEqual(err.code, 'EEXIST')

--- a/lib/mkdirs/__tests__/issue-209.test.js
+++ b/lib/mkdirs/__tests__/issue-209.test.js
@@ -30,8 +30,7 @@ describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error
       try {
         const file = 'c:\\tmp\foo:moo'
         fse.mkdirpSync(file)
-      } catch (err) {
-        // console.error(err)
+      } catch {
         didErr = true
       }
       assert(didErr)

--- a/lib/mkdirs/__tests__/mkdirp.test.js
+++ b/lib/mkdirs/__tests__/mkdirp.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / mkdirp', () => {
   let TEST_DIR
 
@@ -29,7 +25,7 @@ describe('mkdirp / mkdirp', () => {
 
     const file = path.join(TEST_DIR, x, y, z)
 
-    fse.mkdirp(file, o755, err => {
+    fse.mkdirp(file, 0o755, err => {
       assert.ifError(err)
       fse.pathExists(file, (err, ex) => {
         assert.ifError(err)
@@ -38,9 +34,9 @@ describe('mkdirp / mkdirp', () => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.strictEqual(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & 0o777, 0o666)
           } else {
-            assert.strictEqual(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & 0o777, 0o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/perm.test.js
+++ b/lib/mkdirs/__tests__/perm.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / perm', () => {
   let TEST_DIR
 
@@ -25,7 +21,7 @@ describe('mkdirp / perm', () => {
   it('async perm', done => {
     const file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16))
 
-    fse.mkdirp(file, o755, err => {
+    fse.mkdirp(file, 0o755, err => {
       assert.ifError(err)
       fse.pathExists(file, (err, ex) => {
         assert.ifError(err)
@@ -34,9 +30,9 @@ describe('mkdirp / perm', () => {
           assert.ifError(err)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.strictEqual(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & 0o777, 0o666)
           } else {
-            assert.strictEqual(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & 0o777, 0o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')
@@ -47,7 +43,7 @@ describe('mkdirp / perm', () => {
   })
 
   it('async root perm', done => {
-    fse.mkdirp(path.join(os.tmpdir(), 'tmp'), o755, err => {
+    fse.mkdirp(path.join(os.tmpdir(), 'tmp'), 0o755, err => {
       assert.ifError(err)
       done()
     })

--- a/lib/mkdirs/__tests__/perm_sync.test.js
+++ b/lib/mkdirs/__tests__/perm_sync.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / perm_sync', () => {
   let TEST_DIR
 
@@ -25,7 +21,7 @@ describe('mkdirp / perm_sync', () => {
   it('sync perm', done => {
     const file = path.join(TEST_DIR, (Math.random() * (1 << 30)).toString(16) + '.json')
 
-    fse.mkdirpSync(file, o755)
+    fse.mkdirpSync(file, 0o755)
     fse.pathExists(file, (err, ex) => {
       assert.ifError(err)
       assert.ok(ex, 'file created')
@@ -33,9 +29,9 @@ describe('mkdirp / perm_sync', () => {
         assert.ifError(err)
 
         if (os.platform().indexOf('win') === 0) {
-          assert.strictEqual(stat.mode & o777, o666)
+          assert.strictEqual(stat.mode & 0o777, 0o666)
         } else {
-          assert.strictEqual(stat.mode & o777, o755)
+          assert.strictEqual(stat.mode & 0o777, 0o755)
         }
 
         assert.ok(stat.isDirectory(), 'target not a directory')
@@ -46,7 +42,7 @@ describe('mkdirp / perm_sync', () => {
 
   it('sync root perm', done => {
     const file = TEST_DIR
-    fse.mkdirpSync(file, o755)
+    fse.mkdirpSync(file, 0o755)
     fse.pathExists(file, (err, ex) => {
       assert.ifError(err)
       assert.ok(ex, 'file created')

--- a/lib/mkdirs/__tests__/race.test.js
+++ b/lib/mkdirs/__tests__/race.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / race', () => {
   let TEST_DIR
   let file
@@ -42,7 +38,7 @@ describe('mkdirp / race', () => {
     mk(file, () => --res === 0 ? done() : undefined)
 
     function mk (file, callback) {
-      fse.mkdirp(file, o755, err => {
+      fse.mkdirp(file, 0o755, err => {
         assert.ifError(err)
         fse.pathExists(file, (err, ex) => {
           assert.ifError(err)
@@ -51,9 +47,9 @@ describe('mkdirp / race', () => {
             assert.ifError(err)
 
             if (os.platform().indexOf('win') === 0) {
-              assert.strictEqual(stat.mode & o777, o666)
+              assert.strictEqual(stat.mode & 0o777, 0o666)
             } else {
-              assert.strictEqual(stat.mode & o777, o755)
+              assert.strictEqual(stat.mode & 0o777, 0o755)
             }
 
             assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/rel.test.js
+++ b/lib/mkdirs/__tests__/rel.test.js
@@ -10,10 +10,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / relative', () => {
   let TEST_DIR
   let file
@@ -39,7 +35,7 @@ describe('mkdirp / relative', () => {
   it('should make the directory with relative path', done => {
     process.chdir(TEST_DIR)
 
-    fse.mkdirp(file, o755, err => {
+    fse.mkdirp(file, 0o755, err => {
       assert.ifError(err)
       fse.pathExists(file, (err, ex) => {
         assert.ifError(err)
@@ -50,9 +46,9 @@ describe('mkdirp / relative', () => {
           process.chdir(CWD)
 
           if (os.platform().indexOf('win') === 0) {
-            assert.strictEqual(stat.mode & o777, o666)
+            assert.strictEqual(stat.mode & 0o777, 0o666)
           } else {
-            assert.strictEqual(stat.mode & o777, o755)
+            assert.strictEqual(stat.mode & 0o777, 0o755)
           }
 
           assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/root.test.js
+++ b/lib/mkdirs/__tests__/root.test.js
@@ -7,8 +7,6 @@ const assert = require('assert')
 
 /* global describe, it */
 
-const o755 = parseInt('755', 8)
-
 describe('mkdirp / root', () => {
   // '/' on unix, 'c:/' on windows.
   const dir = path.normalize(path.resolve(path.sep)).toLowerCase()
@@ -17,7 +15,7 @@ describe('mkdirp / root', () => {
   if (process.platform === 'win32' && (dir.indexOf('c:\\') === -1) && (dir.indexOf('d:\\') === -1)) return
 
   it('should', done => {
-    fse.mkdirp(dir, o755, err => {
+    fse.mkdirp(dir, 0o755, err => {
       if (err) throw err
       fs.stat(dir, (er, stat) => {
         if (er) throw er

--- a/lib/mkdirs/__tests__/sync.test.js
+++ b/lib/mkdirs/__tests__/sync.test.js
@@ -8,10 +8,6 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o755 = parseInt('755', 8)
-const o777 = parseInt('777', 8)
-const o666 = parseInt('666', 8)
-
 describe('mkdirp / sync', () => {
   let TEST_DIR
   let file
@@ -35,7 +31,7 @@ describe('mkdirp / sync', () => {
 
   it('should', done => {
     try {
-      fse.mkdirpSync(file, o755)
+      fse.mkdirpSync(file, 0o755)
     } catch (err) {
       assert.fail(err)
     }
@@ -47,9 +43,9 @@ describe('mkdirp / sync', () => {
         assert.ifError(err)
         // http://stackoverflow.com/questions/592448/c-how-to-set-file-permissions-cross-platform
         if (os.platform().indexOf('win') === 0) {
-          assert.strictEqual(stat.mode & o777, o666)
+          assert.strictEqual(stat.mode & 0o777, 0o666)
         } else {
-          assert.strictEqual(stat.mode & o777, o755)
+          assert.strictEqual(stat.mode & 0o777, 0o755)
         }
 
         assert.ok(stat.isDirectory(), 'target not a directory')

--- a/lib/mkdirs/__tests__/umask.test.js
+++ b/lib/mkdirs/__tests__/umask.test.js
@@ -8,8 +8,6 @@ const fse = require('../../')
 
 /* global afterEach, beforeEach, describe, it */
 
-const o777 = parseInt('777', 8)
-
 describe('mkdirp', () => {
   let TEST_DIR
   let _rndDir
@@ -47,7 +45,7 @@ describe('mkdirp', () => {
             assert.ok(ex, 'file created')
             fs.stat(_rndDir, (err, stat) => {
               assert.ifError(err)
-              assert.strictEqual(stat.mode & o777, o777 & (~process.umask()))
+              assert.strictEqual(stat.mode & 0o777, 0o777 & (~process.umask()))
               assert.ok(stat.isDirectory(), 'target not a directory')
               done()
             })
@@ -71,7 +69,7 @@ describe('mkdirp', () => {
           assert.ok(ex, 'file created')
           fs.stat(_rndDir, (err, stat) => {
             assert.ifError(err)
-            assert.strictEqual(stat.mode & o777, (o777 & (~process.umask())))
+            assert.strictEqual(stat.mode & 0o777, (0o777 & (~process.umask())))
             assert.ok(stat.isDirectory(), 'target not a directory')
             done()
           })

--- a/lib/mkdirs/mkdirs-sync.js
+++ b/lib/mkdirs/mkdirs-sync.js
@@ -28,9 +28,9 @@ function mkdirsSync (p, opts, made) {
   try {
     xfs.mkdirSync(p, mode)
     made = made || p
-  } catch (err0) {
-    if (err0.code === 'ENOENT') {
-      if (path.dirname(p) === p) throw err0
+  } catch (err) {
+    if (err.code === 'ENOENT') {
+      if (path.dirname(p) === p) throw err
       made = mkdirsSync(path.dirname(p), opts, made)
       mkdirsSync(p, opts, made)
     } else {
@@ -39,10 +39,10 @@ function mkdirsSync (p, opts, made) {
       let stat
       try {
         stat = xfs.statSync(p)
-      } catch (err1) {
-        throw err0
+      } catch {
+        throw err
       }
-      if (!stat.isDirectory()) throw err0
+      if (!stat.isDirectory()) throw err
     }
   }
 

--- a/lib/mkdirs/mkdirs-sync.js
+++ b/lib/mkdirs/mkdirs-sync.js
@@ -4,8 +4,6 @@ const fs = require('graceful-fs')
 const path = require('path')
 const invalidWin32Path = require('./win32').invalidWin32Path
 
-const o777 = parseInt('0777', 8)
-
 function mkdirsSync (p, opts, made) {
   if (!opts || typeof opts !== 'object') {
     opts = { mode: opts }
@@ -21,7 +19,7 @@ function mkdirsSync (p, opts, made) {
   }
 
   if (mode === undefined) {
-    mode = o777 & (~process.umask())
+    mode = 0o777 & (~process.umask())
   }
   if (!made) made = null
 

--- a/lib/mkdirs/mkdirs.js
+++ b/lib/mkdirs/mkdirs.js
@@ -4,8 +4,6 @@ const fs = require('graceful-fs')
 const path = require('path')
 const invalidWin32Path = require('./win32').invalidWin32Path
 
-const o777 = parseInt('0777', 8)
-
 function mkdirs (p, opts, callback, made) {
   if (typeof opts === 'function') {
     callback = opts
@@ -24,7 +22,7 @@ function mkdirs (p, opts, callback, made) {
   const xfs = opts.fs || fs
 
   if (mode === undefined) {
-    mode = o777 & (~process.umask())
+    mode = 0o777 & (~process.umask())
   }
   if (!made) made = null
 

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -281,7 +281,7 @@ describe('moveSync()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch (err) {
+    } catch {
       console.log("Can't write to device. Skipping moveSync test.")
       __skipTests = true
     }

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -324,7 +324,7 @@ describe('+ move()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch (err) {
+    } catch {
       console.log("Can't write to device. Skipping move test.")
       __skipTests = true
     }

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -302,7 +302,7 @@ function rmkidsSync (p, options) {
       try {
         const ret = options.rmdirSync(p, options)
         return ret
-      } catch (er) { }
+      } catch {}
     } while (Date.now() - startTime < 500) // give up after 500ms
   } else {
     const ret = options.rmdirSync(p, options)

--- a/lib/util/buffer.js
+++ b/lib/util/buffer.js
@@ -4,7 +4,7 @@ module.exports = function (size) {
   if (typeof Buffer.allocUnsafe === 'function') {
     try {
       return Buffer.allocUnsafe(size)
-    } catch (e) {
+    } catch {
       return new Buffer(size)
     }
   }

--- a/lib/util/utimes.js
+++ b/lib/util/utimes.js
@@ -4,7 +4,7 @@ const fs = require('graceful-fs')
 const os = require('os')
 const path = require('path')
 
-// HFS, ext{2,3}, FAT do not, Node.js v0.10 does not
+// HFS, ext{2,3}, FAT do not
 function hasMillisResSync () {
   let tmpfile = path.join('millis-test-sync' + Date.now().toString() + Math.random().toString().slice(2))
   tmpfile = path.join(os.tmpdir(), tmpfile)

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "8.1.0",
   "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as mkdir -p, cp -r, and rm -rf.",
   "engines": {
-    "node": ">=6 <7 || >=8"
+    "node": ">=10"
   },
   "homepage": "https://github.com/jprichardson/node-fs-extra",
   "repository": {

--- a/test.js
+++ b/test.js
@@ -7,11 +7,12 @@ const Mocha = require('mocha')
 
 const argv = require('minimist')(process.argv.slice(2))
 
-const mochaOpts = Object.assign({
+const mochaOpts = {
   ui: 'bdd',
   reporter: 'dot',
-  timeout: 30000
-}, argv)
+  timeout: 30000,
+  ...argv
+}
 
 const mocha = new Mocha(mochaOpts)
 const testExt = '.test.js'


### PR DESCRIPTION
Resolves https://github.com/jprichardson/node-fs-extra/issues/725. Require Node `>=10`; also upgraded some code to use new language features.

~Will probably need rebased after #747 is merged.~ **Done**

Review commit-by-commit for your sanity.