### PR TITLE
Error when unknown file type is encountered

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -47,6 +47,7 @@ function getStats (destStat, src, dest, opts) {
            srcStat.isCharacterDevice() ||
            srcStat.isBlockDevice()) return onFile(srcStat, destStat, src, dest, opts)
   else if (srcStat.isSymbolicLink()) return onLink(destStat, src, dest, opts)
+  else { cb(new Error(`Unknown file: ${src}`)) }
 }
 
 function onFile (srcStat, destStat, src, dest, opts) {

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -72,6 +72,7 @@ function getStats (destStat, src, dest, opts, cb) {
              srcStat.isCharacterDevice() ||
              srcStat.isBlockDevice()) return onFile(srcStat, destStat, src, dest, opts, cb)
     else if (srcStat.isSymbolicLink()) return onLink(destStat, src, dest, opts, cb)
+    else { cb(new Error(`Unknown file: ${src}`)) }
   })
 }
 


### PR DESCRIPTION
fs.copy was silently exiting when a socket was encountered in my
directory. This prevents silent failure so the user can deal with using
fs.copy appropriately.