### PR TITLE
docs: fix typo in README.md (seperate → separately)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ const fse = require('fs-extra')
 
 ### ESM
 
-There is also an `fs-extra/esm` import, that supports both default and named exports. However, note that `fs` methods are not included in `fs-extra/esm`; you still need to import `fs` and/or `fs/promises` seperately:
+There is also an `fs-extra/esm` import, that supports both default and named exports. However, note that `fs` methods are not included in `fs-extra/esm`; you still need to import `fs` and/or `fs/promises` separately:
 
 ```js
 import { readFileSync } from 'fs'


### PR DESCRIPTION
## Summary

Fixed a typo in README.md:
- **Line 64**: `seperately` → `separately`

## Changes

- Corrected "seperately" to "separately" in the ESM section

## Rationale

This is a straightforward spelling correction that improves documentation quality.

---
🤖 Generated with [Claude Code](https://claude.ai/code)