### PR TITLE
Return promise in outputFile

### DIFF
--- a/lib/output-file/__tests__/output.test.js
+++ b/lib/output-file/__tests__/output.test.js
@@ -30,10 +30,11 @@ describe('output', () => {
           done()
         })
       })
-      it('should support promises', () => {
+      it('should support promises', async () => {
         const file = path.join(TEST_DIR, Math.random() + 't-ne', Math.random() + '.txt')
         assert(!fs.existsSync(file))
-        return fse.outputFile(file, 'hi jp')
+        await fse.outputFile(file, 'hi jp')
+        assert(fs.existsSync(file))
       })
     })
 

--- a/lib/output-file/index.js
+++ b/lib/output-file/index.js
@@ -20,7 +20,7 @@ function outputFile (file, data, encoding, callback) {
     mkdir.mkdirs(dir, err => {
       if (err) return callback(err)
 
-      fs.writeFile(file, data, encoding, callback)
+      return fs.writeFile(file, data, encoding, callback)
     })
   })
 }


### PR DESCRIPTION
Without returning, calling `await outputFile` could continue without waiting for the file to be written.

Also updates a test.