### PR TITLE
Perf: copying dir contents in parallel

### DIFF
--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -113,21 +113,23 @@ async function onDir (srcStat, destStat, src, dest, opts) {
     await fs.mkdir(dest)
   }
 
+  const items = await fs.readdir(src)
+
   // loop through the files in the current directory to copy everything
-  for (const item of await fs.readdir(src)) {
+  await Promise.all(items.map(async item => {
     const srcItem = path.join(src, item)
     const destItem = path.join(dest, item)
 
     // skip the item if it is matches by the filter function
     const include = await runFilter(srcItem, destItem, opts)
-    if (!include) continue
+    if (!include) return
 
     const { destStat } = await stat.checkPaths(srcItem, destItem, 'copy', opts)
 
     // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
     // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
-    await getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
-  }
+    return getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+  }))
 
   if (!destStat) {
     await fs.chmod(dest, srcStat.mode)


### PR DESCRIPTION
The PR uses a technique similar to #885 to speed up the recursive copy operation.

As `fs-extra` is built on top of `graceful-fs`, this change won't cause `EMFILE: too many open files` as `graceful-fs` will exponentially backoff and retry.