### PR TITLE
Convert emptyDir() to async function; remove items in parallel

### DIFF
--- a/lib/empty/index.js
+++ b/lib/empty/index.js
@@ -1,29 +1,20 @@
 'use strict'
 
-const u = require('universalify').fromCallback
-const fs = require('graceful-fs')
+const u = require('universalify').fromPromise
+const fs = require('../fs')
 const path = require('path')
 const mkdir = require('../mkdirs')
 const remove = require('../remove')
 
-const emptyDir = u(function emptyDir (dir, callback) {
-  callback = callback || function () {}
-  fs.readdir(dir, (err, items) => {
-    if (err) return mkdir.mkdirs(dir, callback)
+const emptyDir = u(async function emptyDir (dir) {
+  let items
+  try {
+    items = await fs.readdir(dir)
+  } catch {
+    return mkdir.mkdirs(dir)
+  }
 
-    items = items.map(item => path.join(dir, item))
-
-    deleteItem()
-
-    function deleteItem () {
-      const item = items.pop()
-      if (!item) return callback()
-      remove.remove(item, err => {
-        if (err) return callback(err)
-        deleteItem()
-      })
-    }
-  })
+  return Promise.all(items.map(item => remove.remove(path.join(dir, item))))
 })
 
 function emptyDirSync (dir) {


### PR DESCRIPTION
This theoretically should be faster, since we're launching all the remove operations at once, instead of one-by-one.