### PR TITLE
Add `(e)` to catch blocks

### DIFF
--- a/lib/copy/__tests__/copy-permissions.test.js
+++ b/lib/copy/__tests__/copy-permissions.test.js
@@ -32,13 +32,13 @@ describe('copy', () => {
 
     try {
       gidWheel = process.getgid() // userid.gid('wheel')
-    } catch {
+    } catch (e) {
       gidWheel = process.getgid()
     }
 
     try {
       gidStaff = process.getgid() // userid.gid('staff')
-    } catch {
+    } catch (e) {
       gidStaff = process.getgid()
     }
 

--- a/lib/empty/index.js
+++ b/lib/empty/index.js
@@ -30,7 +30,7 @@ function emptyDirSync (dir) {
   let items
   try {
     items = fs.readdirSync(dir)
-  } catch {
+  } catch (e) {
     return mkdir.mkdirsSync(dir)
   }
 

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -44,7 +44,7 @@ function createFileSync (file) {
   let stats
   try {
     stats = fs.statSync(file)
-  } catch {}
+  } catch (e) {}
   if (stats && stats.isFile()) return
 
   const dir = path.dirname(file)

--- a/lib/ensure/symlink-type.js
+++ b/lib/ensure/symlink-type.js
@@ -19,7 +19,7 @@ function symlinkTypeSync (srcpath, type) {
   if (type) return type
   try {
     stats = fs.lstatSync(srcpath)
-  } catch {
+  } catch (e) {
     return 'file'
   }
   return (stats && stats.isDirectory()) ? 'dir' : 'file'

--- a/lib/mkdirs/__tests__/issue-209.test.js
+++ b/lib/mkdirs/__tests__/issue-209.test.js
@@ -30,7 +30,7 @@ describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error
       try {
         const file = 'c:\\tmp\foo:moo'
         fse.mkdirpSync(file)
-      } catch {
+      } catch (e) {
         didErr = true
       }
       assert(didErr)

--- a/lib/mkdirs/make-dir.js
+++ b/lib/mkdirs/make-dir.js
@@ -82,7 +82,7 @@ module.exports.makeDir = async (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch (e) {
         throw error
       }
     }
@@ -131,7 +131,7 @@ module.exports.makeDirSync = (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch (e) {
         throw error
       }
     }

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -281,7 +281,7 @@ describe('moveSync()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch {
+    } catch (e) {
       console.log("Can't write to device. Skipping moveSync test.")
       __skipTests = true
     }

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -324,7 +324,7 @@ describe('+ move()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch {
+    } catch (e) {
       console.log("Can't write to device. Skipping move test.")
       __skipTests = true
     }

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -302,7 +302,7 @@ function rmkidsSync (p, options) {
       try {
         const ret = options.rmdirSync(p, options)
         return ret
-      } catch {}
+      } catch (e) {}
     } while (Date.now() - startTime < 500) // give up after 500ms
   } else {
     const ret = options.rmdirSync(p, options)


### PR DESCRIPTION
**I know node v8 is not in the list of engines.**
Nevertheless, this _very minor fix_ avoids failing on node v8, where everything else works perfectly.

Basically, it’s just adding the `(e)` on `catch` blocks which don’t specify an exception var.

```js
try {
  // ...
} catch (e) {}
```

This package is the only one failing on a _very lightweight project_, and my team finds it painful to download multiple node versions across projects (I don’t mind using NVM, but it’s still a lot of extra download)…

It would be very kind of you to integrate this small change.