### PR TITLE
Fix preserving timestamp when the move command is executing

### DIFF
--- a/lib/move/__tests__/move-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-preserve-timestamp.test.js
@@ -52,10 +52,9 @@ describeIfPractical('move() - across different devices', () => {
 
   const _it = __skipTests ? it.skip : it
 
-  afterEach(done => {
+  afterEach(() => {
     fse.removeSync(TEST_DIR)
     fse.removeSync(SRC)
-    done()
   })
 
   describe('> default behaviour', () => {

--- a/lib/move/__tests__/move-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-preserve-timestamp.test.js
@@ -1,0 +1,104 @@
+'use strict'
+
+const fs = require('../../')
+const os = require('os')
+const path = require('path')
+const utimesSync = require('../../util/utimes').utimesMillisSync
+const assert = require('assert')
+const fse = require('../../index')
+const copy = require('../../copy/copy')
+
+/* global beforeEach, afterEach, describe, it */
+
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
+
+const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
+
+describeIfPractical('copySync() - preserveTimestamps option across different devices', () => {
+  let TEST_DIR, SRC, DEST, FILES
+  let __skipTests = false
+  const differentDevicePath = '/mnt'
+
+  // must set this up, if not, exit silently
+  if (!fs.existsSync(differentDevicePath)) {
+    console.log('Skipping cross-device move test')
+    __skipTests = true
+  }
+
+  // make sure we have permission on device
+  try {
+    fs.writeFileSync(path.join(differentDevicePath, 'file'), 'hi')
+  } catch {
+    console.log("Can't write to device. Skipping move test.")
+    __skipTests = true
+  }
+
+  function setupFixture (readonly) {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-sync-preserve-timestamp')
+    SRC = path.join(differentDevicePath, 'some/weird/dir-really-weird')
+    DEST = path.join(TEST_DIR, 'dest')
+    FILES = ['a-file', path.join('a-folder', 'another-file'), path.join('a-folder', 'another-folder', 'file3')]
+    const timestamp = Date.now() / 1000 - 5
+    FILES.forEach(f => {
+      const filePath = path.join(SRC, f)
+      fs.ensureFileSync(filePath)
+      // rewind timestamps to make sure that coarser OS timestamp resolution
+      // does not alter results
+      utimesSync(filePath, timestamp, timestamp)
+      if (readonly) {
+        fs.chmodSync(filePath, 0o444)
+      }
+    })
+  }
+
+  const _it = __skipTests ? it.skip : it
+
+  afterEach(done => {
+    fse.removeSync(TEST_DIR)
+    fse.removeSync(SRC)
+    done();
+  })
+
+  describe('> when preserveTimestamps option is true', () => {
+    ;[
+      { subcase: 'writable', readonly: false },
+      { subcase: 'readonly', readonly: true }
+    ].forEach(params => {
+      describe(`>> with ${params.subcase} source files`, () => {
+        beforeEach(() => setupFixture(params.readonly))
+
+        _it('should have the same timestamps after move', done => {
+          const originalTimestamps = FILES.map(file => {
+            const originalPath = path.join(SRC, file)
+            const originalStat = fs.statSync(originalPath)
+            return {
+              mtime: originalStat.mtime.getTime(),
+              atime: originalStat.atime.getTime()
+            }
+          })
+          fse.move(SRC, DEST, { preserveTimestamps: true }, (err) => {
+            if (err) return done(err)
+            FILES.forEach(testFile({ preserveTimestamps: true }, originalTimestamps))
+            done()
+          })
+        })
+      })
+    })
+  })
+
+  function testFile (options, originalTimestamps) {
+    return function (file, idx) {
+      const originalTimestamp = originalTimestamps[idx];
+      const currentPath = path.join(DEST, file)
+      const currentStats = fs.statSync(currentPath)
+      if (options.preserveTimestamps) {
+        // Windows sub-second precision fixed: https://github.com/nodejs/io.js/issues/2069
+        assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
+        assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
+      } else {
+        // the access time might actually be the same, so check only modification time
+        assert.notStrictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'same mtime values')
+      }
+    }
+  }
+})

--- a/lib/move/__tests__/move-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-preserve-timestamp.test.js
@@ -9,7 +9,7 @@ const fse = require('../../index')
 
 /* global beforeEach, afterEach, describe, it */
 
-if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping move timestamp tests')
 
 const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 

--- a/lib/move/__tests__/move-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-preserve-timestamp.test.js
@@ -6,7 +6,6 @@ const path = require('path')
 const utimesSync = require('../../util/utimes').utimesMillisSync
 const assert = require('assert')
 const fse = require('../../index')
-const copy = require('../../copy/copy')
 
 /* global beforeEach, afterEach, describe, it */
 
@@ -14,7 +13,7 @@ if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp 
 
 const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 
-describeIfPractical('copySync() - preserveTimestamps option across different devices', () => {
+describeIfPractical('move() - across different devices', () => {
   let TEST_DIR, SRC, DEST, FILES
   let __skipTests = false
   const differentDevicePath = '/mnt'
@@ -56,10 +55,10 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
   afterEach(done => {
     fse.removeSync(TEST_DIR)
     fse.removeSync(SRC)
-    done();
+    done()
   })
 
-  describe('> when preserveTimestamps option is true', () => {
+  describe('> default behaviour', () => {
     ;[
       { subcase: 'writable', readonly: false },
       { subcase: 'readonly', readonly: true }
@@ -76,9 +75,9 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
               atime: originalStat.atime.getTime()
             }
           })
-          fse.move(SRC, DEST, { preserveTimestamps: true }, (err) => {
+          fse.move(SRC, DEST, {}, (err) => {
             if (err) return done(err)
-            FILES.forEach(testFile({ preserveTimestamps: true }, originalTimestamps))
+            FILES.forEach(testFile({}, originalTimestamps))
             done()
           })
         })
@@ -88,17 +87,11 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
 
   function testFile (options, originalTimestamps) {
     return function (file, idx) {
-      const originalTimestamp = originalTimestamps[idx];
+      const originalTimestamp = originalTimestamps[idx]
       const currentPath = path.join(DEST, file)
       const currentStats = fs.statSync(currentPath)
-      if (options.preserveTimestamps) {
-        // Windows sub-second precision fixed: https://github.com/nodejs/io.js/issues/2069
-        assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
-        assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
-      } else {
-        // the access time might actually be the same, so check only modification time
-        assert.notStrictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'same mtime values')
-      }
+      assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
+      assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
     }
   }
 })

--- a/lib/move/__tests__/move-sync-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-sync-preserve-timestamp.test.js
@@ -52,10 +52,9 @@ describeIfPractical('moveSync() - across different devices', () => {
 
   const _it = __skipTests ? it.skip : it
 
-  afterEach(done => {
+  afterEach(() => {
     fse.removeSync(TEST_DIR)
     fse.removeSync(SRC)
-    done()
   })
 
   describe('> default behaviour', () => {

--- a/lib/move/__tests__/move-sync-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-sync-preserve-timestamp.test.js
@@ -13,7 +13,7 @@ if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp 
 
 const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 
-describeIfPractical('copySync() - preserveTimestamps option across different devices', () => {
+describeIfPractical('moveSync() - across different devices', () => {
   let TEST_DIR, SRC, DEST, FILES
   let __skipTests = false
   const differentDevicePath = '/mnt'
@@ -55,10 +55,10 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
   afterEach(done => {
     fse.removeSync(TEST_DIR)
     fse.removeSync(SRC)
-    done();
+    done()
   })
 
-  describe('> when preserveTimestamps option is true', () => {
+  describe('> default behaviour', () => {
     ;[
       { subcase: 'writable', readonly: false },
       { subcase: 'readonly', readonly: true }
@@ -75,8 +75,8 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
               atime: originalStat.atime.getTime()
             }
           })
-          fse.moveSync(SRC, DEST, { preserveTimestamps: true })
-          FILES.forEach(testFile({ preserveTimestamps: true }, originalTimestamps))
+          fse.moveSync(SRC, DEST, {})
+          FILES.forEach(testFile({}, originalTimestamps))
         })
       })
     })
@@ -84,17 +84,12 @@ describeIfPractical('copySync() - preserveTimestamps option across different dev
 
   function testFile (options, originalTimestamps) {
     return function (file, idx) {
-      const originalTimestamp = originalTimestamps[idx];
+      const originalTimestamp = originalTimestamps[idx]
       const currentPath = path.join(DEST, file)
       const currentStats = fs.statSync(currentPath)
-      if (options.preserveTimestamps) {
-        // Windows sub-second precision fixed: https://github.com/nodejs/io.js/issues/2069
-        assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
-        assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
-      } else {
-        // the access time might actually be the same, so check only modification time
-        assert.notStrictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'same mtime values')
-      }
+      // Windows sub-second precision fixed: https://github.com/nodejs/io.js/issues/2069
+      assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
+      assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
     }
   }
 })

--- a/lib/move/__tests__/move-sync-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-sync-preserve-timestamp.test.js
@@ -9,7 +9,7 @@ const fse = require('../../index')
 
 /* global beforeEach, afterEach, describe, it */
 
-if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping move timestamp tests')
 
 const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
 

--- a/lib/move/__tests__/move-sync-preserve-timestamp.test.js
+++ b/lib/move/__tests__/move-sync-preserve-timestamp.test.js
@@ -1,0 +1,100 @@
+'use strict'
+
+const fs = require('../../')
+const os = require('os')
+const path = require('path')
+const utimesSync = require('../../util/utimes').utimesMillisSync
+const assert = require('assert')
+const fse = require('../../index')
+
+/* global beforeEach, afterEach, describe, it */
+
+if (process.arch === 'ia32') console.warn('32 bit arch; skipping copy timestamp tests')
+
+const describeIfPractical = process.arch === 'ia32' ? describe.skip : describe
+
+describeIfPractical('copySync() - preserveTimestamps option across different devices', () => {
+  let TEST_DIR, SRC, DEST, FILES
+  let __skipTests = false
+  const differentDevicePath = '/mnt'
+
+  // must set this up, if not, exit silently
+  if (!fs.existsSync(differentDevicePath)) {
+    console.log('Skipping cross-device move test')
+    __skipTests = true
+  }
+
+  // make sure we have permission on device
+  try {
+    fs.writeFileSync(path.join(differentDevicePath, 'file'), 'hi')
+  } catch {
+    console.log("Can't write to device. Skipping move test.")
+    __skipTests = true
+  }
+
+  function setupFixture (readonly) {
+    TEST_DIR = path.join(os.tmpdir(), 'fs-extra', 'move-sync-preserve-timestamp')
+    SRC = path.join(differentDevicePath, 'some/weird/dir-really-weird')
+    DEST = path.join(TEST_DIR, 'dest')
+    FILES = ['a-file', path.join('a-folder', 'another-file'), path.join('a-folder', 'another-folder', 'file3')]
+    const timestamp = Date.now() / 1000 - 5
+    FILES.forEach(f => {
+      const filePath = path.join(SRC, f)
+      fs.ensureFileSync(filePath)
+      // rewind timestamps to make sure that coarser OS timestamp resolution
+      // does not alter results
+      utimesSync(filePath, timestamp, timestamp)
+      if (readonly) {
+        fs.chmodSync(filePath, 0o444)
+      }
+    })
+  }
+
+  const _it = __skipTests ? it.skip : it
+
+  afterEach(done => {
+    fse.removeSync(TEST_DIR)
+    fse.removeSync(SRC)
+    done();
+  })
+
+  describe('> when preserveTimestamps option is true', () => {
+    ;[
+      { subcase: 'writable', readonly: false },
+      { subcase: 'readonly', readonly: true }
+    ].forEach(params => {
+      describe(`>> with ${params.subcase} source files`, () => {
+        beforeEach(() => setupFixture(params.readonly))
+
+        _it('should have the same timestamps after move', () => {
+          const originalTimestamps = FILES.map(file => {
+            const originalPath = path.join(SRC, file)
+            const originalStat = fs.statSync(originalPath)
+            return {
+              mtime: originalStat.mtime.getTime(),
+              atime: originalStat.atime.getTime()
+            }
+          })
+          fse.moveSync(SRC, DEST, { preserveTimestamps: true })
+          FILES.forEach(testFile({ preserveTimestamps: true }, originalTimestamps))
+        })
+      })
+    })
+  })
+
+  function testFile (options, originalTimestamps) {
+    return function (file, idx) {
+      const originalTimestamp = originalTimestamps[idx];
+      const currentPath = path.join(DEST, file)
+      const currentStats = fs.statSync(currentPath)
+      if (options.preserveTimestamps) {
+        // Windows sub-second precision fixed: https://github.com/nodejs/io.js/issues/2069
+        assert.strictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'different mtime values')
+        assert.strictEqual(currentStats.atime.getTime(), originalTimestamp.atime, 'different atime values')
+      } else {
+        // the access time might actually be the same, so check only modification time
+        assert.notStrictEqual(currentStats.mtime.getTime(), originalTimestamp.mtime, 'same mtime values')
+      }
+    }
+  }
+})

--- a/lib/move/move-sync.js
+++ b/lib/move/move-sync.js
@@ -9,11 +9,12 @@ const stat = require('../util/stat')
 
 function moveSync (src, dest, opts) {
   opts = opts || {}
-  opts.overwrite = opts.overwrite || opts.clobber || false
+  const overwrite = opts.overwrite || opts.clobber || false
+
   const { srcStat, isChangingCase = false } = stat.checkPathsSync(src, dest, 'move', opts)
   stat.checkParentPathsSync(src, srcStat, dest, 'move')
   if (!isParentRoot(dest)) mkdirpSync(path.dirname(dest))
-  return doRename(src, dest, isChangingCase, opts)
+  return doRename(src, dest, overwrite, isChangingCase)
 }
 
 function isParentRoot (dest) {
@@ -22,28 +23,31 @@ function isParentRoot (dest) {
   return parsedPath.root === parent
 }
 
-function doRename (src, dest, isChangingCase, opts) {
-  if (isChangingCase) return rename(src, dest, opts)
-  if (opts.overwrite) {
+function doRename (src, dest, overwrite, isChangingCase) {
+  if (isChangingCase) return rename(src, dest, overwrite)
+  if (overwrite) {
     removeSync(dest)
-    return rename(src, dest, opts)
+    return rename(src, dest, overwrite)
   }
   if (fs.existsSync(dest)) throw new Error('dest already exists.')
-  return rename(src, dest, opts)
+  return rename(src, dest, overwrite)
 }
 
-function rename (src, dest, opts) {
+function rename (src, dest, overwrite) {
   try {
     fs.renameSync(src, dest)
   } catch (err) {
     if (err.code !== 'EXDEV') throw err
-    return moveAcrossDevice(src, dest, opts)
+    return moveAcrossDevice(src, dest, overwrite)
   }
 }
 
-function moveAcrossDevice (src, dest, opts) {
-  opts.errorOnExist = true
-  opts.preserveTimestamps = true
+function moveAcrossDevice (src, dest, overwrite) {
+  const opts = {
+    overwrite,
+    errorOnExist: true,
+    preserveTimestamps: true
+  }
   copySync(src, dest, opts)
   return removeSync(src)
 }

--- a/lib/move/move-sync.js
+++ b/lib/move/move-sync.js
@@ -42,7 +42,8 @@ function rename (src, dest, opts) {
 }
 
 function moveAcrossDevice (src, dest, opts) {
-  opts.errorOnExist = true;
+  opts.errorOnExist = true
+  opts.preserveTimestamps = true
   copySync(src, dest, opts)
   return removeSync(src)
 }

--- a/lib/move/move-sync.js
+++ b/lib/move/move-sync.js
@@ -9,12 +9,11 @@ const stat = require('../util/stat')
 
 function moveSync (src, dest, opts) {
   opts = opts || {}
-  const overwrite = opts.overwrite || opts.clobber || false
-
+  opts.overwrite = opts.overwrite || opts.clobber || false
   const { srcStat, isChangingCase = false } = stat.checkPathsSync(src, dest, 'move', opts)
   stat.checkParentPathsSync(src, srcStat, dest, 'move')
   if (!isParentRoot(dest)) mkdirpSync(path.dirname(dest))
-  return doRename(src, dest, overwrite, isChangingCase)
+  return doRename(src, dest, isChangingCase, opts)
 }
 
 function isParentRoot (dest) {
@@ -23,30 +22,27 @@ function isParentRoot (dest) {
   return parsedPath.root === parent
 }
 
-function doRename (src, dest, overwrite, isChangingCase) {
-  if (isChangingCase) return rename(src, dest, overwrite)
-  if (overwrite) {
+function doRename (src, dest, isChangingCase, opts) {
+  if (isChangingCase) return rename(src, dest, opts)
+  if (opts.overwrite) {
     removeSync(dest)
-    return rename(src, dest, overwrite)
+    return rename(src, dest, opts)
   }
   if (fs.existsSync(dest)) throw new Error('dest already exists.')
-  return rename(src, dest, overwrite)
+  return rename(src, dest, opts)
 }
 
-function rename (src, dest, overwrite) {
+function rename (src, dest, opts) {
   try {
     fs.renameSync(src, dest)
   } catch (err) {
     if (err.code !== 'EXDEV') throw err
-    return moveAcrossDevice(src, dest, overwrite)
+    return moveAcrossDevice(src, dest, opts)
   }
 }
 
-function moveAcrossDevice (src, dest, overwrite) {
-  const opts = {
-    overwrite,
-    errorOnExist: true
-  }
+function moveAcrossDevice (src, dest, opts) {
+  opts.errorOnExist = true;
   copySync(src, dest, opts)
   return removeSync(src)
 }

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -15,17 +15,18 @@ function move (src, dest, opts, cb) {
   }
 
   opts = opts || {}
-  opts.overwrite = opts.overwrite || opts.clobber || false
+
+  const overwrite = opts.overwrite || opts.clobber || false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {
     if (err) return cb(err)
     const { srcStat, isChangingCase = false } = stats
     stat.checkParentPaths(src, srcStat, dest, 'move', err => {
       if (err) return cb(err)
-      if (isParentRoot(dest)) return doRename(src, dest, opts, isChangingCase, cb)
+      if (isParentRoot(dest)) return doRename(src, dest, overwrite, isChangingCase, cb)
       mkdirp(path.dirname(dest), err => {
         if (err) return cb(err)
-        return doRename(src, dest, opts, isChangingCase, cb)
+        return doRename(src, dest, overwrite, isChangingCase, cb)
       })
     })
   })
@@ -37,32 +38,35 @@ function isParentRoot (dest) {
   return parsedPath.root === parent
 }
 
-function doRename (src, dest, opts, isChangingCase, cb) {
-  if (isChangingCase) return rename(src, dest, opts, cb)
-  if (opts.overwrite) {
+function doRename (src, dest, overwrite, isChangingCase, cb) {
+  if (isChangingCase) return rename(src, dest, overwrite, cb)
+  if (overwrite) {
     return remove(dest, err => {
       if (err) return cb(err)
-      return rename(src, dest, opts, cb)
+      return rename(src, dest, overwrite, cb)
     })
   }
   pathExists(dest, (err, destExists) => {
     if (err) return cb(err)
     if (destExists) return cb(new Error('dest already exists.'))
-    return rename(src, dest, opts, cb)
+    return rename(src, dest, overwrite, cb)
   })
 }
 
-function rename (src, dest, opts, cb) {
+function rename (src, dest, overwrite, cb) {
   fs.rename(src, dest, err => {
     if (!err) return cb()
     if (err.code !== 'EXDEV') return cb(err)
-    return moveAcrossDevice(src, dest, opts, cb)
+    return moveAcrossDevice(src, dest, overwrite, cb)
   })
 }
 
-function moveAcrossDevice (src, dest, opts, cb) {
-  opts.errorOnExist = true
-  opts.preserveTimestamps = true
+function moveAcrossDevice (src, dest, overwrite, cb) {
+  const opts = {
+    overwrite,
+    errorOnExist: true,
+    preserveTimestamps: true
+  }
   copy(src, dest, opts, err => {
     if (err) return cb(err)
     return remove(src, cb)

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -15,18 +15,17 @@ function move (src, dest, opts, cb) {
   }
 
   opts = opts || {}
-
-  const overwrite = opts.overwrite || opts.clobber || false
+  opts.overwrite = opts.overwrite || opts.clobber || false;
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {
     if (err) return cb(err)
     const { srcStat, isChangingCase = false } = stats
     stat.checkParentPaths(src, srcStat, dest, 'move', err => {
       if (err) return cb(err)
-      if (isParentRoot(dest)) return doRename(src, dest, overwrite, isChangingCase, cb)
+      if (isParentRoot(dest)) return doRename(src, dest, opts, isChangingCase, cb)
       mkdirp(path.dirname(dest), err => {
         if (err) return cb(err)
-        return doRename(src, dest, overwrite, isChangingCase, cb)
+        return doRename(src, dest, opts, isChangingCase, cb)
       })
     })
   })
@@ -38,34 +37,31 @@ function isParentRoot (dest) {
   return parsedPath.root === parent
 }
 
-function doRename (src, dest, overwrite, isChangingCase, cb) {
-  if (isChangingCase) return rename(src, dest, overwrite, cb)
-  if (overwrite) {
+function doRename (src, dest, opts, isChangingCase, cb) {
+  if (isChangingCase) return rename(src, dest, opts, cb)
+  if (opts.overwrite) {
     return remove(dest, err => {
       if (err) return cb(err)
-      return rename(src, dest, overwrite, cb)
+      return rename(src, dest, opts, cb)
     })
   }
   pathExists(dest, (err, destExists) => {
     if (err) return cb(err)
     if (destExists) return cb(new Error('dest already exists.'))
-    return rename(src, dest, overwrite, cb)
+    return rename(src, dest, opts, cb)
   })
 }
 
-function rename (src, dest, overwrite, cb) {
+function rename (src, dest, opts, cb) {
   fs.rename(src, dest, err => {
     if (!err) return cb()
     if (err.code !== 'EXDEV') return cb(err)
-    return moveAcrossDevice(src, dest, overwrite, cb)
+    return moveAcrossDevice(src, dest, opts, cb)
   })
 }
 
-function moveAcrossDevice (src, dest, overwrite, cb) {
-  const opts = {
-    overwrite,
-    errorOnExist: true
-  }
+function moveAcrossDevice (src, dest, opts, cb) {
+  opts.errorOnExist = true
   copy(src, dest, opts, err => {
     if (err) return cb(err)
     return remove(src, cb)

--- a/lib/move/move.js
+++ b/lib/move/move.js
@@ -15,7 +15,7 @@ function move (src, dest, opts, cb) {
   }
 
   opts = opts || {}
-  opts.overwrite = opts.overwrite || opts.clobber || false;
+  opts.overwrite = opts.overwrite || opts.clobber || false
 
   stat.checkPaths(src, dest, 'move', opts, (err, stats) => {
     if (err) return cb(err)
@@ -62,6 +62,7 @@ function rename (src, dest, opts, cb) {
 
 function moveAcrossDevice (src, dest, opts, cb) {
   opts.errorOnExist = true
+  opts.preserveTimestamps = true
   copy(src, dest, opts, err => {
     if (err) return cb(err)
     return remove(src, cb)


### PR DESCRIPTION
This PR resolves issue: #992.

These test files are pretty similar, I just took the `copy` method test files as a blueprint, and it seems we can make some refactoring here and there. I'm open to any suggestions!