### PR TITLE
Don't generate package-lock.json; instead of just ignoring it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 .nyc_output/
 coverage/
 node_modules/
-package-lock.json
 
 .idea
 *.iml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false


### PR DESCRIPTION
Lockfiles are an anti-pattern for libraries; we don't check ours into git, but it's preferable not to even use one.