### PR TITLE
refactor: replace console.warn with process.emitWarning

### DIFF
--- a/lib/copy/copy-sync.js
+++ b/lib/copy/copy-sync.js
@@ -17,8 +17,11 @@ function copySync (src, dest, opts) {
 
   // Warn about using preserveTimestamps on 32-bit node
   if (opts.preserveTimestamps && process.arch === 'ia32') {
-    console.warn(`fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n
-    see https://github.com/jprichardson/node-fs-extra/issues/269`)
+    process.emitWarning(
+      'Using the preserveTimestamps option in 32-bit node is not recommended;\n\n' +
+      '\tsee https://github.com/jprichardson/node-fs-extra/issues/269',
+      'Warning', 'fs-extra-WARN0002'
+    )
   }
 
   const { srcStat, destStat } = stat.checkPathsSync(src, dest, 'copy', opts)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -23,8 +23,11 @@ function copy (src, dest, opts, cb) {
 
   // Warn about using preserveTimestamps on 32-bit node
   if (opts.preserveTimestamps && process.arch === 'ia32') {
-    console.warn(`fs-extra: Using the preserveTimestamps option in 32-bit node is not recommended;\n
-    see https://github.com/jprichardson/node-fs-extra/issues/269`)
+    process.emitWarning(
+      'Using the preserveTimestamps option in 32-bit node is not recommended;\n\n' +
+      '\tsee https://github.com/jprichardson/node-fs-extra/issues/269',
+      'Warning', 'fs-extra-WARN0001'
+    )
   }
 
   stat.checkPaths(src, dest, 'copy', opts, (err, stats) => {


### PR DESCRIPTION
To have consistent warnings from https://github.com/jprichardson/node-fs-extra/pull/953#issuecomment-1092663914 by @JPeer264 
> Yes `process.emitWarning` sounds also like a great option to add (just my opinion on it). However, a separate PR would be nice if you want to go the extra mile as we squash our PRs. @manidlou @RyanZim @jprichardson any objections?

Prints out via `process.emitWarning` in the following format:

![image](https://user-images.githubusercontent.com/29530649/162500584-a6ac7a4a-3df2-4ca4-b657-ca78878744be.png)

