### PR TITLE
BREAKING: Drop Node 10 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,11 @@ os:
   - linux
   - osx
 node_js:
-  - 10
-  - 11
   - 12
   - 13
   - 14
+  - 15
+  - 16
 env: TEST_SUITE=unit
 matrix:
   exclude:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,6 @@ environment:
     # node.js
     - nodejs_version: "12"
     - nodejs_version: "14"
-    - nodejs_version: "16"
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@
 environment:
   matrix:
     # node.js
-    - nodejs_version: "10"
     - nodejs_version: "12"
     - nodejs_version: "14"
+    - nodejs_version: "16"
 # Install scripts. (runs after repo cloning)
 install:
   # Get the latest stable version of Node.js or io.js

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "9.1.0",
   "description": "fs-extra contains methods that aren't included in the vanilla Node.js fs package. Such as recursive mkdir, copy, and remove.",
   "engines": {
-    "node": ">=10"
+    "node": ">=12"
   },
   "homepage": "https://github.com/jprichardson/node-fs-extra",
   "repository": {


### PR DESCRIPTION
~Not needed if we merge https://github.com/jprichardson/node-fs-extra/pull/881 and kill the old CI providers.~ Will need edits; still need `engines` bump.