### PR TITLE
Fix syntax errors that will cause SyntaxError: Unexpected token

### DIFF
--- a/lib/copy/__tests__/copy-permissions.test.js
+++ b/lib/copy/__tests__/copy-permissions.test.js
@@ -32,13 +32,13 @@ describe('copy', () => {
 
     try {
       gidWheel = process.getgid() // userid.gid('wheel')
-    } catch {
+    } catch (error) {
       gidWheel = process.getgid()
     }
 
     try {
       gidStaff = process.getgid() // userid.gid('staff')
-    } catch {
+    } catch (error) {
       gidStaff = process.getgid()
     }
 

--- a/lib/empty/index.js
+++ b/lib/empty/index.js
@@ -30,7 +30,7 @@ function emptyDirSync (dir) {
   let items
   try {
     items = fs.readdirSync(dir)
-  } catch {
+} catch (error) {
     return mkdir.mkdirsSync(dir)
   }
 

--- a/lib/ensure/file.js
+++ b/lib/ensure/file.js
@@ -44,7 +44,7 @@ function createFileSync (file) {
   let stats
   try {
     stats = fs.statSync(file)
-  } catch {}
+  } catch (error) {}
   if (stats && stats.isFile()) return
 
   const dir = path.dirname(file)

--- a/lib/ensure/symlink-type.js
+++ b/lib/ensure/symlink-type.js
@@ -19,7 +19,7 @@ function symlinkTypeSync (srcpath, type) {
   if (type) return type
   try {
     stats = fs.lstatSync(srcpath)
-  } catch {
+  } catch (error) {
     return 'file'
   }
   return (stats && stats.isDirectory()) ? 'dir' : 'file'

--- a/lib/mkdirs/__tests__/issue-209.test.js
+++ b/lib/mkdirs/__tests__/issue-209.test.js
@@ -30,7 +30,7 @@ describe('mkdirp: issue-209, win32, when bad path, should return a cleaner error
       try {
         const file = 'c:\\tmp\foo:moo'
         fse.mkdirpSync(file)
-      } catch {
+      } catch (error) {
         didErr = true
       }
       assert(didErr)

--- a/lib/mkdirs/make-dir.js
+++ b/lib/mkdirs/make-dir.js
@@ -82,7 +82,7 @@ module.exports.makeDir = async (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch (error) {
         throw error
       }
     }
@@ -131,7 +131,7 @@ module.exports.makeDirSync = (input, options) => {
           // it is caught below, and the original error is thrown
           throw new Error('The path is not a directory')
         }
-      } catch {
+      } catch (error) {
         throw error
       }
     }

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -281,7 +281,7 @@ describe('moveSync()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch {
+    } catch (error) {
       console.log("Can't write to device. Skipping moveSync test.")
       __skipTests = true
     }

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -324,7 +324,7 @@ describe('+ move()', () => {
     // make sure we have permission on device
     try {
       fs.writeFileSync(path.join(differentDevice, 'file'), 'hi')
-    } catch {
+    } catch (error) {
       console.log("Can't write to device. Skipping move test.")
       __skipTests = true
     }

--- a/lib/remove/rimraf.js
+++ b/lib/remove/rimraf.js
@@ -290,7 +290,7 @@ function rmkidsSync (p, options) {
       try {
         const ret = options.rmdirSync(p, options)
         return ret
-      } catch {}
+      } catch (error) {}
     } while (Date.now() - startTime < 500) // give up after 500ms
   } else {
     const ret = options.rmdirSync(p, options)


### PR DESCRIPTION
This project is depended by other projects and throws **SyntaxError: Unexpected token** errors while initialisation. For example: [raxjs/rax-scripts](https://github.com/raxjs/rax-scripts). I've added all the misisng `(error)` bits. Examples below:

```
/usr/local/lib/node_modules/rax-cli/node_modules/fs-extra/lib/mkdirs/make-dir.js:85
      } catch {
              ^
SyntaxError: Unexpected token {
```

```
/usr/local/lib/node_modules/rax-cli/node_modules/fs-extra/lib/mkdirs/make-dir.js:134
      } catch {
              ^
SyntaxError: Unexpected token {
```