### PR TITLE
catch => catch(error)

### DIFF
--- a/lib/mkdirs/make-dir.js
+++ b/lib/mkdirs/make-dir.js
@@ -83,7 +83,7 @@ module.exports.makeDir = async (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch(error) {
         throw error
       }
     }
@@ -132,7 +132,7 @@ module.exports.makeDirSync = (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch(error) {
         throw error
       }
     }


### PR DESCRIPTION
Fixes error in catching error

`      } catch {
              ^
SyntaxError: Unexpected token {
`