### PR TITLE
chore: update graceful-fs to 4.2.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "graceful-fs": "^4.2.0",
+    "graceful-fs": "^4.2.9",
     "jsonfile": "^6.0.1",
     "universalify": "^2.0.0"
   },


### PR DESCRIPTION
update graceful-fs to 4.2.9 for support throwIfNoEntry for statSync