### PR TITLE
Mirror all utimesMillis() tests for utimesMillisSync()

### DIFF
--- a/lib/util/__tests__/utimes.test.js
+++ b/lib/util/__tests__/utimes.test.js
@@ -99,6 +99,31 @@ describe('utimes', () => {
   })
 
   describe('utimesMillisSync()', () => {
+    // see discussion https://github.com/jprichardson/node-fs-extra/pull/141
+    it('should set the utimes w/ millisecond precision', () => {
+      const tmpFile = path.join(TEST_DIR, 'someFileSync')
+      fs.writeFileSync(tmpFile, 'hello')
+
+      let stats = fs.lstatSync(tmpFile)
+
+      // Apr 21st, 2012
+      const awhileAgo = new Date(1334990868773)
+      const awhileAgoNoMillis = new Date(1334990868000)
+
+      assert.notDeepStrictEqual(stats.mtime, awhileAgo)
+      assert.notDeepStrictEqual(stats.atime, awhileAgo)
+
+      utimes.utimesMillisSync(tmpFile, awhileAgo, awhileAgo)
+      stats = fs.statSync(tmpFile)
+      if (hasMillisResSync()) {
+        assert.deepStrictEqual(stats.mtime, awhileAgo)
+        assert.deepStrictEqual(stats.atime, awhileAgo)
+      } else {
+        assert.deepStrictEqual(stats.mtime, awhileAgoNoMillis)
+        assert.deepStrictEqual(stats.atime, awhileAgoNoMillis)
+      }
+    })
+
     it('should close open file descriptors after encountering an error', () => {
       const fakeFd = Math.random()
 


### PR DESCRIPTION
For some reason, we only had tests for the async implementation.