### PR TITLE
Fix copy/move recursing into source through a symlinked destination ancestor

### DIFF
--- a/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-prevent-copying-into-itself.test.js
@@ -210,6 +210,29 @@ describe('+ copy() - prevent copying into itself', () => {
         })
       })
 
+      it('should error when dest is a subdirectory of src and the dest parent does not exist yet', done => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        // The immediate dest parent ('sub') does not exist yet, but a deeper
+        // ancestor ('dest-symlink') is a symlink into src.
+        const dest = path.join(destLink, 'sub', 'dest')
+        assert(!fs.existsSync(path.dirname(dest)))
+        fs.copy(src, dest, err => {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${path.join(destLink, 'sub')}'.`)
+
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+          done()
+        })
+      })
+
       it('should copy the directory successfully when src is a subdir of resolved dest path and dereference is true', done => {
         const srcInDest = path.join(TEST_DIR, 'dest', 'some', 'nested', 'src')
         const destLink = path.join(TEST_DIR, 'dest-symlink')

--- a/lib/copy/__tests__/copy-sync-prevent-copying-into-itself.test.js
+++ b/lib/copy/__tests__/copy-sync-prevent-copying-into-itself.test.js
@@ -216,6 +216,33 @@ describe('+ copySync() - prevent copying into itself', () => {
         }
       })
 
+      it('should error when dest is a subdirectory of src and the dest parent does not exist yet', () => {
+        const destLink = path.join(TEST_DIR, 'dest-symlink')
+        fs.symlinkSync(src, destLink, 'dir')
+
+        const srclenBefore = klawSync(src).length
+        assert(srclenBefore > 2)
+
+        // The immediate dest parent ('sub') does not exist yet, but a deeper
+        // ancestor ('dest-symlink') is a symlink into src.
+        const dest = path.join(destLink, 'sub', 'dest')
+        assert(!fs.existsSync(path.dirname(dest)))
+        let errThrown = false
+        try {
+          fs.copySync(src, dest)
+        } catch (err) {
+          assert.strictEqual(err.message, `Cannot copy '${src}' to a subdirectory of itself, '${path.join(destLink, 'sub')}'.`)
+          errThrown = true
+        } finally {
+          assert(errThrown)
+          const srclenAfter = klawSync(src).length
+          assert.strictEqual(srclenAfter, srclenBefore, 'src length should not change')
+
+          const link = fs.readlinkSync(destLink)
+          assert.strictEqual(link, src)
+        }
+      })
+
       it('should copy the directory successfully when src is a subdir of resolved dest path and dereferene is true', () => {
         const srcInDest = path.join(TEST_DIR, 'dest', 'some', 'nested', 'src')
         const destLink = path.join(TEST_DIR, 'dest-symlink')

--- a/lib/util/stat.js
+++ b/lib/util/stat.js
@@ -101,7 +101,10 @@ async function checkParentPaths (src, srcStat, dest, funcName) {
   try {
     destStat = await fs.stat(destParent, { bigint: true })
   } catch (err) {
-    if (err.code === 'ENOENT') return
+    // The destination parent does not exist yet, but a deeper ancestor might
+    // (e.g. when it is a symlink into the source tree). Keep walking up so the
+    // self-subdirectory check is not bypassed.
+    if (err.code === 'ENOENT') return checkParentPaths(src, srcStat, destParent, funcName)
     throw err
   }
 
@@ -120,7 +123,10 @@ function checkParentPathsSync (src, srcStat, dest, funcName) {
   try {
     destStat = fs.statSync(destParent, { bigint: true })
   } catch (err) {
-    if (err.code === 'ENOENT') return
+    // The destination parent does not exist yet, but a deeper ancestor might
+    // (e.g. when it is a symlink into the source tree). Keep walking up so the
+    // self-subdirectory check is not bypassed.
+    if (err.code === 'ENOENT') return checkParentPathsSync(src, srcStat, destParent, funcName)
     throw err
   }
   if (areIdentical(srcStat, destStat)) {


### PR DESCRIPTION
Fixes #1071.

`checkParentPaths` walks up the destination's ancestors to catch the case where the destination is actually inside the source, which otherwise makes `copy` recurse into the very tree it is creating. When an intermediate destination parent doesn't exist yet, it returned early on `ENOENT` and stopped checking. If a *deeper* ancestor is a symlink into the source tree, that early return bypasses the check entirely.

The result is that `copy(src, link/sub/dest)` (where `link` -> `src` and `link/sub` doesn't exist yet) keeps copying `src` into itself, growing `src/sub/dest/sub/dest/...` until it dies with `ENAMETOOLONG`, instead of raising the usual "Cannot copy to a subdirectory of itself" error.

Per @RyanZim's suggestion in the issue, the fix recurses to the next parent on `ENOENT` instead of returning, so the check keeps walking up until it reaches an existing ancestor (or the source parent / root). This affects `copy`, `copySync`, `move`, and `moveSync` since they all go through `checkParentPaths`.

### Testing
- Added regression tests for `copy` and `copySync` covering a non-existent dest parent under a symlink-into-src ancestor (fail before this change: async times out from the runaway recursion, sync doesn't throw; both pass after).
- Verified legitimate deep copies into multiple non-existent parents still succeed (no false positives).
- Full suite green: `npm test` (lint + 728 unit + ESM).
