### PR TITLE
move: do not create parent directory if it is root

### DIFF
--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -271,19 +271,19 @@ describe('moveSync()', () => {
   })
 
   describeIfWindows('> when dest parent is root', () => {
+    let dest
+
+    afterEach(() => fse.removeSync(dest))
+
     it('should not create parent directory', () => {
       const src = path.join(TEST_DIR, 'a-file')
-      const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
+      dest = path.join(path.parse(TEST_DIR).root, 'another-file')
 
       fse.moveSync(src, dest)
 
       const contents = fs.readFileSync(dest, 'utf8')
       const expected = /^sonic the hedgehog\r?\n$/
       assert(contents.match(expected))
-      // this test is a bit special since
-      // we're moving to root, so we need to
-      // manually remove dest after we're done.
-      fse.removeSync(dest)
     })
   })
 

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -275,8 +275,6 @@ describe('moveSync()', () => {
       const src = path.join(TEST_DIR, 'a-file')
       const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
 
-      console.log('debug: dest ==>', dest)
-
       fse.moveSync(src, dest)
 
       const contents = fs.readFileSync(dest, 'utf8')

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -275,11 +275,17 @@ describe('moveSync()', () => {
       const src = path.join(TEST_DIR, 'a-file')
       const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
 
+      console.log('debug: dest ==>', dest)
+
       fse.moveSync(src, dest)
 
       const contents = fs.readFileSync(dest, 'utf8')
       const expected = /^sonic the hedgehog\r?\n$/
       assert(contents.match(expected))
+      // this test is a bit special since
+      // we're moving to root, so we need to
+      // manually remove dest after we're done.
+      fse.removeSync(dest)
     })
   })
 

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -271,19 +271,15 @@ describe('moveSync()', () => {
   })
 
   describeIfWindows('> when dest parent is root', () => {
-    it('should not create parent directory', done => {
+    it('should not create parent directory', () => {
       const src = path.join(TEST_DIR, 'a-file')
       const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
 
-      fse.move(src, dest, err => {
-        assert.ifError(err)
-        fs.readFile(dest, 'utf8', (err, contents) => {
-          const expected = /^sonic the hedgehog\r?\n$/
-          assert.ifError(err)
-          assert.ok(contents.match(expected))
-          done()
-        })
-      })
+      fse.moveSync(src, dest)
+
+      const contents = fs.readFileSync(dest, 'utf8')
+      const expected = /^sonic the hedgehog\r?\n$/
+      assert(contents.match(expected))
     })
   })
 

--- a/lib/move-sync/__tests__/move-sync.test.js
+++ b/lib/move-sync/__tests__/move-sync.test.js
@@ -10,6 +10,8 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
+const describeIfWindows = process.platform === 'win32' ? describe : describe.skip
+
 function createSyncErrFn (errCode) {
   const fn = function () {
     const err = new Error()
@@ -120,7 +122,7 @@ describe('moveSync()', () => {
 
     const contents = fs.readFileSync(dest, 'utf8')
     const expected = /^sonic the hedgehog\r?\n$/
-    assert.ok(contents.match(expected), `${contents} match ${expected}`)
+    assert.ok(contents.match(expected))
   })
 
   it('should overwrite the destination directory if overwrite = true', () => {
@@ -265,6 +267,23 @@ describe('moveSync()', () => {
       const contents = fs.readFileSync(dest, 'utf8')
       const expected = /^sonic the hedgehog\r?\n$/
       assert(contents.match(expected))
+    })
+  })
+
+  describeIfWindows('> when dest parent is root', () => {
+    it('should not create parent directory', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected))
+          done()
+        })
+      })
     })
   })
 

--- a/lib/move-sync/move-sync.js
+++ b/lib/move-sync/move-sync.js
@@ -13,8 +13,14 @@ function moveSync (src, dest, opts) {
 
   const { srcStat, isChangingCase = false } = stat.checkPathsSync(src, dest, 'move', opts)
   stat.checkParentPathsSync(src, srcStat, dest, 'move')
-  mkdirpSync(path.dirname(dest))
+  if (!isParentRoot(dest)) mkdirpSync(path.dirname(dest))
   return doRename(src, dest, overwrite, isChangingCase)
+}
+
+function isParentRoot (dest) {
+  const parent = path.dirname(dest)
+  const parsedPath = path.parse(parent)
+  return parsedPath.root === parent
 }
 
 function doRename (src, dest, overwrite, isChangingCase) {

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -288,6 +288,7 @@ describe('+ move()', () => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
           assert.ok(contents.match(expected))
+          done()
         })
       })
     })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -8,6 +8,8 @@ const assert = require('assert')
 
 /* global afterEach, beforeEach, describe, it */
 
+const describeIfWindows = process.platform === 'win32' ? describe : describe.skip
+
 function createAsyncErrFn (errCode) {
   const fn = function (...args) {
     fn.callCount++
@@ -63,7 +65,7 @@ describe('+ move()', () => {
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           done()
         })
       })
@@ -114,7 +116,7 @@ describe('+ move()', () => {
         fs.readFile(path.join(dest, 'another-folder', 'file3'), 'utf8', (err, contents) => {
           const expected = /^knuckles\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           tearDownMockFs()
           done()
         })
@@ -132,7 +134,7 @@ describe('+ move()', () => {
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           done()
         })
       })
@@ -206,7 +208,7 @@ describe('+ move()', () => {
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           done()
         })
       })
@@ -225,7 +227,7 @@ describe('+ move()', () => {
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           tearDownMockFs()
           done()
         })
@@ -244,7 +246,7 @@ describe('+ move()', () => {
         fs.readFile(path.join(dest, 'another-file'), 'utf8', (err, contents) => {
           const expected = /^tails\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           done()
         })
       })
@@ -263,8 +265,25 @@ describe('+ move()', () => {
         fs.readFile(path.join(dest, 'another-folder', 'file3'), 'utf8', (err, contents) => {
           const expected = /^knuckles\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           tearDownMockFs()
+          done()
+        })
+      })
+    })
+  })
+
+  describeIfWindows('> when dest parent is root', () => {
+    it('should not create parent directory', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
+
+      fse.move(src, dest, err => {
+        assert.ifError(err)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected))
           done()
         })
       })
@@ -284,7 +303,7 @@ describe('+ move()', () => {
         fs.readFile(dest, 'utf8', (err, contents) => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
-          assert.ok(contents.match(expected), `${contents} match ${expected}`)
+          assert.ok(contents.match(expected))
           done()
         })
       })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -284,7 +284,10 @@ describe('+ move()', () => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
           assert.ok(contents.match(expected))
-          done()
+          // this test is a bit special since
+          // we're moving to root, so we need to
+          // manually remove dest after we're done.
+          fse.remove(dest, done)
         })
       })
     })

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -274,9 +274,13 @@ describe('+ move()', () => {
   })
 
   describeIfWindows('> when dest parent is root', () => {
+    let dest
+
+    afterEach(done => fse.remove(dest, done))
+
     it('should not create parent directory', done => {
       const src = path.join(TEST_DIR, 'a-file')
-      const dest = path.join(path.parse(TEST_DIR).root, 'another-file')
+      dest = path.join(path.parse(TEST_DIR).root, 'another-file')
 
       fse.move(src, dest, err => {
         assert.ifError(err)
@@ -284,10 +288,6 @@ describe('+ move()', () => {
           const expected = /^sonic the hedgehog\r?\n$/
           assert.ifError(err)
           assert.ok(contents.match(expected))
-          // this test is a bit special since
-          // we're moving to root, so we need to
-          // manually remove dest after we're done.
-          fse.remove(dest, done)
         })
       })
     })

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -21,12 +21,19 @@ function move (src, dest, opts, cb) {
     const { srcStat, isChangingCase = false } = stats
     stat.checkParentPaths(src, srcStat, dest, 'move', err => {
       if (err) return cb(err)
+      if (isParentRoot(dest)) return doRename(src, dest, overwrite, isChangingCase, cb)
       mkdirp(path.dirname(dest), err => {
         if (err) return cb(err)
         return doRename(src, dest, overwrite, isChangingCase, cb)
       })
     })
   })
+}
+
+function isParentRoot (dest) {
+  const parent = path.dirname(dest)
+  const parsedPath = path.parse(parent)
+  return parsedPath.root === parent
 }
 
 function doRename (src, dest, overwrite, isChangingCase, cb) {


### PR DESCRIPTION
Fixes #819.

Do not create parent directory if it is root. We run tests for this only on windows, moving to root on unix-like systems requires sudo privileges. 