### PR TITLE
Docs: add hint for supported Node.js version

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,5 +1,6 @@
 <!-- First ensure you installed the latest version of fs-extra -->
 <!-- If your bug still exists please fill out the following information if it applies to your issue: -->
 - **Operating System:**
+<!-- Please check if you have installed a supported version of Node.js as written in "engines" in the package.json -->
 - **Node.js version:**
 - **`fs-extra` version:**


### PR DESCRIPTION
As a lot of bugs just came in with the wrong Node version I added a small hint