### PR TITLE
Docs: add fse-cli to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,9 @@ They were removed from `fs-extra` in v2.0.0. If you need the functionality, `wal
 Third Party
 -----------
 
+### CLI
+
+[fse-cli](https://www.npmjs.com/package/@atao60/fse-cli) allows you to run `fs-extra` from a console or from [npm](https://www.npmjs.com) scripts.
 
 ### TypeScript
 


### PR DESCRIPTION
Add a link to npm package [fse-cli](https://www.npmjs.com/package/@atao60/fse-cli), a CLI for fs-extra. Not all fs-extra functions are embedded yet, but those available are fully functional and tested.