### PR TITLE
Use `import` conditional exports for default export for esm modules.

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,10 @@
   },
   "main": "./lib/index.js",
   "exports": {
-    ".": "./lib/index.js",
+    ".": {
+      "import": "./lib/esm.mjs",
+      "default": "./lib/index.js"
+    },
     "./esm": "./lib/esm.mjs"
   },
   "files": [


### PR DESCRIPTION
Hello!

I'd like to propose using the `import` [conditional exports](https://nodejs.org/api/packages.html#conditional-exports) to export `/esm`.

Thank you for your consideration!

Happy to update the doc if this is something we'd like to move forward! Thank you!
