### PR TITLE
Do not mutate args in ensure symlink tests

### DIFF
--- a/lib/ensure/__tests__/symlink.test.js
+++ b/lib/ensure/__tests__/symlink.test.js
@@ -102,8 +102,7 @@ describe('fse-ensure-symlink', () => {
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 
@@ -122,8 +121,7 @@ describe('fse-ensure-symlink', () => {
         assert.throws(() => fs.readFileSync(dstpath, 'utf8'), Error)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 
@@ -139,8 +137,7 @@ describe('fse-ensure-symlink', () => {
         assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 
@@ -162,8 +159,7 @@ describe('fse-ensure-symlink', () => {
         assert(dstDirContents.indexOf(dstBasename) >= 0)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 
@@ -182,8 +178,7 @@ describe('fse-ensure-symlink', () => {
         assert.throws(() => fs.readdirSync(dstpath), Error)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 
@@ -199,8 +194,7 @@ describe('fse-ensure-symlink', () => {
         assert.strictEqual(dstdirExistsBefore, dstdirExistsAfter)
         return done()
       }
-      args.push(callback)
-      return fn(...args)
+      return fn(...args, callback)
     })
   }
 


### PR DESCRIPTION
Just a bad practice period, and actually results in a callback being passed to the synchronous functions later in the file that reuse the same `args` array.