### PR TITLE
Allow passing undefined options to move()

### DIFF
--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -340,13 +340,7 @@ describe('+ move()', () => {
 
       fse.move(SRC_DIR, DEST_DIR, undefined)
         .then(() => done())
-        .catch(error => {
-          if (error instanceof TypeError) {
-            done()
-          } else {
-            done(error)
-          }
-        })
+        .catch(done)
     })
   })
 

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -52,6 +52,65 @@ describe('+ move()', () => {
 
   afterEach(done => fse.remove(TEST_DIR, done))
 
+  describe('> invalid arguments', () => {
+    it('should throw a type error if src is not a string', (done) => {
+      try {
+        fse.move(15, '', {}, () => ({}))
+        done('Failed to throw a type error')
+      } catch (error) {
+        if (error instanceof TypeError) {
+          done()
+        } else {
+          done(error)
+        }
+      }
+    })
+
+    it('should throw a type error if dest is not a string', (done) => {
+      try {
+        fse.move('', 15, {}, () => ({}))
+        done('Failed to throw a type error')
+      } catch (error) {
+        if (error instanceof TypeError) {
+          done()
+        } else {
+          done(error)
+        }
+      }
+    })
+
+    it('should throw a type error if opts is not optionally an object', (done) => {
+      try {
+        fse.move('', '', 15, () => ({}))
+        done('Failed to throw a type error')
+      } catch (error) {
+        if (error instanceof TypeError) {
+          done()
+        } else {
+          done(error)
+        }
+      }
+    })
+
+    it('should not throw a type error if opts is undefined', (done) => {
+      try {
+        fse.move('', '', undefined, () => ({}))
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+
+    it('should not throw a type error if cb is function', (done) => {
+      try {
+        fse.move('', '', () => ({}))
+        done()
+      } catch (error) {
+        done(error)
+      }
+    })
+  })
+
   describe('> when overwrite = true', () => {
     it('should overwrite file', done => {
       const src = path.join(TEST_DIR, 'a-file')
@@ -331,16 +390,56 @@ describe('+ move()', () => {
     })
   })
 
-  describe('> passing undefined explicitly for opts in promise mode', () => {
-    it('should not produce a TypeError', done => {
-      const SRC_DIR = path.join(TEST_DIR, 'test')
-      const DEST_DIR = path.join(TEST_DIR, 'foobar')
+  describe('> promise mode', () => {
+    describe('> passing undefined for opts', () => {
+      it('should not produce a TypeError', done => {
+        const SRC_DIR = path.join(TEST_DIR, 'test')
+        const DEST_DIR = path.join(TEST_DIR, 'foobar')
 
-      fs.mkdirSync(SRC_DIR)
+        fs.mkdirSync(SRC_DIR)
 
-      fse.move(SRC_DIR, DEST_DIR, undefined)
-        .then(() => done())
-        .catch(done)
+        fse.move(SRC_DIR, DEST_DIR, undefined)
+          .then(() => done())
+          .catch(done)
+      })
+    })
+
+    describe('> invalid arguments', () => {
+      it('should reject with a type error if src is not a string', (done) => {
+        fse.move(15, '', {})
+          .then(() => done('Failed to reject with a type error'))
+          .catch(error => {
+            if (error instanceof TypeError) {
+              done()
+            } else {
+              done(error)
+            }
+          })
+      })
+
+      it('should reject with a type error if dest is not a string', (done) => {
+        fse.move('', 15, {})
+          .then(() => done('Failed to reject with a type error'))
+          .catch(error => {
+            if (error instanceof TypeError) {
+              done()
+            } else {
+              done(error)
+            }
+          })
+      })
+
+      it('should reject with a type error if opts is not optionally an object', (done) => {
+        fse.move('', '', 15)
+          .then(() => done('Failed to reject with a type error'))
+          .catch(error => {
+            if (error instanceof TypeError) {
+              done()
+            } else {
+              done(error)
+            }
+          })
+      })
     })
   })
 

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -331,6 +331,25 @@ describe('+ move()', () => {
     })
   })
 
+  describe('> passing undefined explicitly for opts in promise mode', () => {
+    it('should not produce a TypeError', done => {
+      const SRC_DIR = path.join(TEST_DIR, 'test')
+      const DEST_DIR = path.join(TEST_DIR, 'foobar')
+
+      fs.mkdirSync(SRC_DIR)
+
+      fse.move(SRC_DIR, DEST_DIR, undefined)
+        .then(() => done())
+        .catch(error => {
+          if (error instanceof TypeError) {
+            done()
+          } else {
+            done(error)
+          }
+        })
+    })
+  })
+
   // tested on Linux ubuntu 3.13.0-32-generic #57-Ubuntu SMP i686 i686 GNU/Linux
   // this won't trigger a bug on Mac OS X Yosimite with a USB drive (/Volumes)
   // see issue #108

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -14,7 +14,7 @@ function move (src, dest, opts, cb) {
     opts = {}
   }
 
-  opts = opts || {};
+  opts = opts || {}
 
   const overwrite = opts.overwrite || opts.clobber || false
 

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -9,14 +9,30 @@ const pathExists = require('../path-exists').pathExists
 const stat = require('../util/stat')
 
 function move (src, dest, opts, cb) {
+  if (typeof src !== 'string') {
+    throw new TypeError('src must be a string')
+  }
+
+  if (typeof dest !== 'string') {
+    throw new TypeError('dest must be a string')
+  }
+
   if (typeof opts === 'function') {
     cb = opts
     opts = {}
   }
 
-  const overwrite = opts
-    ? (opts.overwrite || opts.clobber || false)
-    : false
+  opts = opts || {}
+
+  if (typeof opts !== 'object') {
+    throw new TypeError('opts must be an object')
+  }
+
+  if (typeof cb !== 'function') {
+    throw new TypeError('cb must be a function')
+  }
+
+  const overwrite = opts.overwrite || opts.clobber || false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {
     if (err) return cb(err)

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -14,9 +14,9 @@ function move (src, dest, opts, cb) {
     opts = {}
   }
 
-  opts = opts || {}
-
-  const overwrite = opts.overwrite || opts.clobber || false
+  const overwrite = opts
+    ? (opts.overwrite || opts.clobber || false)
+    : false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {
     if (err) return cb(err)

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -14,6 +14,8 @@ function move (src, dest, opts, cb) {
     opts = {}
   }
 
+  opts = opts || {};
+
   const overwrite = opts.overwrite || opts.clobber || false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {

--- a/lib/util/stat.js
+++ b/lib/util/stat.js
@@ -5,7 +5,7 @@ const path = require('path')
 const util = require('util')
 
 function getStats (src, dest, opts) {
-  const statFunc = opts.dereference
+  const statFunc = opts && opts.dereference
     ? (file) => fs.stat(file, { bigint: true })
     : (file) => fs.lstat(file, { bigint: true })
   return Promise.all([


### PR DESCRIPTION
fixes #947 

I thought about adding a test but then couldn't find any tests of a similar nature within the repo so I didn't. I can if it is thought to be useful.