### PR TITLE
fix incorrect identical result for windows node v22+

### DIFF
--- a/lib/util/__tests__/stat.test.js
+++ b/lib/util/__tests__/stat.test.js
@@ -63,4 +63,16 @@ describe('util/stat', () => {
       stat.checkParentPathsSync(src, srcStat, dest, 'copy')
     })
   })
+
+  describe('should get correct identical result when stat.ino or stat.dev is 0n', () => {
+    it('stat.areIdentical', () => {
+      assert.ok(stat.areIdentical({ ino: 0n, dev: 0n }, { ino: 0n, dev: 0n }))
+      assert.ok(stat.areIdentical({ ino: 1n, dev: 0n }, { ino: 1n, dev: 0n }))
+      assert.ok(stat.areIdentical({ ino: 0n, dev: 1n }, { ino: 0n, dev: 1n }))
+      assert.ok(stat.areIdentical({ ino: 1n, dev: 1n }, { ino: 1n, dev: 1n }))
+      assert.ok(!stat.areIdentical({ ino: 2n, dev: 0n }, { ino: 1n, dev: 0n }))
+      assert.ok(!stat.areIdentical({ ino: 0n, dev: 2n }, { ino: 0n, dev: 1n }))
+      assert.ok(!stat.areIdentical({ ino: 2n, dev: 1n }, { ino: 1n, dev: 2n }))
+    })
+  })
 })

--- a/lib/util/stat.js
+++ b/lib/util/stat.js
@@ -130,7 +130,8 @@ function checkParentPathsSync (src, srcStat, dest, funcName) {
 }
 
 function areIdentical (srcStat, destStat) {
-  return destStat.ino && destStat.dev && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev
+  // stat.dev can be 0n on windows when node version >= 22.x.x
+  return destStat.ino !== undefined && destStat.dev !== undefined && destStat.ino === srcStat.ino && destStat.dev === srcStat.dev
 }
 
 // return true if dest is a subdir of src, otherwise false.


### PR DESCRIPTION
when testing move() function on windows with node v22+, it is found that stat.areIdentical not working correctly due to fsStat object returned from fs.stat has the value of dev property as 0n, this makes the original check for destStat.ino && destStat.dev returns unexpected false.

test case: move('/tmp/a', '/tmp/A') will throw dest file exist error.