### PR TITLE
Allow passing undefined opts to move()

### DIFF
--- a/lib/__tests__/promise.test.js
+++ b/lib/__tests__/promise.test.js
@@ -10,7 +10,6 @@ const methods = [
   'ensureFile',
   'ensureDir',
   'mkdirs',
-  'move',
   'readJson',
   'readJSON',
   'remove'

--- a/lib/move/__tests__/move.test.js
+++ b/lib/move/__tests__/move.test.js
@@ -140,6 +140,17 @@ describe('+ move()', () => {
       })
     })
 
+    it('should support promises', async () => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-file-dest')
+
+      await fse.move(src, dest)
+
+      const contents = fs.readFileSync(dest, 'utf8')
+      const expected = /^sonic the hedgehog\r?\n$/
+      assert.ok(contents.match(expected))
+    })
+
     it('should not move a file if source and destination are the same', done => {
       const src = path.join(TEST_DIR, 'a-file')
       const dest = src
@@ -270,6 +281,34 @@ describe('+ move()', () => {
           done()
         })
       })
+    })
+  })
+
+  describe('> when opts is explicit undefined', () => {
+    it('works with callbacks', done => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-file-dest')
+
+      fse.move(src, dest, undefined, err => {
+        assert.ifError(err)
+        fs.readFile(dest, 'utf8', (err, contents) => {
+          const expected = /^sonic the hedgehog\r?\n$/
+          assert.ifError(err)
+          assert.ok(contents.match(expected))
+          done()
+        })
+      })
+    })
+
+    it('works with promises', async () => {
+      const src = path.join(TEST_DIR, 'a-file')
+      const dest = path.join(TEST_DIR, 'a-file-dest')
+
+      await fse.move(src, dest, undefined)
+
+      const contents = fs.readFileSync(dest, 'utf8')
+      const expected = /^sonic the hedgehog\r?\n$/
+      assert.ok(contents.match(expected))
     })
   })
 

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -14,6 +14,8 @@ function move (src, dest, opts, cb) {
     opts = {}
   }
 
+  opts = opts || {}
+
   const overwrite = opts.overwrite || opts.clobber || false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {


### PR DESCRIPTION
Fixes #947

Closes #948

Will merge in a few days if no objections.