### PR TITLE
chore: Add Node 26 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     strategy:
       matrix:
-        node: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x]
+        node: [14.x, 16.x, 18.x, 20.x, 22.x, 24.x, 26.x]
         os: [ubuntu-latest, macos-15-intel, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Tests pass locally, so let's see if CI is happy. 

Wouldn't be bad to also add Node 26 into the test matrix, given that it's release was couple of days ago.