### PR TITLE
Simplify reduce for checking match

### DIFF
--- a/lib/util/stat.js
+++ b/lib/util/stat.js
@@ -137,7 +137,7 @@ function areIdentical (srcStat, destStat) {
 function isSrcSubdir (src, dest) {
   const srcArr = path.resolve(src).split(path.sep).filter(i => i)
   const destArr = path.resolve(dest).split(path.sep).filter(i => i)
-  return srcArr.reduce((acc, cur, i) => acc && destArr[i] === cur, true)
+  return srcArr.every((cur, i) => destArr[i] === cur)
 }
 
 function errMsg (src, dest, funcName) {


### PR DESCRIPTION
In this case, `reduce` can be simplified via `every'.