### PR TITLE
Ensure all usages of areIdentical receive bigint stats

### DIFF
--- a/lib/ensure/link.js
+++ b/lib/ensure/link.js
@@ -10,14 +10,14 @@ const { areIdentical } = require('../util/stat')
 async function createLink (srcpath, dstpath) {
   let dstStat
   try {
-    dstStat = await fs.lstat(dstpath)
+    dstStat = await fs.lstat(dstpath, { bigint: true })
   } catch {
     // ignore error
   }
 
   let srcStat
   try {
-    srcStat = await fs.lstat(srcpath)
+    srcStat = await fs.lstat(srcpath, { bigint: true })
   } catch (err) {
     err.message = err.message.replace('lstat', 'ensureLink')
     throw err
@@ -39,11 +39,11 @@ async function createLink (srcpath, dstpath) {
 function createLinkSync (srcpath, dstpath) {
   let dstStat
   try {
-    dstStat = fs.lstatSync(dstpath)
+    dstStat = fs.lstatSync(dstpath, { bigint: true })
   } catch {}
 
   try {
-    const srcStat = fs.lstatSync(srcpath)
+    const srcStat = fs.lstatSync(srcpath, { bigint: true })
     if (dstStat && areIdentical(srcStat, dstStat)) return
   } catch (err) {
     err.message = err.message.replace('lstat', 'ensureLink')

--- a/lib/ensure/symlink.js
+++ b/lib/ensure/symlink.js
@@ -24,18 +24,18 @@ async function createSymlink (srcpath, dstpath, type) {
     // (standard symlink behavior) or fall back to cwd if that doesn't exist
     let srcStat
     if (path.isAbsolute(srcpath)) {
-      srcStat = await fs.stat(srcpath)
+      srcStat = await fs.stat(srcpath, { bigint: true })
     } else {
       const dstdir = path.dirname(dstpath)
       const relativeToDst = path.join(dstdir, srcpath)
       try {
-        srcStat = await fs.stat(relativeToDst)
+        srcStat = await fs.stat(relativeToDst, { bigint: true })
       } catch {
-        srcStat = await fs.stat(srcpath)
+        srcStat = await fs.stat(srcpath, { bigint: true })
       }
     }
 
-    const dstStat = await fs.stat(dstpath)
+    const dstStat = await fs.stat(dstpath, { bigint: true })
     if (areIdentical(srcStat, dstStat)) return
   }
 
@@ -61,18 +61,18 @@ function createSymlinkSync (srcpath, dstpath, type) {
     // (standard symlink behavior) or fall back to cwd if that doesn't exist
     let srcStat
     if (path.isAbsolute(srcpath)) {
-      srcStat = fs.statSync(srcpath)
+      srcStat = fs.statSync(srcpath, { bigint: true })
     } else {
       const dstdir = path.dirname(dstpath)
       const relativeToDst = path.join(dstdir, srcpath)
       try {
-        srcStat = fs.statSync(relativeToDst)
+        srcStat = fs.statSync(relativeToDst, { bigint: true })
       } catch {
-        srcStat = fs.statSync(srcpath)
+        srcStat = fs.statSync(srcpath, { bigint: true })
       }
     }
 
-    const dstStat = fs.statSync(dstpath)
+    const dstStat = fs.statSync(dstpath, { bigint: true })
     if (areIdentical(srcStat, dstStat)) return
   }
 


### PR DESCRIPTION
On Windows, `stats.ino` can exceed `MAX_SAFE_INTEGER`.

We use `{ bigint: true }` here:
https://github.com/jprichardson/node-fs-extra/blob/1e9c57de9fc5e766d3c9938fc7289080c444a568/lib/util/stat.js#L8-L10

But there are a few other uses of `areIdentical()` that didn't get bigint stats. This fixes that.