### PR TITLE
Revert check for fs.realpath.native (#887)

### DIFF
--- a/lib/fs/__tests__/realpath.test.js
+++ b/lib/fs/__tests__/realpath.test.js
@@ -8,15 +8,12 @@ const assert = require('assert')
 
 describe('realpath.native does not exist', () => {
   let warning
-  const originalListener = process.listeners('warning')[process.listeners('warning').length - 1]
   const warningListener = error => {
     if (error.name === 'Warning') {
       if (error.code.startsWith('fs-extra-WARN0003')) {
         warning = error
-        return
       }
     }
-    originalListener(error)
   }
 
   const realpathNativeBackup = fs.realpath.native
@@ -30,30 +27,27 @@ describe('realpath.native does not exist', () => {
   }
 
   before(() => {
-    process.off('warning', originalListener)
     process.on('warning', warningListener)
 
     // clear existing require.cache
     clearFseCache()
 
-    // mock stub
+    // simulate fs monkey-patch
     delete fs.realpath.native
   })
 
   after(() => {
     process.off('warning', warningListener)
-    process.on('warning', originalListener)
 
     // clear stubbed require.cache
     clearFseCache()
 
-    // reinstate
+    // reinstate fs.realpath.native
     fs.realpath.native = realpathNativeBackup
-    require('../..')
   })
 
   it('fse should not export realpath.native', () => {
-    const fse = require(require.resolve('../..'))
+    const fse = require('../..')
 
     // next event loop to allow event emitter/listener to happen
     setImmediate(() => {

--- a/lib/fs/__tests__/realpath.test.js
+++ b/lib/fs/__tests__/realpath.test.js
@@ -46,12 +46,13 @@ describe('realpath.native does not exist', () => {
     fs.realpath.native = realpathNativeBackup
   })
 
-  it('fse should not export realpath.native', () => {
+  it('fse should not export realpath.native', done => {
     const fse = require('../..')
 
     // next event loop to allow event emitter/listener to happen
     setImmediate(() => {
       assert(warning, 'fs-extra-WARN0003 should be emitted')
+      done()
     })
 
     assert(!fse.realpath.native)

--- a/lib/fs/__tests__/realpath.test.js
+++ b/lib/fs/__tests__/realpath.test.js
@@ -52,7 +52,7 @@ describe('realpath.native does not exist', () => {
     require('../..')
   })
 
-  it('fse fallback to realpath internally', () => {
+  it('fse should not export realpath.native', () => {
     const fse = require(require.resolve('../..'))
 
     // next event loop to allow event emitter/listener to happen
@@ -60,10 +60,7 @@ describe('realpath.native does not exist', () => {
       assert(warning, 'fs-extra-WARN0003 should be emitted')
     })
 
-    fse.realpath.native(__dirname, (err, path) => {
-      assert.ifError(err)
-      assert.strictEqual(path, __dirname)
-    })
+    assert(!fse.realpath.native)
   })
 })
 

--- a/lib/fs/__tests__/realpath.test.js
+++ b/lib/fs/__tests__/realpath.test.js
@@ -1,11 +1,75 @@
 'use strict'
 
-const fse = require('../..')
+const fs = require('fs')
+const path = require('path')
 const assert = require('assert')
 
 /* eslint-env mocha */
 
+describe('realpath.native does not exist', () => {
+  let warning
+  const originalListener = process.listeners('warning')[process.listeners('warning').length - 1]
+  const warningListener = error => {
+    if (error.name === 'Warning') {
+      if (error.code.startsWith('fs-extra-WARN0003')) {
+        warning = error
+        return
+      }
+    }
+    originalListener(error)
+  }
+
+  const realpathNativeBackup = fs.realpath.native
+  const clearFseCache = () => {
+    const fsePath = path.dirname(require.resolve('../../..'))
+    for (const entry in require.cache) {
+      if (entry.startsWith(fsePath)) {
+        delete require.cache[entry]
+      }
+    }
+  }
+
+  before(() => {
+    process.off('warning', originalListener)
+    process.on('warning', warningListener)
+
+    // clear existing require.cache
+    clearFseCache()
+
+    // mock stub
+    delete fs.realpath.native
+  })
+
+  after(() => {
+    process.off('warning', warningListener)
+    process.on('warning', originalListener)
+
+    // clear stubbed require.cache
+    clearFseCache()
+
+    // reinstate
+    fs.realpath.native = realpathNativeBackup
+    require('../..')
+  })
+
+  it('fse fallback to realpath internally', () => {
+    const fse = require(require.resolve('../..'))
+
+    // next event loop to allow event emitter/listener to happen
+    setImmediate(() => {
+      assert(warning, 'fs-extra-WARN0003 should be emitted')
+    })
+
+    fse.realpath.native(__dirname, (err, path) => {
+      assert.ifError(err)
+      assert.strictEqual(path, __dirname)
+    })
+  })
+})
+
 describe('realpath.native', () => {
+  const fse = require('../..')
+
   it('works with callbacks', () => {
     fse.realpath.native(__dirname, (err, path) => {
       assert.ifError(err)

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -121,20 +121,10 @@ if (typeof fs.writev === 'function') {
 if (typeof fs.realpath.native === 'function') {
   exports.realpath.native = u(fs.realpath.native)
 } else {
-  // fallback to a similar method signature that is present before Node v9.2
-  exports.realpath.native = u(fs.realpath)
-
-  // emit warning that fs.realpath.native is not a function (or undefined)
-  const nodeVer = process.version.match(/(\d+)\.(\d+)\.(\d+)/)
-  const [major, minor] = nodeVer.slice(1).map(_ => parseInt(_))
   process.emitWarning(
-    `fs.realpath.native is not a function: ${fs.realpath.native}.\n` +
-    '\tfs.realpath.native is now redirected to fs.realpath as a fallback measure.\n\n' +
-    (
-      (major <= 9 || (major === 9 && minor < 2))
-        ? `\tEnsure that NodeJS is at least v9.2.0. Detected: ${process.version}.`
-        : '\tEnsure that fs-extra is imported before other dependencies that can change fs.\n\n' +
-          '\tsee https://github.com/jprichardson/node-fs-extra/pull/953'
-    ),
-    'Warning', 'fs-extra-WARN0003')
+    'fs.realpath.native is not a function. ' +
+    'Ensure that fs-extra is imported before other dependencies that can change fs.\n\n' +
+    '\tsee https://github.com/jprichardson/node-fs-extra/pull/953',
+    'Warning', 'fs-extra-WARN0003'
+  )
 }

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -117,7 +117,7 @@ if (typeof fs.writev === 'function') {
   }
 }
 
-// fs.realpath.native only available in Node v9.2+
+// fs.realpath.native sometimes not available if fs is monkey-patched
 if (typeof fs.realpath.native === 'function') {
   exports.realpath.native = u(fs.realpath.native)
 } else {

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -120,4 +120,21 @@ if (typeof fs.writev === 'function') {
 // fs.realpath.native only available in Node v9.2+
 if (typeof fs.realpath.native === 'function') {
   exports.realpath.native = u(fs.realpath.native)
+} else {
+  // fallback to a similar method signature that is present before Node v9.2
+  exports.realpath.native = u(fs.realpath)
+
+  // emit warning that fs.realpath.native is not a function (or undefined)
+  const nodeVer = process.version.match(/(\d+)\.(\d+)\.(\d+)/)
+  const [major, minor] = nodeVer.slice(1).map(_ => parseInt(_))
+  process.emitWarning(
+    `fs.realpath.native is not a function: ${fs.realpath.native}.\n` +
+    '\tfs.realpath.native is now redirected to fs.realpath as a fallback measure.\n\n' +
+    (
+      (major <= 9 || (major === 9 && minor < 2))
+        ? `\tEnsure that NodeJS is at least v9.2.0. Detected: ${process.version}.`
+        : '\tEnsure that fs-extra is imported before other dependencies that can change fs.\n\n' +
+          '\tsee https://github.com/jprichardson/node-fs-extra/pull/953'
+    ),
+    'Warning', 'fs-extra-WARN0003')
 }

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -122,9 +122,7 @@ if (typeof fs.realpath.native === 'function') {
   exports.realpath.native = u(fs.realpath.native)
 } else {
   process.emitWarning(
-    'fs.realpath.native is not a function. ' +
-    'Ensure that fs-extra is imported before other dependencies that can change fs.\n\n' +
-    '\tsee https://github.com/jprichardson/node-fs-extra/pull/953',
+    'fs.realpath.native is not a function. Is fs being monkey-patched?',
     'Warning', 'fs-extra-WARN0003'
   )
 }

--- a/lib/fs/index.js
+++ b/lib/fs/index.js
@@ -54,7 +54,6 @@ Object.assign(exports, fs)
 api.forEach(method => {
   exports[method] = u(fs[method])
 })
-exports.realpath.native = u(fs.realpath.native)
 
 // We differ from mz/fs in that we still ship the old, broken, fs.exists()
 // since we are a drop-in replacement for the native module
@@ -116,4 +115,9 @@ if (typeof fs.writev === 'function') {
       })
     })
   }
+}
+
+// fs.realpath.native only available in Node v9.2+
+if (typeof fs.realpath.native === 'function') {
+  exports.realpath.native = u(fs.realpath.native)
 }


### PR DESCRIPTION
#887 causes a few regressions, not because of `fs-extra`, but due to other dependencies who are using `fs-extra`.

**The general gist is that others' improper monkey-patches of `fs` should not impact the import and initialisation of `fs-extra`.**

---

When `fs.realpath.native` is `undefined` caused by the improper handling by other packages, it inevitably affected the import and initialisation of `fs-extra` as the `universalify` would not be able to parse this line properly.
https://github.com/jprichardson/node-fs-extra/blob/7edcb16a06e041826af3303f961866bf3b243dae/lib/fs/index.js#L57

**It results in `fs-extra` throwing errors on import, even if the `fs-extra.realpath.native` API is not being used during runtime.**

And the stacktrace shows:
```
    TypeError: Cannot read property 'name' of undefined

      at Object.<anonymous>.exports.fromCallback (node_modules/universalify/index.js:15:26)
      at Object.<anonymous> (node_modules/fs-extra/lib/fs/index.js:57:27)
      at Object.<anonymous> (node_modules/fs-extra/lib/index.js:5:6)
```
![image](https://user-images.githubusercontent.com/29530649/161987896-73679265-dcc8-4f2c-a068-9482ef535e01.png)
_(src: https://github.com/RyanZim/universalify/blob/a853a4aedc63c69fcdc62b77643d75b0d162a098/index.js#L15)_

---

While it is up to the responsibility of the underlying packages to fix their root cause of poor monkey-patches to `fs`, **it might be wise for `fs-extra` to keep the check for `fs.realpath.native` during initialisation so that `fs-extra` does not throw errors on import.**

To name a few:
1. https://github.com/heimdalljs/heimdalljs/issues/151
2. https://github.com/streamich/memfs/issues/803
3. https://github.com/log4js-node/log4js-node/issues/1225

To summarise from the 3 listed issues above, it does seem like most dependencies did not factor in `fs` third-level functions. From the [NodeJS fs API documentation](https://nodejs.org/docs/latest-v14.x/api/fs.html), most are second-level functions (i.e. fs.xxx). But there are 2 exceptions since NodeJS 9.2.0 that are in third-level (i.e. fs.xxx.yyy), which are `fs.realpath.native` and `fs.realpathSync.native`. So if any the packages did some wrapping around, which usually naively only handles direct members (second-level), the third-level functions breaks and becomes `undefined`. 

Even in Angular (traced from the 3rd issue above, https://github.com/log4js-node/log4js-node/issues/1225), they, too, did not factor in the 2 special functions.
https://github.com/angular/angular/blob/1c11a5715576632a4fb7170202395cf95dfbce09/packages/zone.js/lib/node/fs.ts#L20-L26

I have filed an issue to [zone.js/node](https://github.com/angular/angular/) separately here: https://github.com/angular/angular/issues/45546

---

**For your kind consideration, please.**