### PR TITLE
BREAKING: Use fs.rm/rmSync where supported

### DIFF
--- a/lib/remove/index.js
+++ b/lib/remove/index.js
@@ -1,9 +1,22 @@
 'use strict'
 
+const fs = require('graceful-fs')
 const u = require('universalify').fromCallback
 const rimraf = require('./rimraf')
 
+function remove (path, callback) {
+  // Node 14.14.0+
+  if (fs.rm) return fs.rm(path, { recursive: true, force: true }, callback)
+  rimraf(path, callback)
+}
+
+function removeSync (path) {
+  // Node 14.14.0+
+  if (fs.rmSync) return fs.rmSync(path, { recursive: true, force: true })
+  rimraf.sync(path)
+}
+
 module.exports = {
-  remove: u(rimraf),
-  removeSync: rimraf.sync
+  remove: u(remove),
+  removeSync
 }


### PR DESCRIPTION
Fixes #806

Technically a breaking change since this removes the undocumented ability to pass options to remove*()