### PR TITLE
test: fix birthtime not available on tmpfs on Linux

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-dir.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-dir.test.js
@@ -182,7 +182,7 @@ describe('+ copySync() / dir', () => {
     it('should apply filter when it is applied only to dest', done => {
       const timeCond = new Date().getTime()
 
-      const filter = (s, d) => fs.statSync(d).birthtime.getTime() < timeCond
+      const filter = (s, d) => fs.statSync(d).mtime.getTime() < timeCond
 
       const dest = path.join(TEST_DIR, 'dest')
 
@@ -197,7 +197,7 @@ describe('+ copySync() / dir', () => {
 
     it('should apply filter when it is applied to both src and dest', done => {
       const timeCond = new Date().getTime()
-      const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).birthtime.getTime() > timeCond
+      const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).mtime.getTime() > timeCond
 
       const dest = path.join(TEST_DIR, 'dest')
 

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -366,7 +366,7 @@ describe('fs-extra', () => {
       it('should apply filter when it is applied only to dest', done => {
         const timeCond = new Date().getTime()
 
-        const filter = (s, d) => fs.statSync(d).birthtime.getTime() < timeCond
+        const filter = (s, d) => fs.statSync(d).mtime.getTime() < timeCond
 
         const src = path.join(TEST_DIR, 'src')
         fse.mkdirsSync(src)
@@ -388,7 +388,7 @@ describe('fs-extra', () => {
 
       it('should apply filter when it is applied to both src and dest', done => {
         const timeCond = new Date().getTime()
-        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).birthtime.getTime() > timeCond
+        const filter = (s, d) => s.split('.').pop() !== 'css' && fs.statSync(path.dirname(d)).mtime.getTime() > timeCond
 
         const dest = path.join(TEST_DIR, 'dest')
         setTimeout(() => {


### PR DESCRIPTION
Fixes tests being broken locally, mentioned in https://github.com/jprichardson/node-fs-extra/pull/860#pullrequestreview-571128655.

Birth time is unavailable on tmpfs:

```console
$ LANG=C stat /tmp/fs-extra/
  File: /tmp/fs-extra/
  Size: 60              Blocks: 0          IO Block: 4096   directory
Device: 31h/49d Inode: 32254       Links: 3
Access: (0755/drwxr-xr-x)  Uid: ( 1000/ chalker)   Gid: ( 1000/ chalker)
Access: 2021-01-19 16:38:51.439969625 +0300
Modify: 2021-01-19 16:38:55.031733100 +0300
Change: 2021-01-19 16:38:55.031733100 +0300
 Birth: -
```