### PR TITLE
Upgrade devDeps

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "klaw": "^2.1.1",
     "klaw-sync": "^3.0.2",
     "minimist": "^1.1.1",
-    "mocha": "^5.0.5",
+    "mocha": "^10.1.0",
     "nyc": "^15.0.0",
     "proxyquire": "^2.0.1",
     "read-dir-files": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "nyc": "^15.0.0",
     "proxyquire": "^2.0.1",
     "read-dir-files": "^0.1.1",
-    "standard": "^16.0.3"
+    "standard": "^17.0.0"
   },
   "main": "./lib/index.js",
   "files": [


### PR DESCRIPTION
Shut up `npm audit` and use latest `standard`. Will merge in a few days if no objection.