### PR TITLE
Minor improvement to code quality

### DIFF
--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -98,11 +98,13 @@ function setDestTimestamps (src, dest) {
 }
 
 function onDir (srcStat, destStat, src, dest, opts) {
-  if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts)
-  if (destStat && !destStat.isDirectory()) {
+  if (destStat) {
+    if (destStat.isDirectory()) {
+      return copyDir(src, dest, opts)
+    }
     throw new Error(`Cannot overwrite non-directory '${dest}' with directory '${src}'.`)
   }
-  return copyDir(src, dest, opts)
+  return mkDirAndCopy(srcStat.mode, src, dest, opts)
 }
 
 function mkDirAndCopy (srcMode, src, dest, opts) {

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -142,11 +142,13 @@ function setDestTimestamps (src, dest, cb) {
 }
 
 function onDir (srcStat, destStat, src, dest, opts, cb) {
-  if (!destStat) return mkDirAndCopy(srcStat.mode, src, dest, opts, cb)
-  if (destStat && !destStat.isDirectory()) {
+  if (destStat) {
+    if (destStat.isDirectory()) {
+      return copyDir(src, dest, opts, cb)
+    }
     return cb(new Error(`Cannot overwrite non-directory '${dest}' with directory '${src}'.`))
   }
-  return copyDir(src, dest, opts, cb)
+  return mkDirAndCopy(srcStat.mode, src, dest, opts, cb)
 }
 
 function mkDirAndCopy (srcMode, src, dest, opts, cb) {


### PR DESCRIPTION
Hi :)

This is a minor update to code quality. The expression `destStat` on line `102` and `146` will always return `true`. This is bad code practice and is described in [CWE 571](https://cwe.mitre.org/data/definitions/571.html).

I found this issue while doing a security audit of our dependencies. It's not a big deal but might as well be fixed. I have tried to mimic your existing code style in my rewrite, but feel free to rewrite it in another way.

Let me know if you want me to explain in more detail why this is bad practice.