### PR TITLE
feat: support for esm named imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,23 +59,23 @@ const fse = require('fs-extra')
 
 ### ESM
 
-There is also an `fs-extra/esm` import, that supports both default and named exports. However, note that `fs` methods are not included in `fs-extra/esm`; you still need to import `fs` and/or `fs/promises` seperately:
+There is also an `fs-extra` import, that supports both default and named exports. However, note that `fs` methods are not included in `fs-extra`; you still need to import `fs` and/or `fs/promises` seperately:
 
 ```js
 import { readFileSync } from 'fs'
 import { readFile } from 'fs/promises'
-import { outputFile, outputFileSync } from 'fs-extra/esm'
+import { outputFile, outputFileSync } from 'fs-extra'
 ```
 
 Default exports are supported:
 
 ```js
 import fs from 'fs'
-import fse from 'fs-extra/esm'
+import fse from 'fs-extra'
 // fse.readFileSync is not a function; must use fs.readFileSync
 ```
 
-but you probably want to just use regular `fs-extra` instead of `fs-extra/esm` for default exports:
+but you probably want to just use regular `fs-extra` instead of `fs-extra` for default exports:
 
 ```js
 import fs from 'fs-extra'
@@ -224,7 +224,7 @@ fs-extra contains hundreds of tests.
 
 - `npm run lint`: runs the linter ([standard](http://standardjs.com/))
 - `npm run unit`: runs the unit tests
-- `npm run unit-esm`: runs tests for `fs-extra/esm` exports
+- `npm run unit-esm`: runs tests for `fs-extra` exports
 - `npm test`: runs the linter and all tests
 
 

--- a/generate.js
+++ b/generate.js
@@ -1,0 +1,35 @@
+const fsExtra = require('./lib/index')
+const path = require('path')
+const { difference } = require('lodash')
+
+function scan () {
+  const excludes = [
+    'FileReadStream',
+    'FileWriteStream',
+    '_toUnixTimestamp',
+    'F_OK',
+    'R_OK',
+    'W_OK',
+    'X_OK',
+    'gracefulify'
+  ]
+  return difference(Object.keys(fsExtra), excludes)
+}
+
+function generate (list) {
+  return (
+    'import fsExtra from \'./index\'\n' +
+    list.map((item) => `export const ${item} = fsExtra.${item}\n`).join('') +
+    `export default {${list
+      .map((item) => `${item}: fsExtra.${item},`)
+      .join('')}}`
+  )
+}
+
+async function build () {
+  const list = scan()
+  const code = generate(list)
+  await fsExtra.writeFile(path.resolve(__dirname, 'lib/esm.mjs'), code)
+}
+
+build()

--- a/lib/esm.mjs
+++ b/lib/esm.mjs
@@ -1,68 +1,279 @@
-import _copy from './copy/index.js'
-import _empty from './empty/index.js'
-import _ensure from './ensure/index.js'
-import _json from './json/index.js'
-import _mkdirs from './mkdirs/index.js'
-import _move from './move/index.js'
-import _outputFile from './output-file/index.js'
-import _pathExists from './path-exists/index.js'
-import _remove from './remove/index.js'
-
-// NOTE: Only exports fs-extra's functions; fs functions must be imported from "node:fs" or "node:fs/promises"
-
-export const copy = _copy.copy
-export const copySync = _copy.copySync
-export const emptyDirSync = _empty.emptyDirSync
-export const emptydirSync = _empty.emptydirSync
-export const emptyDir = _empty.emptyDir
-export const emptydir = _empty.emptydir
-export const createFile = _ensure.createFile
-export const createFileSync = _ensure.createFileSync
-export const ensureFile = _ensure.ensureFile
-export const ensureFileSync = _ensure.ensureFileSync
-export const createLink = _ensure.createLink
-export const createLinkSync = _ensure.createLinkSync
-export const ensureLink = _ensure.ensureLink
-export const ensureLinkSync = _ensure.ensureLinkSync
-export const createSymlink = _ensure.createSymlink
-export const createSymlinkSync = _ensure.createSymlinkSync
-export const ensureSymlink = _ensure.ensureSymlink
-export const ensureSymlinkSync = _ensure.ensureSymlinkSync
-export const readJson = _json.readJson
-export const readJSON = _json.readJSON
-export const readJsonSync = _json.readJsonSync
-export const readJSONSync = _json.readJSONSync
-export const writeJson = _json.writeJson
-export const writeJSON = _json.writeJSON
-export const writeJsonSync = _json.writeJsonSync
-export const writeJSONSync = _json.writeJSONSync
-export const outputJson = _json.outputJson
-export const outputJSON = _json.outputJSON
-export const outputJsonSync = _json.outputJsonSync
-export const outputJSONSync = _json.outputJSONSync
-export const mkdirs = _mkdirs.mkdirs
-export const mkdirsSync = _mkdirs.mkdirsSync
-export const mkdirp = _mkdirs.mkdirp
-export const mkdirpSync = _mkdirs.mkdirpSync
-export const ensureDir = _mkdirs.ensureDir
-export const ensureDirSync = _mkdirs.ensureDirSync
-export const move = _move.move
-export const moveSync = _move.moveSync
-export const outputFile = _outputFile.outputFile
-export const outputFileSync = _outputFile.outputFileSync
-export const pathExists = _pathExists.pathExists
-export const pathExistsSync = _pathExists.pathExistsSync
-export const remove = _remove.remove
-export const removeSync = _remove.removeSync
-
+import fsExtra from './index'
+export const appendFile = fsExtra.appendFile
+export const appendFileSync = fsExtra.appendFileSync
+export const access = fsExtra.access
+export const accessSync = fsExtra.accessSync
+export const chown = fsExtra.chown
+export const chownSync = fsExtra.chownSync
+export const chmod = fsExtra.chmod
+export const chmodSync = fsExtra.chmodSync
+export const close = fsExtra.close
+export const closeSync = fsExtra.closeSync
+export const copyFile = fsExtra.copyFile
+export const copyFileSync = fsExtra.copyFileSync
+export const cp = fsExtra.cp
+export const cpSync = fsExtra.cpSync
+export const createReadStream = fsExtra.createReadStream
+export const createWriteStream = fsExtra.createWriteStream
+export const exists = fsExtra.exists
+export const existsSync = fsExtra.existsSync
+export const fchown = fsExtra.fchown
+export const fchownSync = fsExtra.fchownSync
+export const fchmod = fsExtra.fchmod
+export const fchmodSync = fsExtra.fchmodSync
+export const fdatasync = fsExtra.fdatasync
+export const fdatasyncSync = fsExtra.fdatasyncSync
+export const fstat = fsExtra.fstat
+export const fstatSync = fsExtra.fstatSync
+export const fsync = fsExtra.fsync
+export const fsyncSync = fsExtra.fsyncSync
+export const ftruncate = fsExtra.ftruncate
+export const ftruncateSync = fsExtra.ftruncateSync
+export const futimes = fsExtra.futimes
+export const futimesSync = fsExtra.futimesSync
+export const lchown = fsExtra.lchown
+export const lchownSync = fsExtra.lchownSync
+export const lchmod = fsExtra.lchmod
+export const lchmodSync = fsExtra.lchmodSync
+export const link = fsExtra.link
+export const linkSync = fsExtra.linkSync
+export const lstat = fsExtra.lstat
+export const lstatSync = fsExtra.lstatSync
+export const lutimes = fsExtra.lutimes
+export const lutimesSync = fsExtra.lutimesSync
+export const mkdir = fsExtra.mkdir
+export const mkdirSync = fsExtra.mkdirSync
+export const mkdtemp = fsExtra.mkdtemp
+export const mkdtempSync = fsExtra.mkdtempSync
+export const open = fsExtra.open
+export const openSync = fsExtra.openSync
+export const opendir = fsExtra.opendir
+export const opendirSync = fsExtra.opendirSync
+export const readdir = fsExtra.readdir
+export const readdirSync = fsExtra.readdirSync
+export const read = fsExtra.read
+export const readSync = fsExtra.readSync
+export const readv = fsExtra.readv
+export const readvSync = fsExtra.readvSync
+export const readFile = fsExtra.readFile
+export const readFileSync = fsExtra.readFileSync
+export const readlink = fsExtra.readlink
+export const readlinkSync = fsExtra.readlinkSync
+export const realpath = fsExtra.realpath
+export const realpathSync = fsExtra.realpathSync
+export const rename = fsExtra.rename
+export const renameSync = fsExtra.renameSync
+export const rm = fsExtra.rm
+export const rmSync = fsExtra.rmSync
+export const rmdir = fsExtra.rmdir
+export const rmdirSync = fsExtra.rmdirSync
+export const stat = fsExtra.stat
+export const statSync = fsExtra.statSync
+export const symlink = fsExtra.symlink
+export const symlinkSync = fsExtra.symlinkSync
+export const truncate = fsExtra.truncate
+export const truncateSync = fsExtra.truncateSync
+export const unwatchFile = fsExtra.unwatchFile
+export const unlink = fsExtra.unlink
+export const unlinkSync = fsExtra.unlinkSync
+export const utimes = fsExtra.utimes
+export const utimesSync = fsExtra.utimesSync
+export const watch = fsExtra.watch
+export const watchFile = fsExtra.watchFile
+export const writeFile = fsExtra.writeFile
+export const writeFileSync = fsExtra.writeFileSync
+export const write = fsExtra.write
+export const writeSync = fsExtra.writeSync
+export const writev = fsExtra.writev
+export const writevSync = fsExtra.writevSync
+export const Dir = fsExtra.Dir
+export const Dirent = fsExtra.Dirent
+export const Stats = fsExtra.Stats
+export const ReadStream = fsExtra.ReadStream
+export const WriteStream = fsExtra.WriteStream
+export const constants = fsExtra.constants
+export const promises = fsExtra.promises
+export const copy = fsExtra.copy
+export const copySync = fsExtra.copySync
+export const emptyDirSync = fsExtra.emptyDirSync
+export const emptydirSync = fsExtra.emptydirSync
+export const emptyDir = fsExtra.emptyDir
+export const emptydir = fsExtra.emptydir
+export const createFile = fsExtra.createFile
+export const createFileSync = fsExtra.createFileSync
+export const ensureFile = fsExtra.ensureFile
+export const ensureFileSync = fsExtra.ensureFileSync
+export const createLink = fsExtra.createLink
+export const createLinkSync = fsExtra.createLinkSync
+export const ensureLink = fsExtra.ensureLink
+export const ensureLinkSync = fsExtra.ensureLinkSync
+export const createSymlink = fsExtra.createSymlink
+export const createSymlinkSync = fsExtra.createSymlinkSync
+export const ensureSymlink = fsExtra.ensureSymlink
+export const ensureSymlinkSync = fsExtra.ensureSymlinkSync
+export const readJson = fsExtra.readJson
+export const readJsonSync = fsExtra.readJsonSync
+export const writeJson = fsExtra.writeJson
+export const writeJsonSync = fsExtra.writeJsonSync
+export const outputJson = fsExtra.outputJson
+export const outputJsonSync = fsExtra.outputJsonSync
+export const outputJSON = fsExtra.outputJSON
+export const outputJSONSync = fsExtra.outputJSONSync
+export const writeJSON = fsExtra.writeJSON
+export const writeJSONSync = fsExtra.writeJSONSync
+export const readJSON = fsExtra.readJSON
+export const readJSONSync = fsExtra.readJSONSync
+export const mkdirs = fsExtra.mkdirs
+export const mkdirsSync = fsExtra.mkdirsSync
+export const mkdirp = fsExtra.mkdirp
+export const mkdirpSync = fsExtra.mkdirpSync
+export const ensureDir = fsExtra.ensureDir
+export const ensureDirSync = fsExtra.ensureDirSync
+export const move = fsExtra.move
+export const moveSync = fsExtra.moveSync
+export const outputFile = fsExtra.outputFile
+export const outputFileSync = fsExtra.outputFileSync
+export const pathExists = fsExtra.pathExists
+export const pathExistsSync = fsExtra.pathExistsSync
+export const remove = fsExtra.remove
+export const removeSync = fsExtra.removeSync
 export default {
-  ..._copy,
-  ..._empty,
-  ..._ensure,
-  ..._json,
-  ..._mkdirs,
-  ..._move,
-  ..._outputFile,
-  ..._pathExists,
-  ..._remove
+  appendFile: fsExtra.appendFile,
+  appendFileSync: fsExtra.appendFileSync,
+  access: fsExtra.access,
+  accessSync: fsExtra.accessSync,
+  chown: fsExtra.chown,
+  chownSync: fsExtra.chownSync,
+  chmod: fsExtra.chmod,
+  chmodSync: fsExtra.chmodSync,
+  close: fsExtra.close,
+  closeSync: fsExtra.closeSync,
+  copyFile: fsExtra.copyFile,
+  copyFileSync: fsExtra.copyFileSync,
+  cp: fsExtra.cp,
+  cpSync: fsExtra.cpSync,
+  createReadStream: fsExtra.createReadStream,
+  createWriteStream: fsExtra.createWriteStream,
+  exists: fsExtra.exists,
+  existsSync: fsExtra.existsSync,
+  fchown: fsExtra.fchown,
+  fchownSync: fsExtra.fchownSync,
+  fchmod: fsExtra.fchmod,
+  fchmodSync: fsExtra.fchmodSync,
+  fdatasync: fsExtra.fdatasync,
+  fdatasyncSync: fsExtra.fdatasyncSync,
+  fstat: fsExtra.fstat,
+  fstatSync: fsExtra.fstatSync,
+  fsync: fsExtra.fsync,
+  fsyncSync: fsExtra.fsyncSync,
+  ftruncate: fsExtra.ftruncate,
+  ftruncateSync: fsExtra.ftruncateSync,
+  futimes: fsExtra.futimes,
+  futimesSync: fsExtra.futimesSync,
+  lchown: fsExtra.lchown,
+  lchownSync: fsExtra.lchownSync,
+  lchmod: fsExtra.lchmod,
+  lchmodSync: fsExtra.lchmodSync,
+  link: fsExtra.link,
+  linkSync: fsExtra.linkSync,
+  lstat: fsExtra.lstat,
+  lstatSync: fsExtra.lstatSync,
+  lutimes: fsExtra.lutimes,
+  lutimesSync: fsExtra.lutimesSync,
+  mkdir: fsExtra.mkdir,
+  mkdirSync: fsExtra.mkdirSync,
+  mkdtemp: fsExtra.mkdtemp,
+  mkdtempSync: fsExtra.mkdtempSync,
+  open: fsExtra.open,
+  openSync: fsExtra.openSync,
+  opendir: fsExtra.opendir,
+  opendirSync: fsExtra.opendirSync,
+  readdir: fsExtra.readdir,
+  readdirSync: fsExtra.readdirSync,
+  read: fsExtra.read,
+  readSync: fsExtra.readSync,
+  readv: fsExtra.readv,
+  readvSync: fsExtra.readvSync,
+  readFile: fsExtra.readFile,
+  readFileSync: fsExtra.readFileSync,
+  readlink: fsExtra.readlink,
+  readlinkSync: fsExtra.readlinkSync,
+  realpath: fsExtra.realpath,
+  realpathSync: fsExtra.realpathSync,
+  rename: fsExtra.rename,
+  renameSync: fsExtra.renameSync,
+  rm: fsExtra.rm,
+  rmSync: fsExtra.rmSync,
+  rmdir: fsExtra.rmdir,
+  rmdirSync: fsExtra.rmdirSync,
+  stat: fsExtra.stat,
+  statSync: fsExtra.statSync,
+  symlink: fsExtra.symlink,
+  symlinkSync: fsExtra.symlinkSync,
+  truncate: fsExtra.truncate,
+  truncateSync: fsExtra.truncateSync,
+  unwatchFile: fsExtra.unwatchFile,
+  unlink: fsExtra.unlink,
+  unlinkSync: fsExtra.unlinkSync,
+  utimes: fsExtra.utimes,
+  utimesSync: fsExtra.utimesSync,
+  watch: fsExtra.watch,
+  watchFile: fsExtra.watchFile,
+  writeFile: fsExtra.writeFile,
+  writeFileSync: fsExtra.writeFileSync,
+  write: fsExtra.write,
+  writeSync: fsExtra.writeSync,
+  writev: fsExtra.writev,
+  writevSync: fsExtra.writevSync,
+  Dir: fsExtra.Dir,
+  Dirent: fsExtra.Dirent,
+  Stats: fsExtra.Stats,
+  ReadStream: fsExtra.ReadStream,
+  WriteStream: fsExtra.WriteStream,
+  constants: fsExtra.constants,
+  promises: fsExtra.promises,
+  copy: fsExtra.copy,
+  copySync: fsExtra.copySync,
+  emptyDirSync: fsExtra.emptyDirSync,
+  emptydirSync: fsExtra.emptydirSync,
+  emptyDir: fsExtra.emptyDir,
+  emptydir: fsExtra.emptydir,
+  createFile: fsExtra.createFile,
+  createFileSync: fsExtra.createFileSync,
+  ensureFile: fsExtra.ensureFile,
+  ensureFileSync: fsExtra.ensureFileSync,
+  createLink: fsExtra.createLink,
+  createLinkSync: fsExtra.createLinkSync,
+  ensureLink: fsExtra.ensureLink,
+  ensureLinkSync: fsExtra.ensureLinkSync,
+  createSymlink: fsExtra.createSymlink,
+  createSymlinkSync: fsExtra.createSymlinkSync,
+  ensureSymlink: fsExtra.ensureSymlink,
+  ensureSymlinkSync: fsExtra.ensureSymlinkSync,
+  readJson: fsExtra.readJson,
+  readJsonSync: fsExtra.readJsonSync,
+  writeJson: fsExtra.writeJson,
+  writeJsonSync: fsExtra.writeJsonSync,
+  outputJson: fsExtra.outputJson,
+  outputJsonSync: fsExtra.outputJsonSync,
+  outputJSON: fsExtra.outputJSON,
+  outputJSONSync: fsExtra.outputJSONSync,
+  writeJSON: fsExtra.writeJSON,
+  writeJSONSync: fsExtra.writeJSONSync,
+  readJSON: fsExtra.readJSON,
+  readJSONSync: fsExtra.readJSONSync,
+  mkdirs: fsExtra.mkdirs,
+  mkdirsSync: fsExtra.mkdirsSync,
+  mkdirp: fsExtra.mkdirp,
+  mkdirpSync: fsExtra.mkdirpSync,
+  ensureDir: fsExtra.ensureDir,
+  ensureDirSync: fsExtra.ensureDirSync,
+  move: fsExtra.move,
+  moveSync: fsExtra.moveSync,
+  outputFile: fsExtra.outputFile,
+  outputFileSync: fsExtra.outputFileSync,
+  pathExists: fsExtra.pathExists,
+  pathExistsSync: fsExtra.pathExistsSync,
+  remove: fsExtra.remove,
+  removeSync: fsExtra.removeSync
 }

--- a/package.json
+++ b/package.json
@@ -42,8 +42,10 @@
     "universalify": "^2.0.0"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.191",
     "klaw": "^2.1.1",
     "klaw-sync": "^3.0.2",
+    "lodash": "^4.17.21",
     "minimist": "^1.1.1",
     "mocha": "^10.1.0",
     "nyc": "^15.0.0",
@@ -53,14 +55,18 @@
   },
   "main": "./lib/index.js",
   "exports": {
-    ".": "./lib/index.js",
-    "./esm": "./lib/esm.mjs"
+    ".": {
+      "import": "./lib/esm.mjs",
+      "require": "./lib/index.js"
+    }
   },
   "files": [
     "lib/",
     "!lib/**/__tests__/"
   ],
   "scripts": {
+    "prepublishOnly": "npm run build",
+    "build": "node ./generate.js",
     "lint": "standard",
     "test-find": "find ./lib/**/__tests__ -name *.test.js | xargs mocha",
     "test": "npm run lint && npm run unit && npm run unit-esm",


### PR DESCRIPTION
motivation

There are still problems with esm support at present, and named imports are not really available. For example, the following code will report an error when using the latest version of fs-extra

```ts
import { readdir } from 'fs-extra'
import fsExtra from 'fs-extra'
import { fileURLToPath } from 'url'
import path from 'path'

const __filename = fileURLToPath(import.meta.url)
const __dirname = path.dirname(__filename)
console.log(await readdir(__dirname))
console.log(await fsExtra.readdir(__dirname))
```

This PR addresses the following issues

- Named imports and default imports support in esm
  ```ts
  import { readdir } from 'fs-extra'
  import fsExtra from 'fs-extra'
  import { fileURLToPath } from 'url'
  import path from 'path'
  
  const __filename = fileURLToPath(import.meta.url)
  const __dirname = path.dirname(__filename)
  console.log(await readdir(__dirname))
  console.log(await fsExtra.readdir(__dirname))
  ```
- named import and default import support in cjs
  ```ts
  import { readdir } from 'fs-extra'
  import fsExtra from 'fs-extra'
  const { readdir: readdirCjs } = require('fs-extra')
  const fsExtraCjs = require('fs-extra')
  ;(async () => {
    console.log(await readdir(__dirname))
    console.log(await readdirCjs(__dirname))
    console.log(await fsExtra.readdir(__dirname))
    console.log(await fsExtraCjs.readdir(__dirname))
  })()
  ```
- Properly support the use in ts, no longer use `fs-extra/esm`

For specific test methods, see: https://github.com/rxliuli/fs-extra-demo
