### PR TITLE
chore: "sideEffects": false

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,5 +62,6 @@
     "test-find": "find ./lib/**/__tests__ -name *.test.js | xargs mocha",
     "test": "npm run lint && npm run unit",
     "unit": "nyc node test.js"
-  }
+  },
+  "sideEffects": false
 }


### PR DESCRIPTION
Add `"sideEffects": false` to package.json to allow frameworks that mix client and server code in the same files to tree-shake out fs-extra from client bundles.