### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/lib/copy/__tests__/ncp/ncp.test.js
+++ b/lib/copy/__tests__/ncp/ncp.test.js
@@ -33,7 +33,7 @@ describe('ncp', () => {
 
     describe('when copying files using filter', () => {
       before(cb => {
-        const filter = name => name.substr(name.length - 1) !== 'a'
+        const filter = name => name.slice(-1) !== 'a'
 
         rimraf(out, () => ncp(src, out, { filter }, cb))
       })
@@ -45,7 +45,7 @@ describe('ncp', () => {
               const curFile = files[fileName]
               if (curFile instanceof Object) {
                 filter(curFile)
-              } else if (fileName.substr(fileName.length - 1) === 'a') {
+              } else if (fileName.slice(-1) === 'a') {
                 delete files[fileName]
               }
             }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.