### PR TITLE
Skip the ncp / error / dest-permission test if running as root

### DIFF
--- a/lib/copy/__tests__/ncp/ncp-error-perm.test.js
+++ b/lib/copy/__tests__/ncp/ncp-error-perm.test.js
@@ -21,7 +21,9 @@ describe('ncp / error / dest-permission', () => {
   const src = path.join(TEST_DIR, 'src')
   const dest = path.join(TEST_DIR, 'dest')
 
-  if (os.platform().indexOf('win') === 0) return
+  // when we are root, then we will be able to create the subdirectory even if
+  // we don't have the permissions to do so, so no point in running this test
+  if (os.platform().indexOf('win') === 0 || os.userInfo().uid === 0) return
 
   beforeEach(done => {
     fse.emptyDir(TEST_DIR, err => {


### PR DESCRIPTION
This test tries to create a directory where the current user does not have the
permissions to do so and expects a failure. However, the root user is by design
always allowed to do that (ignoring file permissions). So we must skip the test
in these cases then.

This fixes https://github.com/jprichardson/node-fs-extra/issues/898