### PR TITLE
Fix exposed fs stream classes being monkey patched by graceful-fs

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   "author": "JP Richardson <jprichardson@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "graceful-fs": "^4.2.0",
+    "graceful-fs": "^4.2.10",
     "jsonfile": "^6.0.1",
     "universalify": "^2.0.0"
   },


### PR DESCRIPTION
Hey!

I am opening this PR because I run into an issue while using a library that uses this `fs-extra` ([serverless-esbuild](https://github.com/floydspace/serverless-esbuild/tree/master)). 

The `serverless-esbuild` library uses the `fs.createWriteStream` API to create a new stream ([ref](https://github.com/floydspace/serverless-esbuild/blob/6172b653da523e7c4ebbb1001f4622e09a1e7d28/src/utils.ts#L118-L121)) and listens to the `'open'` event to perform some logic and close the stream. With my node version (v16.14.0), the `'open'` event was never being triggered.

After digging a little bit, I tried changing the importing `createWriteStream` from `fs` instead of `fs-extra`, which solved the issue.

It seems that `fs-extra` exposes the `createWriteStream` function from `graceful-fs` and `graceful-fs` had this issue some time ago: https://github.com/isaacs/node-graceful-fs/issues/170 which seems related to the problem I observed

I am opening this PR to upgrade the `graceful-fs` dependency, to fix the same bug on upstream consumers of this library