### PR TITLE
Clarify docs for ensureSymlink() when destPath already exists

### DIFF
--- a/docs/ensureSymlink.md
+++ b/docs/ensureSymlink.md
@@ -1,6 +1,6 @@
 # ensureSymlink(srcPath, destPath[, type][, callback])
 
-Ensures that the symlink exists. If the directory structure does not exist, it is created.
+Ensures that the symlink exists. If the directory structure does not exist, it is created. If `destPath` already exists then it will not be updated, even if it is not a symlink to `srcPath`.
 
 **Alias:** `createSymlink()`
 


### PR DESCRIPTION
The existing docs for `ensureSymlink()` don't specify what happens in the case where `destPath` already exists. Looking at the code it turns out that when `destFile` already exists the function exits without making any modifications, whether or not `destPath` is a symlink to `srcPath`: https://github.com/jprichardson/node-fs-extra/blob/1625838cdfc65a1bbf28ab5fa962a75805629b9c/lib/ensure/symlink.js#L26

I found this behavior surprising, because the function name `ensureSymlink()` sounds like it will ensure that the symlink `destPath -> srcPath` exists. This PR clarifies the existing behavior in the docs.