### PR TITLE
Fixes functions outputJSON and pathExists execute callbacks even if there are errors/missing args

### DIFF
--- a/lib/json/__tests__/output-json.test.js
+++ b/lib/json/__tests__/output-json.test.js
@@ -77,5 +77,28 @@ describe('json', () => {
         })
       })
     })
+
+    describe('> exit with error when missing or invalid arguments', () => {
+      it('passing non-string for file should result in error', done => {
+        fse.outputJson(3, {}).catch(err => {
+          assert.strictEqual(err.toString(), 'TypeError: [ERR_INVALID_ARG_TYPE] the "file" argument must be of type string')
+          done()
+        })
+      })
+
+      it('passing non-object for data should result in error', done => {
+        fse.outputJson('file.json', 'bad arg').catch(err => {
+          assert.strictEqual(err.toString(), 'TypeError: [ERR_INVALID_ARG_TYPE] the "data" argument must be of type object')
+          done()
+        })
+      })
+
+      it('passing only a callback argument should result in error', done => {
+        fse.outputJson(() => {}).catch(err => {
+          assert.strictEqual(err.toString(), 'TypeError: [ERR_INVALID_ARG_TYPE] the "file" argument must be of type string')
+          done()
+        })
+      })
+    })
   })
 })

--- a/lib/json/index.js
+++ b/lib/json/index.js
@@ -1,9 +1,8 @@
 'use strict'
 
-const u = require('universalify').fromPromise
 const jsonFile = require('./jsonfile')
 
-jsonFile.outputJson = u(require('./output-json'))
+jsonFile.outputJson = require('./output-json')
 jsonFile.outputJsonSync = require('./output-json-sync')
 // aliases
 jsonFile.outputJSON = jsonFile.outputJson

--- a/lib/json/output-json.js
+++ b/lib/json/output-json.js
@@ -8,7 +8,7 @@ async function outputJson (file, data, options = {}, callback = undefined) {
     throw TypeError('[ERR_INVALID_ARG_TYPE] the "file" argument must be of type string')
   }
   if (typeof data !== 'object') {
-    throw TypeError('[ERR_INVALID_ARG_TYPE] the "data" argument must be a JSON object')
+    throw TypeError('[ERR_INVALID_ARG_TYPE] the "data" argument must be of type object')
   }
 
   // if the options argument is a function and there is no callback argument

--- a/lib/json/output-json.js
+++ b/lib/json/output-json.js
@@ -3,10 +3,28 @@
 const { stringify } = require('jsonfile/utils')
 const { outputFile } = require('../output')
 
-async function outputJson (file, data, options = {}) {
+async function outputJson (file, data, options = {}, callback = undefined) {
+  if (typeof file !== 'string') {
+    throw TypeError('[ERR_INVALID_ARG_TYPE] the "file" argument must be of type string')
+  }
+  if (typeof data !== 'object') {
+    throw TypeError('[ERR_INVALID_ARG_TYPE] the "data" argument must be a JSON object')
+  }
+
+  // if the options argument is a function and there is no callback argument
+  // then the options argument specifies the callback
+  if (typeof options === 'function' && !callback) {
+    callback = options
+    options = {}
+  }
+
   const str = stringify(data, options)
 
-  await outputFile(file, str, options)
+  const res = outputFile(file, str, options)
+  if (callback) {
+    res.then(r => callback(null, r), callback) // this is the fromPromise behaviour
+  }
+  await res
 }
 
 module.exports = outputJson

--- a/lib/path-exists/__tests__/path-exists.test.js
+++ b/lib/path-exists/__tests__/path-exists.test.js
@@ -37,4 +37,10 @@ describe('pathExists()', () => {
       done()
     })
   })
+
+  it('exit with error when missing or invalid file argument', done => {
+    assert.throws(() => fs.pathExists(() => {}), TypeError, '[ERR_INVALID_ARG_TYPE] the "path" argument must be of type string')
+    assert.throws(() => fs.pathExists(), TypeError, '[ERR_INVALID_ARG_TYPE] the "path" argument must be of type string')
+    done()
+  })
 })

--- a/lib/path-exists/index.js
+++ b/lib/path-exists/index.js
@@ -1,12 +1,19 @@
 'use strict'
-const u = require('universalify').fromPromise
 const fs = require('../fs')
 
-function pathExists (path) {
-  return fs.access(path).then(() => true).catch(() => false)
+function pathExists (path, callback = undefined) {
+  if (typeof path !== 'string') {
+    throw TypeError('[ERR_INVALID_ARG_TYPE] the "path" argument must be of type string')
+  }
+  const res = fs.access(path).then(() => true).catch(() => false)
+  if (callback) {
+    res.then(r => callback(null, r), callback) // this is the fromPromise behaviour
+  } else {
+    return res
+  }
 }
 
 module.exports = {
-  pathExists: u(pathExists),
+  pathExists: pathExists,
   pathExistsSync: fs.existsSync
 }


### PR DESCRIPTION
Fixes #865 

And, adds tests for this new error checking.