### PR TITLE
Refactor `copy` to use `opendir`

### DIFF
--- a/lib/copy/copy-sync.js
+++ b/lib/copy/copy-sync.js
@@ -106,7 +106,17 @@ function mkDirAndCopy (srcMode, src, dest, opts) {
 }
 
 function copyDir (src, dest, opts) {
-  fs.readdirSync(src).forEach(item => copyDirItem(item, src, dest, opts))
+  const dir = fs.opendirSync(src)
+
+  try {
+    let dirent
+
+    while ((dirent = dir.readSync()) !== null) {
+      copyDirItem(dirent.name, src, dest, opts)
+    }
+  } finally {
+    dir.closeSync()
+  }
 }
 
 function copyDirItem (item, src, dest, opts) {

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -113,6 +113,8 @@ async function onDir (srcStat, destStat, src, dest, opts) {
     await fs.mkdir(dest)
   }
 
+  const promises = []
+
   // loop through the files in the current directory to copy everything
   for await (const item of await fs.opendir(src)) {
     const srcItem = path.join(src, item.name)
@@ -122,12 +124,16 @@ async function onDir (srcStat, destStat, src, dest, opts) {
     const include = await runFilter(srcItem, destItem, opts)
     if (!include) continue
 
-    const { destStat } = await stat.checkPaths(srcItem, destItem, 'copy', opts)
-
-    // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
-    // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
-    await getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+    promises.push(
+      stat.checkPaths(srcItem, destItem, 'copy', opts).then(({ destStat }) => {
+        // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
+        // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
+        return getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+      })
+    )
   }
+
+  await Promise.all(promises)
 
   if (!destStat) {
     await fs.chmod(dest, srcStat.mode)

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -120,15 +120,16 @@ async function onDir (srcStat, destStat, src, dest, opts) {
     const srcItem = path.join(src, item.name)
     const destItem = path.join(dest, item.name)
 
-    // skip the item if it is matches by the filter function
-    const include = await runFilter(srcItem, destItem, opts)
-    if (!include) continue
-
     promises.push(
-      stat.checkPaths(srcItem, destItem, 'copy', opts).then(({ destStat }) => {
-        // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
-        // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
-        return getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+      runFilter(srcItem, destItem, opts).then(include => {
+        if (include) {
+          // only copy the item if it matches the filter function
+          return stat.checkPaths(srcItem, destItem, 'copy', opts).then(({ destStat }) => {
+            // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
+            // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
+            return getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+          })
+        }
       })
     )
   }

--- a/lib/copy/copy.js
+++ b/lib/copy/copy.js
@@ -113,23 +113,21 @@ async function onDir (srcStat, destStat, src, dest, opts) {
     await fs.mkdir(dest)
   }
 
-  const items = await fs.readdir(src)
-
   // loop through the files in the current directory to copy everything
-  await Promise.all(items.map(async item => {
-    const srcItem = path.join(src, item)
-    const destItem = path.join(dest, item)
+  for await (const item of await fs.opendir(src)) {
+    const srcItem = path.join(src, item.name)
+    const destItem = path.join(dest, item.name)
 
     // skip the item if it is matches by the filter function
     const include = await runFilter(srcItem, destItem, opts)
-    if (!include) return
+    if (!include) continue
 
     const { destStat } = await stat.checkPaths(srcItem, destItem, 'copy', opts)
 
     // If the item is a copyable file, `getStatsAndPerformCopy` will copy it
     // If the item is a directory, `getStatsAndPerformCopy` will call `onDir` recursively
-    return getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
-  }))
+    await getStatsAndPerformCopy(destStat, srcItem, destItem, opts)
+  }
 
   if (!destStat) {
     await fs.chmod(dest, srcStat.mode)


### PR DESCRIPTION
The PR closes #972.

The `readdir` returns the contents of a directory all at once, which can be slow (and blocking) when a directory contains many items. The `opendir` returns the contents of a directory one at a time.

Unlike the original Node.js changes (which copy items one by one), this PR retains copy in parallel (as introduced in #1026).