### PR TITLE
Remove sketchy citebite links in documentation

### DIFF
--- a/docs/outputFile-sync.md
+++ b/docs/outputFile-sync.md
@@ -1,6 +1,6 @@
 # outputFileSync(file, data[, options])
 
-Almost the same as `writeFileSync` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed).
+Almost the same as `writeFileSync` (i.e. it overwrites), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed).
 
 - `file` `<String>`
 - `data` `<String> | <Buffer> | <Uint8Array>`

--- a/docs/outputFile.md
+++ b/docs/outputFile.md
@@ -1,6 +1,6 @@
 # outputFile(file, data[, options][, callback])
 
-Almost the same as `writeFile` (i.e. it [overwrites](http://pages.citebite.com/v2o5n8l2f5reb)), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed).
+Almost the same as `writeFile` (i.e. it overwrites), except that if the parent directory does not exist, it's created. `file` must be a file path (a buffer or a file descriptor is not allowed).
 
 - `file` `<String>`
 - `data` `<String> | <Buffer> | <Uint8Array>`


### PR DESCRIPTION

I tried to follow these links, and they led me to really sketchy websites that have nothing to do with Node.js at all.