### PR TITLE
Revert "Remove check for fs.realpath.native support, since it's every where (#887)"

### DIFF
--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -54,7 +54,6 @@ Object.assign(exports, fs)
 api.forEach(method => {
   exports[method] = u(fs[method])
 })
-exports.realpath.native = u(fs.realpath.native)
 
 // We differ from mz/fs in that we still ship the old, broken, fs.exists()
 // since we are a drop-in replacement for the native module
@@ -116,4 +115,9 @@ if (typeof fs.writev === 'function') {
       })
     })
   }
+}
+
+// fs.realpath.native only available in Node v9.2+
+if (typeof fs.realpath.native === 'function') {
+  exports.realpath.native = u(fs.realpath.native)
 }


### PR DESCRIPTION
This reverts commit f4a880d29c3a699c0695755fe8533d786c55f65f.

Operating System: Linux/mac

Node.js version: v12.22.6/v16.13.1

fs-extra version: 10.0.0

The simple check can avoid countless headaches especially for large codebases that need fs-extra version 10. It would be awesome if we could get it back because the issue is happening just with the import statement.

Fixes #

- [TypeError: Cannot read property 'name' of undefined](https://github.com/jprichardson/node-fs-extra/issues/926)
- [Universalify 2.0.0 breaks fs.realpath ](https://github.com/jprichardson/node-fs-extra/issues/915)
- [Incompatible with Nexe packaging tool while using fs-extra 10.0.0](https://github.com/jprichardson/node-fs-extra/issues/909)
