### PR TITLE
Ensure copy filter fn is not called more than needed

### DIFF
--- a/lib/copy-sync/__tests__/copy-sync-file.test.js
+++ b/lib/copy-sync/__tests__/copy-sync-file.test.js
@@ -104,6 +104,25 @@ describe('+ copySync() / file', () => {
       assert(fs.existsSync(destFile3))
     })
 
+    it('should not call filter fn more than needed', () => {
+      const src = path.join(TEST_DIR, 'foo')
+
+      fs.writeFileSync(src, '')
+
+      const dest = path.join(TEST_DIR, 'bar')
+
+      let filterCallCount = 0
+      const filter = () => {
+        filterCallCount++
+        return true
+      }
+
+      fs.copySync(src, dest, filter)
+
+      assert.strictEqual(filterCallCount, 1)
+      assert(fs.existsSync(dest))
+    })
+
     describe('> when the destination dir does not exist', () => {
       it('should create the destination directory and copy the file', () => {
         const src = path.join(TEST_DIR, 'file.txt')

--- a/lib/copy-sync/copy-sync.js
+++ b/lib/copy-sync/copy-sync.js
@@ -30,7 +30,7 @@ function handleFilterAndCopy (destStat, src, dest, opts) {
   if (opts.filter && !opts.filter(src, dest)) return
   const destParent = path.dirname(dest)
   if (!fs.existsSync(destParent)) mkdirsSync(destParent)
-  return startCopy(destStat, src, dest, opts)
+  return getStats(destStat, src, dest, opts)
 }
 
 function startCopy (destStat, src, dest, opts) {

--- a/lib/copy/__tests__/copy.test.js
+++ b/lib/copy/__tests__/copy.test.js
@@ -283,6 +283,25 @@ describe('fs-extra', () => {
         })
       })
 
+      it('should not call filter fn more than needed', done => {
+        const src = path.join(TEST_DIR, 'foo')
+        fs.writeFileSync(src, '')
+        const dest = path.join(TEST_DIR, 'bar')
+
+        let filterCallCount = 0
+        const filter = () => {
+          filterCallCount++
+          return true
+        }
+
+        fse.copy(src, dest, filter, err => {
+          assert(!err)
+          assert.strictEqual(filterCallCount, 1)
+          assert(fs.existsSync(dest))
+          done()
+        })
+      })
+
       it('accepts options object in place of filter', done => {
         const srcFile1 = path.join(TEST_DIR, '1.jade')
         fs.writeFileSync(srcFile1, '')

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -42,10 +42,10 @@ function checkParentDir (destStat, src, dest, opts, cb) {
   const destParent = path.dirname(dest)
   pathExists(destParent, (err, dirExists) => {
     if (err) return cb(err)
-    if (dirExists) return startCopy(destStat, src, dest, opts, cb)
+    if (dirExists) return getStats(destStat, src, dest, opts, cb)
     mkdirs(destParent, err => {
       if (err) return cb(err)
-      return startCopy(destStat, src, dest, opts, cb)
+      return getStats(destStat, src, dest, opts, cb)
     })
   })
 }


### PR DESCRIPTION
Fixes #809

We need to check filter before creating a parent directory for `dest`, in case the filter cancels the entire operation. After creating the parent (if needed), we were calling a function that rechecked the filter, which wasn't needed, and resulted in the filter fn being called twice at the root level.

With these changes, we should possibly consider renaming some functions, as it doesn't seem to make much sense anymore.